### PR TITLE
Bump WorkOS version for starter kits

### DIFF
--- a/kits/Inertia/WorkOS/Base/composer.json
+++ b/kits/Inertia/WorkOS/Base/composer.json
@@ -13,7 +13,7 @@
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
-        "laravel/workos": "^0.1.0",
+        "laravel/workos": "^0.5.0",
         "laravel/wayfinder": "^0.1.9"
     },
     "require-dev": {

--- a/kits/Livewire/WorkOS/composer.json
+++ b/kits/Livewire/WorkOS/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.2",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
-        "laravel/workos": "^0.1.0",
+        "laravel/workos": "^0.5.0",
         "livewire/flux": "^2.1.1",
         "livewire/livewire": "^4.0"
     },


### PR DESCRIPTION
This ports the changes from these PRs:
1. https://github.com/laravel/livewire-starter-kit/pull/233
2. https://github.com/laravel/react-starter-kit/pull/267
3. https://github.com/laravel/vue-starter-kit/pull/289