### PR TITLE
Browser tests & Fortify feature-aware skip guards

### DIFF
--- a/.agents/skills/maestro/SKILL.md
+++ b/.agents/skills/maestro/SKILL.md
@@ -26,8 +26,9 @@ All commands below run from the `orchestrator/` directory unless noted otherwise
 | `php artisan build --kit=svelte --blank`             | Build Blank Svelte kit.                                                    |
 | `php artisan build --kit=livewire --workos`          | Build Livewire WorkOS kit.                                                 |
 | `composer kit:run`                                   | Start dev server + file watcher (syncs `build/` back to `kits/`).          |
-| `composer lint:kits`                                 | Run Pint for `kits/`, then lint/format all Inertia variants and sync back. |
+| `composer kits:lint`                                 | Run Pint for `kits/`, then lint/format all Inertia variants and sync back. |
 | `composer kits:check`                                | Build and run CI checks (`composer setup && composer ci:check`) for all 13 kit variants sequentially. |
+| `composer kits:browser-tests`                        | Build and run browser tests for all 4 Fortify kit variants (Livewire, React, Svelte, Vue). |
 | `npm run watch:kits`                                 | Run only the file watcher (no dev server).                                 |
 | `composer setup && composer ci:check`                | Run inside `build/` — installs deps, builds frontend, runs checks (see below). |
 
@@ -163,7 +164,15 @@ Svelte and Vue use PascalCase page names. React uses kebab-case.
 
 ## Browser Tests (Local CI Parity)
 
-To run browser tests locally with the same steps used in `.github/workflows/browser-tests.yml`, run the sequence below for each matrix kit (`Livewire`, `React`, `Svelte`, `Vue`).
+To run browser tests for all kits locally, run from the `orchestrator/` directory:
+
+```bash
+composer kits:browser-tests
+```
+
+This builds each Fortify variant (Livewire, React, Svelte, Vue), copies the shared browser tests, installs dependencies, and runs the tests — matching the steps in `.github/workflows/browser-tests.yml`.
+
+To run the steps manually for a single kit, use the sequence below.
 
 ### Per-Kit Command Sequence
 
@@ -250,5 +259,5 @@ Kit names are case-sensitive here because the workflow matrix uses `Livewire`, `
 2. **Follow sibling patterns**: When creating a Svelte file, check the React and Vue equivalents for expected structure and behavior and vice-versa.
 3. **Layer awareness**: Know which layer a file belongs to. Shared files affect all kits. Framework-specific files only affect that framework.
 4. **Placeholder awareness**: Files in `kits/` contain `{{placeholders}}`. Files in `build/` have resolved values. The watcher handles conversion.
-5. **Lint changes**: Run `composer lint` in `orchestrator` for orchestrator PHP linting, and run `composer lint:kits` to run Pint on `kits/`, run UI lint/format across all Inertia variants, and sync changes back to `kits/`.
+5. **Lint changes**: Run `composer lint` in `orchestrator` for orchestrator PHP linting, and run `composer kits:lint` to run Pint on `kits/`, run UI lint/format across all Inertia variants, and sync changes back to `kits/`.
 6. **Test after changes**: Run `composer setup && composer ci:check` inside `build/` to verify nothing is broken.

--- a/.claude/skills/maestro/SKILL.md
+++ b/.claude/skills/maestro/SKILL.md
@@ -26,8 +26,9 @@ All commands below run from the `orchestrator/` directory unless noted otherwise
 | `php artisan build --kit=svelte --blank`             | Build Blank Svelte kit.                                                    |
 | `php artisan build --kit=livewire --workos`          | Build Livewire WorkOS kit.                                                 |
 | `composer kit:run`                                   | Start dev server + file watcher (syncs `build/` back to `kits/`).          |
-| `composer lint:kits`                                 | Run Pint for `kits/`, then lint/format all Inertia variants and sync back. |
+| `composer kits:lint`                                 | Run Pint for `kits/`, then lint/format all Inertia variants and sync back. |
 | `composer kits:check`                                | Build and run CI checks (`composer setup && composer ci:check`) for all 13 kit variants sequentially. |
+| `composer kits:browser-tests`                        | Build and run browser tests for all 4 Fortify kit variants (Livewire, React, Svelte, Vue). |
 | `npm run watch:kits`                                 | Run only the file watcher (no dev server).                                 |
 | `composer setup && composer ci:check`                | Run inside `build/` — installs deps, builds frontend, runs checks (see below). |
 
@@ -163,7 +164,15 @@ Svelte and Vue use PascalCase page names. React uses kebab-case.
 
 ## Browser Tests (Local CI Parity)
 
-To run browser tests locally with the same steps used in `.github/workflows/browser-tests.yml`, run the sequence below for each matrix kit (`Livewire`, `React`, `Svelte`, `Vue`).
+To run browser tests for all kits locally, run from the `orchestrator/` directory:
+
+```bash
+composer kits:browser-tests
+```
+
+This builds each Fortify variant (Livewire, React, Svelte, Vue), copies the shared browser tests, installs dependencies, and runs the tests — matching the steps in `.github/workflows/browser-tests.yml`.
+
+To run the steps manually for a single kit, use the sequence below.
 
 ### Per-Kit Command Sequence
 
@@ -250,5 +259,5 @@ Kit names are case-sensitive here because the workflow matrix uses `Livewire`, `
 2. **Follow sibling patterns**: When creating a Svelte file, check the React and Vue equivalents for expected structure and behavior and vice-versa.
 3. **Layer awareness**: Know which layer a file belongs to. Shared files affect all kits. Framework-specific files only affect that framework.
 4. **Placeholder awareness**: Files in `kits/` contain `{{placeholders}}`. Files in `build/` have resolved values. The watcher handles conversion.
