### PR TITLE
Deprecate prettier plugin to avoid conflict with eslint

### DIFF
--- a/kits/Inertia/Base/.prettierrc
+++ b/kits/Inertia/Base/.prettierrc
@@ -5,7 +5,6 @@
     "htmlWhitespaceSensitivity": "css",
     "printWidth": 80,
     "plugins": [
-        "prettier-plugin-organize-imports",
         "prettier-plugin-tailwindcss"
     ],
     "tailwindFunctions": [

--- a/kits/Inertia/Blank/Base/.prettierrc
+++ b/kits/Inertia/Blank/Base/.prettierrc
@@ -4,7 +4,7 @@
     "singleAttributePerLine": false,
     "htmlWhitespaceSensitivity": "css",
     "printWidth": 150,
-    "plugins": ["prettier-plugin-organize-imports", "prettier-plugin-tailwindcss"],
+    "plugins": ["prettier-plugin-tailwindcss"],
     "tailwindFunctions": ["clsx", "cn"],
     "tailwindStylesheet": "resources/css/app.css",
     "tabWidth": 4,

--- a/kits/Inertia/Blank/React/package.json
+++ b/kits/Inertia/Blank/React/package.json
@@ -23,7 +23,6 @@
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-hooks": "^5.1.0",
         "prettier": "^3.4.2",
-        "prettier-plugin-organize-imports": "^4.1.0",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "typescript-eslint": "^8.23.0"
     },

--- a/kits/Inertia/Blank/Vue/package.json
+++ b/kits/Inertia/Blank/Vue/package.json
@@ -21,7 +21,6 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-vue": "^9.32.0",
         "prettier": "^3.4.2",
-        "prettier-plugin-organize-imports": "^4.1.0",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "typescript-eslint": "^8.23.0",
         "vue-tsc": "^2.2.4"

--- a/kits/Inertia/React/package.json
+++ b/kits/Inertia/React/package.json
@@ -23,7 +23,6 @@
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-hooks": "^7.0.0",
         "prettier": "^3.4.2",
-        "prettier-plugin-organize-imports": "^4.1.0",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "typescript-eslint": "^8.23.0"
     },

--- a/kits/Inertia/Vue/package.json
+++ b/kits/Inertia/Vue/package.json
@@ -24,7 +24,6 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-vue": "^9.32.0",
         "prettier": "^3.4.2",
-        "prettier-plugin-organize-imports": "^4.1.0",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "typescript": "^5.2.2",
         "typescript-eslint": "^8.23.0",

--- a/kits/Inertia/WorkOS/Vue/package.json
+++ b/kits/Inertia/WorkOS/Vue/package.json
@@ -24,7 +24,6 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-vue": "^9.32.0",
         "prettier": "^3.4.2",
-        "prettier-plugin-organize-imports": "^4.1.0",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "typescript": "^5.2.2",
         "typescript-eslint": "^8.23.0",


### PR DESCRIPTION
This is "migrating" this change: https://github.com/laravel/vue-starter-kit/pull/278 to Maestro to test its workflows.