### PR TITLE
Align app variant API across Vue, Svelte, and React

### DIFF
--- a/kits/Inertia/React/resources/js/components/app-content.tsx
+++ b/kits/Inertia/React/resources/js/components/app-content.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { SidebarInset } from '@/components/ui/sidebar';
+import type { AppVariant } from '@/types';
 
 type Props = React.ComponentProps<'main'> & {
-    variant?: 'header' | 'sidebar';
+    variant?: AppVariant;
 };
 
-export function AppContent({ variant = 'header', children, ...props }: Props) {
+export function AppContent({ variant = 'sidebar', children, ...props }: Props) {
     if (variant === 'sidebar') {
         return <SidebarInset {...props}>{children}</SidebarInset>;
     }

--- a/kits/Inertia/React/resources/js/components/app-shell.tsx
+++ b/kits/Inertia/React/resources/js/components/app-shell.tsx
@@ -1,13 +1,14 @@
 import { usePage } from '@inertiajs/react';
 import type { ReactNode } from 'react';
 import { SidebarProvider } from '@/components/ui/sidebar';
+import type { AppVariant } from '@/types';
 
 type Props = {
     children: ReactNode;
-    variant?: 'header' | 'sidebar';
+    variant?: AppVariant;
 };
 
-export function AppShell({ children, variant = 'header' }: Props) {
+export function AppShell({ children, variant = 'sidebar' }: Props) {
     const isOpen = usePage().props.sidebarOpen;
 
     if (variant === 'header') {

--- a/kits/Inertia/React/resources/js/layouts/app/app-header-layout.tsx
+++ b/kits/Inertia/React/resources/js/layouts/app/app-header-layout.tsx
@@ -8,9 +8,9 @@ export default function AppHeaderLayout({
     breadcrumbs,
 }: AppLayoutProps) {
     return (
-        <AppShell>
+        <AppShell variant="header">
             <AppHeader breadcrumbs={breadcrumbs} />
-            <AppContent>{children}</AppContent>
+            <AppContent variant="header">{children}</AppContent>
         </AppShell>
     );
 }

--- a/kits/Inertia/React/resources/js/types/ui.ts
+++ b/kits/Inertia/React/resources/js/types/ui.ts
@@ -6,6 +6,8 @@ export type AppLayoutProps = {
     breadcrumbs?: BreadcrumbItem[];
 };
 
+export type AppVariant = 'header' | 'sidebar';
+
 export type AuthLayoutProps = {
     children?: ReactNode;
     name?: string;

--- a/kits/Inertia/Svelte/resources/js/components/AppContent.svelte
+++ b/kits/Inertia/Svelte/resources/js/components/AppContent.svelte
@@ -2,13 +2,14 @@
     import type { Snippet } from 'svelte';
     import { SidebarInset } from '@/components/ui/sidebar';
     import { cn } from '@/lib/utils';
+    import type { AppVariant } from '@/types';
 
     let {
         variant = 'sidebar',
         class: className = '',
         children,
     }: {
-        variant?: 'header' | 'sidebar';
+        variant?: AppVariant;
         class?: string;
         children?: Snippet;
     } = $props();

--- a/kits/Inertia/Svelte/resources/js/components/AppShell.svelte
+++ b/kits/Inertia/Svelte/resources/js/components/AppShell.svelte
@@ -2,14 +2,14 @@
     import { page } from '@inertiajs/svelte';
     import type { Snippet } from 'svelte';
     import { SidebarProvider } from '@/components/ui/sidebar';
-    import type { AppShellVariant } from '@/types';
+    import type { AppVariant } from '@/types';
 
     let {
         variant = 'sidebar',
         class: className = '',
         children,
     }: {
-        variant?: AppShellVariant;
+        variant?: AppVariant;
         class?: string;
         children?: Snippet;
     } = $props();

--- a/kits/Inertia/Svelte/resources/js/layouts/app/AppHeaderLayout.svelte
+++ b/kits/Inertia/Svelte/resources/js/layouts/app/AppHeaderLayout.svelte
@@ -14,7 +14,7 @@
     } = $props();
 </script>
 
-<AppShell variant="header" class="flex-col">
+<AppShell variant="header">
     <AppHeader {breadcrumbs} />
     <AppContent variant="header">
         {@render children?.()}

--- a/kits/Inertia/Svelte/resources/js/types/ui.ts
+++ b/kits/Inertia/Svelte/resources/js/types/ui.ts
@@ -1,4 +1,4 @@
 export type Appearance = 'light' | 'dark' | 'system';
 export type ResolvedAppearance = 'light' | 'dark';
 
-export type AppShellVariant = 'header' | 'sidebar';
+export type AppVariant = 'header' | 'sidebar';

--- a/kits/Inertia/Vue/resources/js/components/AppContent.vue
+++ b/kits/Inertia/Vue/resources/js/components/AppContent.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { SidebarInset } from '@/components/ui/sidebar';
+import type { AppVariant } from '@/types';
 
 type Props = {
-    variant?: 'header' | 'sidebar';
+    variant?: AppVariant;
     class?: string;
 };
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+    variant: 'sidebar',
+});
 const className = computed(() => props.class);
 </script>
 

--- a/kits/Inertia/Vue/resources/js/components/AppShell.vue
+++ b/kits/Inertia/Vue/resources/js/components/AppShell.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import { usePage } from '@inertiajs/vue3';
 import { SidebarProvider } from '@/components/ui/sidebar';
-import type { AppShellVariant } from '@/types';
+import type { AppVariant } from '@/types';
 
 type Props = {
-    variant?: AppShellVariant;
+    variant?: AppVariant;
 };
 
-defineProps<Props>();
+withDefaults(defineProps<Props>(), {
+    variant: 'sidebar',
+});
 
 const isOpen = usePage().props.sidebarOpen;
 </script>

--- a/kits/Inertia/Vue/resources/js/layouts/app/AppHeaderLayout.vue
+++ b/kits/Inertia/Vue/resources/js/layouts/app/AppHeaderLayout.vue
@@ -14,9 +14,9 @@ withDefaults(defineProps<Props>(), {
 </script>
 
 <template>
-    <AppShell class="flex-col">
+    <AppShell variant="header">
         <AppHeader :breadcrumbs="breadcrumbs" />
-        <AppContent>
+        <AppContent variant="header">
             <slot />
         </AppContent>
     </AppShell>

--- a/kits/Inertia/Vue/resources/js/types/ui.ts
+++ b/kits/Inertia/Vue/resources/js/types/ui.ts
@@ -1,4 +1,4 @@
 export type Appearance = 'light' | 'dark' | 'system';
 export type ResolvedAppearance = 'light' | 'dark';
 
-export type AppShellVariant = 'header' | 'sidebar';
+export type AppVariant = 'header' | 'sidebar';

--- a/kits/Inertia/WorkOS/Vue/resources/js/types/ui.ts
+++ b/kits/Inertia/WorkOS/Vue/resources/js/types/ui.ts
@@ -1,3 +1,3 @@
 export type Appearance = 'light' | 'dark' | 'system';
 
-export type AppShellVariant = 'header' | 'sidebar';
+export type AppVariant = 'header' | 'sidebar';


### PR DESCRIPTION
This applies the changes from https://github.com/laravel/vue-starter-kit/pull/309 to all the Inertia starter kits.

## Summary

- Renames `AppShellVariant` to `AppVariant` across all Inertia frameworks (Vue, Svelte, React) and the Vue WorkOS override, giving every kit the same shared type name
- Defaults both `AppShell` and `AppContent` to `sidebar` in all frameworks (React previously defaulted to `header`)
- Makes header layouts pass `variant="header"` explicitly now that `sidebar` is the default, and removes the unnecessary `class="flex-col"` from Vue and Svelte header layouts

## Changes

| Area | Vue | Svelte | React |
|------|-----|--------|-------|
| **Type rename** | `AppShellVariant` → `AppVariant` | `AppShellVariant` → `AppVariant` | Added new `AppVariant` type |
| **AppShell default** | Added `withDefaults` for `sidebar` | Type rename only (already `sidebar`) | Changed default `header` → `sidebar` |
| **AppContent default** | Added `withDefaults` for `sidebar` | Type rename only (already `sidebar`) | Changed default `header` → `sidebar` |
| **Header layout** | Added explicit `variant="header"`, removed `class="flex-col"` | Removed `class="flex-col"` | Added explicit `variant="header"` |
| **WorkOS override** | Renamed to stay compatible | — | — |