-5. **Lint changes**: Run `composer lint` in `orchestrator` for orchestrator PHP linting, and run `composer lint:kits` to run Pint on `kits/`, run UI lint/format across all Inertia variants, and sync changes back to `kits/`.
+5. **Lint changes**: Run `composer lint` in `orchestrator` for orchestrator PHP linting, and run `composer kits:lint` to run Pint on `kits/`, run UI lint/format across all Inertia variants, and sync changes back to `kits/`.
 6. **Test after changes**: Run `composer setup && composer ci:check` inside `build/` to verify nothing is broken.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,5 +10,6 @@ Maestro is the monorepo orchestrator for the official Laravel starter kits. Use 
 - Dev: `composer kit:run` (from `orchestrator/`)
 - Test: `composer setup && composer ci:check` (from `build/`)
 - Test all kits: `composer kits:check` (from `orchestrator/`) — builds and runs CI checks for all 13 variants
-- Lint: `composer lint:kits` (from `orchestrator/`)
+- Lint: `composer kits:lint` (from `orchestrator/`)
+- Browser tests (all kits): `composer kits:browser-tests` (from `orchestrator/`)
 - Edit in `build/` (when available), commit in `kits/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,5 +10,6 @@ Maestro is the monorepo orchestrator for the official Laravel starter kits. Use 
 - Dev: `composer kit:run` (from `orchestrator/`)
 - Test: `composer setup && composer ci:check` (from `build/`)
 - Test all kits: `composer kits:check` (from `orchestrator/`) — builds and runs CI checks for all 13 variants
-- Lint: `composer lint:kits` (from `orchestrator/`)
+- Lint: `composer kits:lint` (from `orchestrator/`)
+- Browser tests (all kits): `composer kits:browser-tests` (from `orchestrator/`)
 - Edit in `build/` (when available), commit in `kits/`

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ This will start both the standard Laravel development server and a file watcher 
 From the `orchestrator` directory, run:
 
 ```bash
