### PR TITLE
Add docblock for configureDefaults method

### DIFF
--- a/kits/Shared/Blank/app/Providers/AppServiceProvider.php
+++ b/kits/Shared/Blank/app/Providers/AppServiceProvider.php
@@ -26,6 +26,9 @@ class AppServiceProvider extends ServiceProvider
         $this->configureDefaults();
     }
 
+    /**
+     * Configure default behaviors for production-ready applications.
+     */
     protected function configureDefaults(): void
     {
         Date::use(CarbonImmutable::class);


### PR DESCRIPTION
This adds a missing docblock for the `configureDefaults` method in the `AppServiceProvider`