-composer lint:kits
+composer kits:lint
 ```
 
 This command loops over all Inertia variants, builds each variant, runs frontend linting/formatting in `build` (`npm install`, then lint/format), and then runs `npm run watch:kits -- --initial-sync-only` to perform and verify an initial sync back to `kits`.
 
-`composer lint:kits` also runs Pint on `kits/` before the frontend lint pass.
+`composer kits:lint` also runs Pint on `kits/` before the frontend lint pass.
 
 ### Submitting Changes
 

--- a/browser_tests/tests/Browser/Auth/AuthenticationTest.php
+++ b/browser_tests/tests/Browser/Auth/AuthenticationTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Models\User;
-use Illuminate\Support\Facades\RateLimiter;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertAuthenticated;

--- a/browser_tests/tests/Browser/Auth/PasswordResetTest.php
+++ b/browser_tests/tests/Browser/Auth/PasswordResetTest.php
@@ -5,8 +5,6 @@ use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Password;
 
-use function Pest\Laravel\post;
-
 test('reset password link screen can be rendered', function () {
     visit(route('password.request'))
         ->assertSee('Forgot password')
@@ -60,7 +58,9 @@ test('password can be reset with valid token', function () {
             ->assertValue('email', $user->email)
             ->press('@reset-password-button')
             ->assertUrlIs(route('login'))
-            ->assertSee('Your password has been reset.');
+            ->assertSee('Your password has been reset.')
+            ->assertNoConsoleLogs()
+            ->assertNoJavaScriptErrors();
 
         return true;
     });

--- a/browser_tests/tests/Browser/DashboardTest.php
+++ b/browser_tests/tests/Browser/DashboardTest.php
@@ -21,3 +21,15 @@ test('authenticated users can visit the dashboard', function () {
         ->assertNoConsoleLogs()
         ->assertNoJavaScriptErrors();
 });
+
+test('authenticated users can toggle the sidebar on mobile', function () {
+    actingAs(User::factory()->create());
+
+    visit(route('dashboard'))->on()->mobile()
+        ->click('[data-sidebar="trigger"], [data-flux-sidebar-toggle]')
+        ->assertVisible('[data-sidebar="sidebar"][data-mobile="true"], [data-flux-sidebar]:not([data-flux-sidebar-collapsed-mobile])')
+        ->click('[data-slot="sheet-overlay"], [data-flux-sidebar-backdrop], button[aria-label="Close"]')
+        ->wait(0.5)
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});

--- a/browser_tests/tests/Browser/DashboardTest.php
+++ b/browser_tests/tests/Browser/DashboardTest.php
@@ -7,10 +7,10 @@ use function Pest\Laravel\actingAs;
 test('guests are redirected to the login page', function () {
     visit(route('dashboard'))
         ->assertUrlIs(route('login'))
-        ->assertNoConsoleLogs()
-        ->assertNoJavaScriptErrors()
         ->assertSee('Log in to your account')
-        ->assertSee('Enter your email and password below to log in');
+        ->assertSee('Enter your email and password below to log in')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
 });
 
 test('authenticated users can visit the dashboard', function () {
@@ -29,7 +29,7 @@ test('authenticated users can toggle the sidebar on mobile', function () {
         ->click('[data-sidebar="trigger"], [data-flux-sidebar-toggle]')
         ->assertVisible('[data-sidebar="sidebar"][data-mobile="true"], [data-flux-sidebar]:not([data-flux-sidebar-collapsed-mobile])')
         ->click('[data-slot="sheet-overlay"], [data-flux-sidebar-backdrop], button[aria-label="Close"]')
-        ->wait(0.5)
+        ->assertMissing('[data-sidebar="sidebar"][data-mobile="true"], [data-flux-sidebar]:not([data-flux-sidebar-collapsed-mobile])')
         ->assertNoConsoleLogs()
         ->assertNoJavaScriptErrors();
 });

--- a/browser_tests/tests/Browser/Settings/AppearanceTest.php
+++ b/browser_tests/tests/Browser/Settings/AppearanceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+
+test('appearance page can be rendered', function () {
+    actingAs(User::factory()->create());
+
+    visit(route('appearance.edit'))
+        ->assertSee('Appearance')
+        ->assertSee('Light')
+        ->assertSee('Dark')
+        ->assertSee('System')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});
+
+test('user can switch theme to dark mode', function () {
+    actingAs(User::factory()->create());
+
+    visit(route('appearance.edit'))
+        ->click('Dark')
+        ->assertScript('document.documentElement.classList.contains("dark")', true)
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});
+
+test('user can switch theme to light mode', function () {
+    actingAs(User::factory()->create());
+
+    visit(route('appearance.edit'))
+        ->click('Dark')
+        ->assertScript('document.documentElement.classList.contains("dark")', true)
+        ->click('Light')
+        ->assertScript('document.documentElement.classList.contains("dark")', false)
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});
+
+

--- a/browser_tests/tests/Browser/Settings/AppearanceTest.php
+++ b/browser_tests/tests/Browser/Settings/AppearanceTest.php
@@ -37,5 +37,3 @@ test('user can switch theme to light mode', function () {
         ->assertNoConsoleLogs()
         ->assertNoJavaScriptErrors();
 });
-
-

--- a/browser_tests/tests/Browser/Settings/ProfileUpdateTest.php
+++ b/browser_tests/tests/Browser/Settings/ProfileUpdateTest.php
@@ -40,7 +40,7 @@ test('profile information can be updated', function () {
     expect($user->name)->toBe('Test User');
     expect($user->email)->toBe('test@example.com');
     expect($user->email_verified_at)->toBeNull();
-})->with('users');;
+})->with('users');
 
 test('email verification status is unchanged when the email address is unchanged', function () {
     actingAs($user = User::factory()->create());

--- a/browser_tests/tests/Browser/Settings/TwoFactorAuthenticationTest.php
+++ b/browser_tests/tests/Browser/Settings/TwoFactorAuthenticationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+
+test('two-factor authentication page can be rendered', function () {
+    actingAs(User::factory()->create());
+
+    visitPasswordProtectedPage('two-factor.show')
+        ->assertPathEndsWith('/settings/two-factor')
+        ->assertSee('Two-factor authentication')
+        ->assertSee('Manage your two-factor authentication settings')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});
+
+test('two-factor authentication shows disabled state by default', function () {
+    actingAs(User::factory()->create());
+
+    visitPasswordProtectedPage('two-factor.show')
+        ->assertPathEndsWith('/settings/two-factor')
+        ->assertSee('Disabled')
+        ->assertSee('Enable 2FA')
+        ->assertSee('When you enable two-factor authentication')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});
+
+test('two-factor authentication shows enabled state', function () {
+    actingAs(User::factory()->create([
+        'two_factor_secret' => encrypt('test-secret'),
+        'two_factor_confirmed_at' => now(),
+        'two_factor_recovery_codes' => encrypt(json_encode([
+            'code-1', 'code-2', 'code-3', 'code-4',
+            'code-5', 'code-6', 'code-7', 'code-8',
+        ])),
+    ]));
+
+    visitPasswordProtectedPage('two-factor.show')
+        ->assertPathEndsWith('/settings/two-factor')
+        ->assertSee('Enabled')
+        ->assertSee('Disable 2FA')
+        ->assertSee('View recovery codes')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});
+
+test('two-factor authentication recovery codes can be viewed', function () {
+    actingAs(User::factory()->create([
+        'two_factor_secret' => encrypt('test-secret'),
+        'two_factor_confirmed_at' => now(),
+        'two_factor_recovery_codes' => encrypt(json_encode([
+            'code-1', 'code-2', 'code-3', 'code-4',
+            'code-5', 'code-6', 'code-7', 'code-8',
+        ])),
+    ]));
+
+    visitPasswordProtectedPage('two-factor.show')
+        ->assertPathEndsWith('/settings/two-factor')
+        ->assertSee('View recovery codes')
+        ->click('View recovery codes')
+        ->assertSee('Hide recovery codes')
+        ->assertSee('Regenerate codes')
+        ->assertSee('Each recovery code can be used once')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});

--- a/browser_tests/tests/Browser/Settings/TwoFactorAuthenticationTest.php
+++ b/browser_tests/tests/Browser/Settings/TwoFactorAuthenticationTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Models\User;
+use Pest\Browser\Api\AwaitableWebpage;
+use PragmaRX\Google2FA\Google2FA;
 
 use function Pest\Laravel\actingAs;
 
@@ -23,6 +25,33 @@ test('two-factor authentication shows disabled state by default', function () {
         ->assertSee('Disabled')
         ->assertSee('Enable 2FA')
         ->assertSee('When you enable two-factor authentication')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});
+
+test('two-factor authentication can be enabled and confirmed', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    $browser = visitPasswordProtectedPage('two-factor.show')
+        ->assertPathEndsWith('/settings/two-factor')
+        ->assertSee('Disabled')
+        ->click('Enable 2FA')
+        ->assertSee('Enable two-factor authentication')
+        ->assertSee('Continue')
+        ->click('Continue')
+        ->assertSee('Verify authentication code');
+
+    $user->refresh();
+    $secret = decrypt($user->two_factor_secret);
+    $code = (new Google2FA)->getCurrentOtp($secret);
+
+    fillOTPCode($browser, $code);
+
+    $browser->click('Confirm')
+        ->assertSee('Enabled')
+        ->assertSee('Disable 2FA')
         ->assertNoConsoleLogs()
         ->assertNoJavaScriptErrors();
 });
@@ -66,3 +95,36 @@ test('two-factor authentication recovery codes can be viewed', function () {
         ->assertNoConsoleLogs()
         ->assertNoJavaScriptErrors();
 });
+
+function fillOTPCode(AwaitableWebpage $browser, string $code): AwaitableWebpage
+{
+    $isInertia = $browser->script(
+        "!!document.getElementById('otp')"
+    );
+
+    if ($isInertia) {
+        return $browser->typeSlowly('#otp', $code, 50);
+    }
+
+    // Livewire/Flux: fill each individual OTP input and trigger change
+    // so the hidden input and wire:model binding update correctly.
+    $jsCode = json_encode($code);
+    $browser->script(<<<JS
+        (() => {
+            const inputs = document.querySelectorAll('[data-flux-otp-input]');
+            const code = {$jsCode};
+            inputs.forEach((input, i) => {
+                input.value = code[i] || '';
+                input.dispatchEvent(new Event('input', { bubbles: true }));
+            });
+            // Trigger change on the <ui-otp> container to update wire:model
+            const otp = document.querySelector('ui-otp');
+            if (otp) {
+                otp.dispatchEvent(new Event('input', { bubbles: true }));
+                otp.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+        })()
+    JS);
+
+    return $browser;
+}

--- a/browser_tests/tests/Browser/WelcomeTest.php
+++ b/browser_tests/tests/Browser/WelcomeTest.php
@@ -6,31 +6,31 @@ use function Pest\Laravel\actingAs;
 
 test('welcome screen can be rendered', function () {
     visit('/')
-        ->assertNoConsoleLogs()
-        ->assertNoJavaScriptErrors()
         ->assertSee('Let\'s get started')
         ->assertSee('Log In')
-        ->assertSee('Register');
+        ->assertSee('Register')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
 });
 
 test('guests can browse to register page from welcome page', function () {
     visit(route('home'))
         ->click('Register')
         ->assertUrlIs(route('register'))
-        ->assertNoConsoleLogs()
-        ->assertNoJavaScriptErrors()
         ->assertSee('Create an account')
-        ->assertSee('Enter your details below to create your account');
+        ->assertSee('Enter your details below to create your account')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
 });
 
 test('guests can browse to login page from welcome page', function () {
     visit(route('home'))
         ->click('Log in')
         ->assertUrlIs(route('login'))
-        ->assertNoConsoleLogs()
-        ->assertNoJavaScriptErrors()
         ->assertSee('Log in to your account')
-        ->assertSee('Enter your email and password below to log in');
+        ->assertSee('Enter your email and password below to log in')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
 });
 
 test('authenticated users see dashboard link on welcome page', function () {

--- a/browser_tests/tests/Browser/WelcomeTest.php
+++ b/browser_tests/tests/Browser/WelcomeTest.php
@@ -1,5 +1,9 @@
 <?php
 
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+
 test('welcome screen can be rendered', function () {
     visit('/')
         ->assertNoConsoleLogs()
@@ -27,4 +31,15 @@ test('guests can browse to login page from welcome page', function () {
         ->assertNoJavaScriptErrors()
         ->assertSee('Log in to your account')
         ->assertSee('Enter your email and password below to log in');
+});
+
+test('authenticated users see dashboard link on welcome page', function () {
+    actingAs(User::factory()->create());
+
+    visit(route('home'))
+        ->assertSeeLink('Dashboard')
+        ->click('Dashboard')
+        ->assertUrlIs(route('dashboard'))
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
 });

--- a/browser_tests/tests/Pest.php
+++ b/browser_tests/tests/Pest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Pest\Browser\Api\AwaitableWebpage;
+use Pest\Browser\Api\Webpage;
+
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -42,15 +45,22 @@ expect()->extend('toBeOne', function () {
 */
 
 /**
- * Visit a route that is behind the `password.confirm` middleware.
+ * Visit a route that requires the `password.confirm` middleware.
  *
- * Fills in the password confirmation form and waits for the redirect
- * to the intended destination before returning the browser instance.
+ * Confirms the password via the confirmation page first, then navigates
+ * to the intended destination within the same browser context so the
+ * session cookie with `auth.password_confirmed_at` carries over.
  */
-function visitPasswordProtectedPage(string $route, string $password = 'password'): mixed
+function visitPasswordProtectedPage(string $route, string $password = 'password'): AwaitableWebpage|Webpage
 {
-    return visit(route($route))
-        ->assertVisible('@confirm-password-button')
-        ->fill('password', $password)
-        ->press('@confirm-password-button');
+    $browser = visit(route('password.confirm'))
+        ->assertSee('Confirm password')
+        ->fill('password', $password);
+
+    // Submit the form via JS and wait for the redirect to complete,
+    // avoiding Playwright click-wait-navigation timeout issues.
+    $browser->script("document.querySelector('form').submit()");
+    $browser->waitForEvent('load');
+
+    return $browser->navigate(route($route));
 }

--- a/browser_tests/tests/Pest.php
+++ b/browser_tests/tests/Pest.php
@@ -44,23 +44,13 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-/**
- * Visit a route that requires the `password.confirm` middleware.
- *
- * Confirms the password via the confirmation page first, then navigates
- * to the intended destination within the same browser context so the
- * session cookie with `auth.password_confirmed_at` carries over.
- */
 function visitPasswordProtectedPage(string $route, string $password = 'password'): AwaitableWebpage|Webpage
 {
-    $browser = visit(route('password.confirm'))
+    $destinationUrl = route($route);
+
+    return visit($destinationUrl)
         ->assertSee('Confirm password')
-        ->fill('password', $password);
-
-    // Submit the form via JS and wait for the redirect to complete,
-    // avoiding Playwright click-wait-navigation timeout issues.
-    $browser->script("document.querySelector('form').submit()");
-    $browser->waitForEvent('load');
-
-    return $browser->navigate(route($route));
+        ->fill('password', $password)
+        ->press('@confirm-password-button')
+        ->assertUrlIs($destinationUrl);
 }

--- a/browser_tests/tests/Pest.php
+++ b/browser_tests/tests/Pest.php
@@ -41,7 +41,16 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function something()
+/**
+ * Visit a route that is behind the `password.confirm` middleware.
+ *
+ * Fills in the password confirmation form and waits for the redirect
+ * to the intended destination before returning the browser instance.
+ */
+function visitPasswordProtectedPage(string $route, string $password = 'password'): mixed
 {
-    // ..
+    return visit(route($route))
+        ->assertVisible('@confirm-password-button')
+        ->fill('password', $password)
+        ->press('@confirm-password-button');
 }

--- a/kits/Inertia/Fortify/Base/tests/Feature/Auth/AuthenticationTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Auth/AuthenticationTest.php
@@ -34,9 +34,7 @@ class AuthenticationTest extends TestCase
 
     public function test_users_with_two_factor_enabled_are_redirected_to_two_factor_challenge()
     {
-        if (! Features::canManageTwoFactorAuthentication()) {
-            $this->markTestSkipped('Two-factor authentication is not enabled.');
-        }
+        $this->skipUnlessFortifyFeature(Features::twoFactorAuthentication());
 
         Features::twoFactorAuthentication([
             'confirm' => true,

--- a/kits/Inertia/Fortify/Base/tests/Feature/Auth/EmailVerificationTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Auth/EmailVerificationTest.php
@@ -7,11 +7,19 @@ use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class EmailVerificationTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipUnlessFortifyFeature(Features::emailVerification());
+    }
 
     public function test_email_verification_screen_can_be_rendered()
     {

--- a/kits/Inertia/Fortify/Base/tests/Feature/Auth/PasswordResetTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Auth/PasswordResetTest.php
@@ -6,11 +6,19 @@ use App\Models\User;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class PasswordResetTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipUnlessFortifyFeature(Features::resetPasswords());
+    }
 
     public function test_reset_password_link_screen_can_be_rendered()
     {

--- a/kits/Inertia/Fortify/Base/tests/Feature/Auth/RegistrationTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Auth/RegistrationTest.php
@@ -3,11 +3,19 @@
 namespace Tests\Feature\Auth;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class RegistrationTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipUnlessFortifyFeature(Features::registration());
+    }
 
     public function test_registration_screen_can_be_rendered()
     {

--- a/kits/Inertia/Fortify/Base/tests/Feature/Auth/TwoFactorChallengeTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Auth/TwoFactorChallengeTest.php
@@ -12,12 +12,15 @@ class TwoFactorChallengeTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipUnlessFortifyFeature(Features::twoFactorAuthentication());
+    }
+
     public function test_two_factor_challenge_redirects_to_login_when_not_authenticated(): void
     {
-        if (! Features::canManageTwoFactorAuthentication()) {
-            $this->markTestSkipped('Two-factor authentication is not enabled.');
-        }
-
         $response = $this->get(route('two-factor.login'));
 
         $response->assertRedirect(route('login'));
@@ -25,10 +28,6 @@ class TwoFactorChallengeTest extends TestCase
 
     public function test_two_factor_challenge_can_be_rendered(): void
     {
-        if (! Features::canManageTwoFactorAuthentication()) {
-            $this->markTestSkipped('Two-factor authentication is not enabled.');
-        }
-
         Features::twoFactorAuthentication([
             'confirm' => true,
             'confirmPassword' => true,

--- a/kits/Inertia/Fortify/Base/tests/Feature/Auth/VerificationNotificationTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Auth/VerificationNotificationTest.php
@@ -6,11 +6,19 @@ use App\Models\User;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class VerificationNotificationTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipUnlessFortifyFeature(Features::emailVerification());
+    }
 
     public function test_sends_verification_notification(): void
     {

--- a/kits/Inertia/Fortify/Base/tests/Feature/Settings/TwoFactorAuthenticationTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Settings/TwoFactorAuthenticationTest.php
@@ -14,9 +14,7 @@ class TwoFactorAuthenticationTest extends TestCase
 
     public function test_two_factor_settings_page_can_be_rendered()
     {
-        if (! Features::canManageTwoFactorAuthentication()) {
-            $this->markTestSkipped('Two-factor authentication is not enabled.');
-        }
+        $this->skipUnlessFortifyFeature(Features::twoFactorAuthentication());
 
         Features::twoFactorAuthentication([
             'confirm' => true,
@@ -36,9 +34,7 @@ class TwoFactorAuthenticationTest extends TestCase
 
     public function test_two_factor_settings_page_requires_password_confirmation_when_enabled()
     {
-        if (! Features::canManageTwoFactorAuthentication()) {
-            $this->markTestSkipped('Two-factor authentication is not enabled.');
-        }
+        $this->skipUnlessFortifyFeature(Features::twoFactorAuthentication());
 
         $user = User::factory()->create();
 
@@ -55,9 +51,7 @@ class TwoFactorAuthenticationTest extends TestCase
 
     public function test_two_factor_settings_page_does_not_requires_password_confirmation_when_disabled()
     {
-        if (! Features::canManageTwoFactorAuthentication()) {
-            $this->markTestSkipped('Two-factor authentication is not enabled.');
-        }
+        $this->skipUnlessFortifyFeature(Features::twoFactorAuthentication());
 
         $user = User::factory()->create();
 
@@ -76,9 +70,7 @@ class TwoFactorAuthenticationTest extends TestCase
 
     public function test_two_factor_settings_page_returns_forbidden_response_when_two_factor_is_disabled()
     {
-        if (! Features::canManageTwoFactorAuthentication()) {
-            $this->markTestSkipped('Two-factor authentication is not enabled.');
-        }
+        $this->skipUnlessFortifyFeature(Features::twoFactorAuthentication());
 
         config(['fortify.features' => []]);
 

--- a/kits/Livewire/Components/tests/Feature/Settings/TwoFactorAuthenticationTest.php
+++ b/kits/Livewire/Components/tests/Feature/Settings/TwoFactorAuthenticationTest.php
@@ -16,9 +16,7 @@ class TwoFactorAuthenticationTest extends TestCase
     {
         parent::setUp();
 
-        if (! Features::canManageTwoFactorAuthentication()) {
-            $this->markTestSkipped('Two-factor authentication is not enabled.');
-        }
+        $this->skipUnlessFortifyFeature(Features::twoFactorAuthentication());
 
         Features::twoFactorAuthentication([
             'confirm' => true,

--- a/kits/Livewire/Fortify/tests/Feature/Auth/AuthenticationTest.php
+++ b/kits/Livewire/Fortify/tests/Feature/Auth/AuthenticationTest.php
@@ -50,9 +50,7 @@ class AuthenticationTest extends TestCase
 
     public function test_users_with_two_factor_enabled_are_redirected_to_two_factor_challenge(): void
     {
-        if (! Features::canManageTwoFactorAuthentication()) {
-            $this->markTestSkipped('Two-factor authentication is not enabled.');
-        }
+        $this->skipUnlessFortifyFeature(Features::twoFactorAuthentication());
 
         Features::twoFactorAuthentication([
             'confirm' => true,

--- a/kits/Livewire/Fortify/tests/Feature/Auth/EmailVerificationTest.php
+++ b/kits/Livewire/Fortify/tests/Feature/Auth/EmailVerificationTest.php
@@ -7,11 +7,19 @@ use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class EmailVerificationTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipUnlessFortifyFeature(Features::emailVerification());
+    }
 
     public function test_email_verification_screen_can_be_rendered(): void
     {

--- a/kits/Livewire/Fortify/tests/Feature/Auth/PasswordResetTest.php
+++ b/kits/Livewire/Fortify/tests/Feature/Auth/PasswordResetTest.php
@@ -6,11 +6,19 @@ use App\Models\User;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class PasswordResetTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipUnlessFortifyFeature(Features::resetPasswords());
+    }
 
     public function test_reset_password_link_screen_can_be_rendered(): void
     {

--- a/kits/Livewire/Fortify/tests/Feature/Auth/RegistrationTest.php
+++ b/kits/Livewire/Fortify/tests/Feature/Auth/RegistrationTest.php
@@ -3,11 +3,19 @@
 namespace Tests\Feature\Auth;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class RegistrationTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipUnlessFortifyFeature(Features::registration());
+    }
 
     public function test_registration_screen_can_be_rendered(): void
     {

--- a/kits/Livewire/Fortify/tests/Feature/Auth/TwoFactorChallengeTest.php
+++ b/kits/Livewire/Fortify/tests/Feature/Auth/TwoFactorChallengeTest.php
@@ -11,12 +11,15 @@ class TwoFactorChallengeTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipUnlessFortifyFeature(Features::twoFactorAuthentication());
+    }
+
     public function test_two_factor_challenge_redirects_to_login_when_not_authenticated(): void
     {
-        if (! Features::canManageTwoFactorAuthentication()) {
-            $this->markTestSkipped('Two-factor authentication is not enabled.');
-        }
-
         $response = $this->get(route('two-factor.login'));
 
         $response->assertRedirect(route('login'));
@@ -24,10 +27,6 @@ class TwoFactorChallengeTest extends TestCase
 
     public function test_two_factor_challenge_can_be_rendered(): void
     {
-        if (! Features::canManageTwoFactorAuthentication()) {
-            $this->markTestSkipped('Two-factor authentication is not enabled.');
-        }
-
         Features::twoFactorAuthentication([
             'confirm' => true,
             'confirmPassword' => true,

--- a/kits/Livewire/Fortify/tests/Feature/Settings/TwoFactorAuthenticationTest.php
+++ b/kits/Livewire/Fortify/tests/Feature/Settings/TwoFactorAuthenticationTest.php
@@ -16,9 +16,7 @@ class TwoFactorAuthenticationTest extends TestCase
     {
         parent::setUp();
 
-        if (! Features::canManageTwoFactorAuthentication()) {
-            $this->markTestSkipped('Two-factor authentication is not enabled.');
-        }
+        $this->skipUnlessFortifyFeature(Features::twoFactorAuthentication());
 
         Features::twoFactorAuthentication([
             'confirm' => true,

--- a/kits/Shared/Fortify/tests/TestCase.php
+++ b/kits/Shared/Fortify/tests/TestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Laravel\Fortify\Features;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected function skipUnlessFortifyFeature(string $feature, ?string $message = null): void
+    {
+        if (! Features::enabled($feature)) {
+            $this->markTestSkipped($message ?? "Fortify feature [{$feature}] is not enabled.");
+        }
+    }
+}

--- a/orchestrator/composer.json
+++ b/orchestrator/composer.json
@@ -57,7 +57,7 @@
         "lint": [
             "pint --parallel"
         ],
-        "lint:kits": [
+        "kits:lint": [
             "Composer\\Config::disableProcessTimeout",
             "pint --parallel ../kits",
             "node scripts/lint-kits.js"
@@ -65,6 +65,10 @@
         "kits:check": [
             "Composer\\Config::disableProcessTimeout",
             "node scripts/check-kits.js"
+        ],
+        "kits:browser-tests": [
+            "Composer\\Config::disableProcessTimeout",
+            "node scripts/browser-tests-kits.js"
         ],
         "kit:run": [
             "Composer\\Config::disableProcessTimeout",

--- a/orchestrator/scripts/browser-tests-kits.js
+++ b/orchestrator/scripts/browser-tests-kits.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import { spawn, execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const orchestratorDir = path.dirname(__dirname);
+const rootDir = path.dirname(orchestratorDir);
+const buildDir = path.join(rootDir, 'build');
+const browserTestsDir = path.join(rootDir, 'browser_tests');
+
+const variants = [
+    {
+        key: 'livewire',
+        display: 'Livewire',
+        buildArgs: ['build', '--no-interaction', '--kit=Livewire'],
+    },
+    {
+        key: 'react',
+        display: 'React',
+        buildArgs: ['build', '--no-interaction', '--kit=React'],
+    },
+    {
+        key: 'svelte',
+        display: 'Svelte',
+        buildArgs: ['build', '--no-interaction', '--kit=Svelte'],
+    },
+    {
+        key: 'vue',
+        display: 'Vue',
+        buildArgs: ['build', '--no-interaction', '--kit=Vue'],
+    },
+];
+
+const colors = {
+    reset: '\x1b[0m',
+    blue: '\x1b[34m',
+    green: '\x1b[32m',
+    yellow: '\x1b[33m',
+    red: '\x1b[31m',
+};
+
+function log(message, color = 'reset') {
+    console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+function runCommand(command, args, options = {}) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            stdio: 'inherit',
+            shell: true,
+            ...options,
+        });
+
+        child.on('close', code => {
+            if (code === 0) {
+                resolve();
+
+                return;
+            }
+
+            reject(new Error(`Command failed: ${command} ${args.join(' ')}`));
+        });
+
+        child.on('error', reject);
+    });
+}
+
+function removeBuildDirectory() {
+    if (!fs.existsSync(buildDir)) {
+        return;
+    }
+
+    log('Removing existing build directory...', 'yellow');
+    fs.rmSync(buildDir, { recursive: true, force: true });
+}
+
+function copyBrowserTests() {
+    log('Copying browser tests into build...', 'blue');
+    fs.cpSync(browserTestsDir, buildDir, { recursive: true });
+}
+
+function playwrightBrowsersInstalled() {
+    try {
+        const output = execSync('npx playwright install --dry-run', { cwd: buildDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+        const installPaths = output.match(/Install location:\s+(.+)/g);
+
+        if (!installPaths) {
+            return false;
+        }
+
+        return installPaths
+            .map(line => line.replace('Install location:', '').trim())
+            .every(dir => fs.existsSync(dir));
+    } catch {
+        return false;
+    }
+}
+
+async function ensurePlaywrightBrowsers() {
+    if (playwrightBrowsersInstalled()) {
+        log('Playwright browsers already installed, skipping...', 'green');
+
+        return;
+    }
+
+    log('Installing Playwright browsers...', 'blue');
+    await runCommand('npx', ['playwright', 'install', '--with-deps'], { cwd: buildDir });
+}
+
+async function runBrowserTestsForCurrentBuild() {
+    await runCommand('composer', ['remove', '--dev', 'phpunit/phpunit', '--no-interaction', '--no-update'], { cwd: buildDir });
+    await runCommand('composer', ['require', '--dev', 'pestphp/pest', 'pestphp/pest-plugin-browser', 'pestphp/pest-plugin-laravel', '--no-interaction'], { cwd: buildDir });
+    await runCommand('npm', ['install'], { cwd: buildDir });
+    await runCommand('npm', ['install', 'playwright'], { cwd: buildDir });
+    await ensurePlaywrightBrowsers();
+    await runCommand('cp', ['.env.example', '.env'], { cwd: buildDir });
+    await runCommand('php', ['artisan', 'key:generate'], { cwd: buildDir });
+    await runCommand('npm', ['run', 'build'], { cwd: buildDir });
+    await runCommand('php', ['vendor/bin/pest', '--parallel'], { cwd: buildDir });
+}
+
+async function browserTestVariant(variant, index, total) {
+    log(`\n[${index}/${total}] ${variant.display} (${variant.key})`, 'blue');
+
+    removeBuildDirectory();
+
+    log('Building variant...', 'blue');
+    await runCommand('php', ['artisan', ...variant.buildArgs], { cwd: orchestratorDir });
+
+    copyBrowserTests();
+
+    log('Running browser tests...', 'blue');
+    await runBrowserTestsForCurrentBuild();
+
+    log(`Passed ${variant.key}`, 'green');
+}
+
+async function main() {
+    const total = variants.length;
+
+    for (let index = 0; index < total; index++) {
+        await browserTestVariant(variants[index], index + 1, total);
+    }
+
+    log('\nAll starter kit variants passed browser tests.', 'green');
+}
+
+main().catch(error => {
+    log(`\nBrowser tests failed: ${error.message}`, 'red');
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Browser tests infrastructure**: Add a `composer kits:browser-tests` command and `browser-tests-kits.js` script that builds each Fortify variant (Livewire, React, Svelte, Vue), copies shared browser tests into the build, and runs them with Pest Browser (Playwright) — matching the GitHub Actions workflow locally.
- **New browser test coverage**: Mobile sidebar toggle, appearance/theme switching, two-factor authentication settings (enable, confirm, view recovery codes), authenticated welcome page, and password reset flow improvements.
- **Fortify feature-aware test skip guards**: Introduce a Fortify-layer `TestCase` with `skipUnlessFortifyFeature()` helper and apply it across 14 auth test files so tests depending on optional Fortify features (registration, password reset, email verification, 2FA) are gracefully skipped when disabled — replacing ad-hoc `canManageTwoFactorAuthentication()` / `markTestSkipped` patterns.
- **Documentation & command updates**: Rename `lint:kits` → `kits:lint` for consistency, document `kits:browser-tests` in SKILL.md / AGENTS.md / CLAUDE.md / README.md.

## Validation

- `composer kits:lint` — all 9 Inertia variants + Pint passed
- `composer kits:check` — all 13 kit variants passed CI checks
- `composer kits:browser-tests` — all 4 Fortify kits passed browser tests