### PR TITLE
Add password visibility toggle to all starter kits

### DIFF
--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/confirm-password.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/confirm-password.tsx
@@ -1,7 +1,7 @@
 import { Form, Head } from '@inertiajs/react';
 import InputError from '@/components/input-error';
+import PasswordInput from '@/components/password-input';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
 import AuthLayout from '@/layouts/auth-layout';
@@ -20,9 +20,8 @@ export default function ConfirmPassword() {
                     <div className="space-y-6">
                         <div className="grid gap-2">
                             <Label htmlFor="password">Password</Label>
-                            <Input
+                            <PasswordInput
                                 id="password"
-                                type="password"
                                 name="password"
                                 placeholder="Password"
                                 autoComplete="current-password"

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/login.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/login.tsx
@@ -1,5 +1,6 @@
 import { Form, Head } from '@inertiajs/react';
 import InputError from '@/components/input-error';
+import PasswordInput from '@/components/password-input';
 import TextLink from '@/components/text-link';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -65,9 +66,8 @@ export default function Login({
                                         </TextLink>
                                     )}
                                 </div>
-                                <Input
+                                <PasswordInput
                                     id="password"
-                                    type="password"
                                     name="password"
                                     required
                                     tabIndex={2}

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/register.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/register.tsx
@@ -1,5 +1,6 @@
 import { Form, Head } from '@inertiajs/react';
 import InputError from '@/components/input-error';
+import PasswordInput from '@/components/password-input';
 import TextLink from '@/components/text-link';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -59,9 +60,8 @@ export default function Register() {
 
                             <div className="grid gap-2">
                                 <Label htmlFor="password">Password</Label>
-                                <Input
+                                <PasswordInput
                                     id="password"
-                                    type="password"
                                     required
                                     tabIndex={3}
                                     autoComplete="new-password"
@@ -75,9 +75,8 @@ export default function Register() {
                                 <Label htmlFor="password_confirmation">
                                     Confirm password
                                 </Label>
-                                <Input
+                                <PasswordInput
                                     id="password_confirmation"
-                                    type="password"
                                     required
                                     tabIndex={4}
                                     autoComplete="new-password"

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/reset-password.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/reset-password.tsx
@@ -1,5 +1,6 @@
 import { Form, Head } from '@inertiajs/react';
 import InputError from '@/components/input-error';
+import PasswordInput from '@/components/password-input';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -46,9 +47,8 @@ export default function ResetPassword({ token, email }: Props) {
 
                         <div className="grid gap-2">
                             <Label htmlFor="password">Password</Label>
-                            <Input
+                            <PasswordInput
                                 id="password"
-                                type="password"
                                 name="password"
                                 autoComplete="new-password"
                                 className="mt-1 block w-full"
@@ -62,9 +62,8 @@ export default function ResetPassword({ token, email }: Props) {
                             <Label htmlFor="password_confirmation">
                                 Confirm password
                             </Label>
-                            <Input
+                            <PasswordInput
                                 id="password_confirmation"
-                                type="password"
                                 name="password_confirmation"
                                 autoComplete="new-password"
                                 className="mt-1 block w-full"

--- a/kits/Inertia/Fortify/React/resources/js/pages/settings/password.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/settings/password.tsx
@@ -4,8 +4,8 @@ import { useRef } from 'react';
 import PasswordController from '@/actions/App/Http/Controllers/Settings/PasswordController';
 import Heading from '@/components/heading';
 import InputError from '@/components/input-error';
+import PasswordInput from '@/components/password-input';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AppLayout from '@/layouts/app-layout';
 import SettingsLayout from '@/layouts/settings/layout';
@@ -66,11 +66,10 @@ export default function Password() {
                                         Current password
                                     </Label>
 
-                                    <Input
+                                    <PasswordInput
                                         id="current_password"
                                         ref={currentPasswordInput}
                                         name="current_password"
-                                        type="password"
                                         className="mt-1 block w-full"
                                         autoComplete="current-password"
                                         placeholder="Current password"
@@ -86,11 +85,10 @@ export default function Password() {
                                         New password
                                     </Label>
 
-                                    <Input
+                                    <PasswordInput
                                         id="password"
                                         ref={passwordInput}
                                         name="password"
-                                        type="password"
                                         className="mt-1 block w-full"
                                         autoComplete="new-password"
                                         placeholder="New password"
@@ -104,10 +102,9 @@ export default function Password() {
                                         Confirm password
                                     </Label>
 
-                                    <Input
+                                    <PasswordInput
                                         id="password_confirmation"
                                         name="password_confirmation"
-                                        type="password"
                                         className="mt-1 block w-full"
                                         autoComplete="new-password"
                                         placeholder="Confirm password"

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/ConfirmPassword.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/ConfirmPassword.svelte
@@ -2,8 +2,8 @@
     import { Form } from '@inertiajs/svelte';
     import AppHead from '@/components/AppHead.svelte';
     import InputError from '@/components/InputError.svelte';
+    import PasswordInput from '@/components/PasswordInput.svelte';
     import { Button } from '@/components/ui/button';
-    import { Input } from '@/components/ui/input';
     import { Label } from '@/components/ui/label';
     import { Spinner } from '@/components/ui/spinner';
     import AuthLayout from '@/layouts/AuthLayout.svelte';
@@ -21,9 +21,8 @@
             <div class="space-y-6">
                 <div class="grid gap-2">
                     <Label for="password">Password</Label>
-                    <Input
+                    <PasswordInput
                         id="password"
-                        type="password"
                         name="password"
                         class="mt-1 block w-full"
                         required

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Login.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Login.svelte
@@ -2,6 +2,7 @@
     import { Form } from '@inertiajs/svelte';
     import AppHead from '@/components/AppHead.svelte';
     import InputError from '@/components/InputError.svelte';
+    import PasswordInput from '@/components/PasswordInput.svelte';
     import TextLink from '@/components/TextLink.svelte';
     import { Button } from '@/components/ui/button';
     import { Checkbox } from '@/components/ui/checkbox';
@@ -65,9 +66,8 @@
                             </TextLink>
                         {/if}
                     </div>
-                    <Input
+                    <PasswordInput
                         id="password"
-                        type="password"
                         name="password"
                         required
                         autocomplete="current-password"

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Register.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Register.svelte
@@ -2,6 +2,7 @@
     import { Form } from '@inertiajs/svelte';
     import AppHead from '@/components/AppHead.svelte';
     import InputError from '@/components/InputError.svelte';
+    import PasswordInput from '@/components/PasswordInput.svelte';
     import TextLink from '@/components/TextLink.svelte';
     import { Button } from '@/components/ui/button';
     import { Input } from '@/components/ui/input';
@@ -53,9 +54,8 @@
 
                 <div class="grid gap-2">
                     <Label for="password">Password</Label>
-                    <Input
+                    <PasswordInput
                         id="password"
-                        type="password"
                         required
                         autocomplete="new-password"
                         name="password"
@@ -66,9 +66,8 @@
 
                 <div class="grid gap-2">
                     <Label for="password_confirmation">Confirm password</Label>
-                    <Input
+                    <PasswordInput
                         id="password_confirmation"
-                        type="password"
                         required
                         autocomplete="new-password"
                         name="password_confirmation"

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/ResetPassword.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/ResetPassword.svelte
@@ -2,6 +2,7 @@
     import { Form } from '@inertiajs/svelte';
     import AppHead from '@/components/AppHead.svelte';
     import InputError from '@/components/InputError.svelte';
+    import PasswordInput from '@/components/PasswordInput.svelte';
     import { Button } from '@/components/ui/button';
     import { Input } from '@/components/ui/input';
     import { Label } from '@/components/ui/label';
@@ -47,9 +48,8 @@
 
                 <div class="grid gap-2">
                     <Label for="password">Password</Label>
-                    <Input
+                    <PasswordInput
                         id="password"
-                        type="password"
                         name="password"
                         autocomplete="new-password"
                         class="mt-1 block w-full"
@@ -60,9 +60,8 @@
 
                 <div class="grid gap-2">
                     <Label for="password_confirmation">Confirm password</Label>
-                    <Input
+                    <PasswordInput
                         id="password_confirmation"
-                        type="password"
                         name="password_confirmation"
                         autocomplete="new-password"
                         class="mt-1 block w-full"

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/settings/Password.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/settings/Password.svelte
@@ -4,8 +4,8 @@
     import AppHead from '@/components/AppHead.svelte';
     import Heading from '@/components/Heading.svelte';
     import InputError from '@/components/InputError.svelte';
+    import PasswordInput from '@/components/PasswordInput.svelte';
     import { Button } from '@/components/ui/button';
-    import { Input } from '@/components/ui/input';
     import { Label } from '@/components/ui/label';
     import AppLayout from '@/layouts/AppLayout.svelte';
     import SettingsLayout from '@/layouts/settings/Layout.svelte';
@@ -47,10 +47,9 @@
                 {#snippet children({ errors, processing, recentlySuccessful })}
                     <div class="grid gap-2">
                         <Label for="current_password">Current password</Label>
-                        <Input
+                        <PasswordInput
                             id="current_password"
                             name="current_password"
-                            type="password"
                             class="mt-1 block w-full"
                             autocomplete="current-password"
                             placeholder="Current password"
@@ -60,10 +59,9 @@
 
                     <div class="grid gap-2">
                         <Label for="password">New password</Label>
-                        <Input
+                        <PasswordInput
                             id="password"
                             name="password"
-                            type="password"
                             class="mt-1 block w-full"
                             autocomplete="new-password"
                             placeholder="New password"
@@ -75,10 +73,9 @@
                         <Label for="password_confirmation"
                             >Confirm password</Label
                         >
-                        <Input
+                        <PasswordInput
                             id="password_confirmation"
                             name="password_confirmation"
-                            type="password"
                             class="mt-1 block w-full"
                             autocomplete="new-password"
                             placeholder="Confirm password"

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ConfirmPassword.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ConfirmPassword.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { Form, Head } from '@inertiajs/vue3';
 import InputError from '@/components/InputError.vue';
+import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
 import AuthLayout from '@/layouts/AuthLayout.vue';
@@ -24,9 +24,8 @@ import { store } from '@/routes/password/confirm';
             <div class="space-y-6">
                 <div class="grid gap-2">
                     <Label htmlFor="password">Password</Label>
-                    <Input
+                    <PasswordInput
                         id="password"
-                        type="password"
                         name="password"
                         class="mt-1 block w-full"
                         required

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Login.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Login.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Form, Head } from '@inertiajs/vue3';
 import InputError from '@/components/InputError.vue';
+import PasswordInput from '@/components/PasswordInput.vue';
 import TextLink from '@/components/TextLink.vue';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -67,9 +68,8 @@ defineProps<{
                             Forgot password?
                         </TextLink>
                     </div>
-                    <Input
+                    <PasswordInput
                         id="password"
-                        type="password"
                         name="password"
                         required
                         :tabindex="2"

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Register.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Register.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Form, Head } from '@inertiajs/vue3';
 import InputError from '@/components/InputError.vue';
+import PasswordInput from '@/components/PasswordInput.vue';
 import TextLink from '@/components/TextLink.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -56,9 +57,8 @@ import { store } from '@/routes/register';
 
                 <div class="grid gap-2">
                     <Label for="password">Password</Label>
-                    <Input
+                    <PasswordInput
                         id="password"
-                        type="password"
                         required
                         :tabindex="3"
                         autocomplete="new-password"
@@ -70,9 +70,8 @@ import { store } from '@/routes/register';
 
                 <div class="grid gap-2">
                     <Label for="password_confirmation">Confirm password</Label>
-                    <Input
+                    <PasswordInput
                         id="password_confirmation"
-                        type="password"
                         required
                         :tabindex="4"
                         autocomplete="new-password"

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ResetPassword.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ResetPassword.vue
@@ -2,6 +2,7 @@
 import { Form, Head } from '@inertiajs/vue3';
 import { ref } from 'vue';
 import InputError from '@/components/InputError.vue';
+import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -47,9 +48,8 @@ const inputEmail = ref(props.email);
 
                 <div class="grid gap-2">
                     <Label for="password">Password</Label>
-                    <Input
+                    <PasswordInput
                         id="password"
-                        type="password"
                         name="password"
                         autocomplete="new-password"
                         class="mt-1 block w-full"
@@ -63,9 +63,8 @@ const inputEmail = ref(props.email);
                     <Label for="password_confirmation">
                         Confirm password
                     </Label>
-                    <Input
+                    <PasswordInput
                         id="password_confirmation"
-                        type="password"
                         name="password_confirmation"
                         autocomplete="new-password"
                         class="mt-1 block w-full"

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/settings/Password.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/settings/Password.vue
@@ -3,8 +3,8 @@ import { Form, Head } from '@inertiajs/vue3';
 import PasswordController from '@/actions/App/Http/Controllers/Settings/PasswordController';
 import Heading from '@/components/Heading.vue';
 import InputError from '@/components/InputError.vue';
+import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AppLayout from '@/layouts/AppLayout.vue';
 import SettingsLayout from '@/layouts/settings/Layout.vue';
@@ -49,10 +49,9 @@ const breadcrumbItems: BreadcrumbItem[] = [
                 >
                     <div class="grid gap-2">
                         <Label for="current_password">Current password</Label>
-                        <Input
+                        <PasswordInput
                             id="current_password"
                             name="current_password"
-                            type="password"
                             class="mt-1 block w-full"
                             autocomplete="current-password"
                             placeholder="Current password"
@@ -62,10 +61,9 @@ const breadcrumbItems: BreadcrumbItem[] = [
 
                     <div class="grid gap-2">
                         <Label for="password">New password</Label>
-                        <Input
+                        <PasswordInput
                             id="password"
                             name="password"
-                            type="password"
                             class="mt-1 block w-full"
                             autocomplete="new-password"
                             placeholder="New password"
@@ -77,10 +75,9 @@ const breadcrumbItems: BreadcrumbItem[] = [
                         <Label for="password_confirmation"
                             >Confirm password</Label
                         >
-                        <Input
+                        <PasswordInput
                             id="password_confirmation"
                             name="password_confirmation"
-                            type="password"
                             class="mt-1 block w-full"
                             autocomplete="new-password"
                             placeholder="Confirm password"

--- a/kits/Inertia/React/resources/js/components/delete-user.tsx
+++ b/kits/Inertia/React/resources/js/components/delete-user.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileController';
 import Heading from '@/components/heading';
 import InputError from '@/components/input-error';
+import PasswordInput from '@/components/password-input';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -13,7 +14,6 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
 export default function DeleteUser() {
@@ -73,9 +73,8 @@ export default function DeleteUser() {
                                             Password
                                         </Label>
 
-                                        <Input
+                                        <PasswordInput
                                             id="password"
-                                            type="password"
                                             name="password"
                                             ref={passwordInput}
                                             placeholder="Password"

--- a/kits/Inertia/React/resources/js/components/password-input.tsx
+++ b/kits/Inertia/React/resources/js/components/password-input.tsx
@@ -1,0 +1,37 @@
+import { Eye, EyeOff } from 'lucide-react';
+import type { ComponentProps, Ref } from 'react';
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+export default function PasswordInput({
+    className,
+    ref,
+    ...props
+}: Omit<ComponentProps<'input'>, 'type'> & { ref?: Ref<HTMLInputElement> }) {
+    const [showPassword, setShowPassword] = useState(false);
+
+    return (
+        <div className="relative">
+            <Input
+                type={showPassword ? 'text' : 'password'}
+                className={cn('pr-10', className)}
+                ref={ref}
+                {...props}
+            />
+            <button
+                type="button"
+                onClick={() => setShowPassword((prev) => !prev)}
+                className="absolute inset-y-0 right-0 flex items-center rounded-r-md px-3 text-muted-foreground hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:outline-none"
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+                tabIndex={-1}
+            >
+                {showPassword ? (
+                    <EyeOff className="size-4" />
+                ) : (
+                    <Eye className="size-4" />
+                )}
+            </button>
+        </div>
+    );
+}

--- a/kits/Inertia/Svelte/resources/js/components/DeleteUser.svelte
+++ b/kits/Inertia/Svelte/resources/js/components/DeleteUser.svelte
@@ -3,6 +3,7 @@
     import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileController';
     import Heading from '@/components/Heading.svelte';
     import InputError from '@/components/InputError.svelte';
+    import PasswordInput from '@/components/PasswordInput.svelte';
     import { Button } from '@/components/ui/button';
     import {
         Dialog,
@@ -13,7 +14,6 @@
         DialogTitle,
         DialogTrigger,
     } from '@/components/ui/dialog';
-    import { Input } from '@/components/ui/input';
     import { Label } from '@/components/ui/label';
 </script>
 
@@ -62,9 +62,8 @@
                             <Label for="password" class="sr-only"
                                 >Password</Label
                             >
-                            <Input
+                            <PasswordInput
                                 id="password"
-                                type="password"
                                 name="password"
                                 placeholder="Password"
                             />

--- a/kits/Inertia/Svelte/resources/js/components/PasswordInput.svelte
+++ b/kits/Inertia/Svelte/resources/js/components/PasswordInput.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+    import Eye from 'lucide-svelte/icons/eye';
+    import EyeOff from 'lucide-svelte/icons/eye-off';
+    import { Input } from '@/components/ui/input';
+    import { cn } from '@/lib/utils';
+
+    let { class: className = '', ...rest } = $props();
+
+    let showPassword = $state(false);
+</script>
+
+<div class="relative">
+    <Input
+        type={showPassword ? 'text' : 'password'}
+        class={cn('pr-10', className)}
+        {...rest}
+    />
+    <button
+        type="button"
+        onclick={() => (showPassword = !showPassword)}
+        class="text-muted-foreground hover:text-foreground focus-visible:ring-ring absolute inset-y-0 right-0 flex items-center rounded-r-md px-3 focus-visible:outline-none focus-visible:ring-[3px]"
+        aria-label={showPassword ? 'Hide password' : 'Show password'}
+        tabindex={-1}
+    >
+        {#if showPassword}
+            <EyeOff class="size-4" />
+        {:else}
+            <Eye class="size-4" />
+        {/if}
+    </button>
+</div>

--- a/kits/Inertia/Vue/resources/js/components/DeleteUser.vue
+++ b/kits/Inertia/Vue/resources/js/components/DeleteUser.vue
@@ -4,6 +4,7 @@ import { useTemplateRef } from 'vue';
 import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileController';
 import Heading from '@/components/Heading.vue';
 import InputError from '@/components/InputError.vue';
+import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -15,7 +16,6 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
 const passwordInput = useTemplateRef('passwordInput');
@@ -47,7 +47,7 @@ const passwordInput = useTemplateRef('passwordInput');
                     <Form
                         v-bind="ProfileController.destroy.form()"
                         reset-on-success
-                        @error="() => passwordInput?.$el?.focus()"
+                        @error="() => passwordInput?.focus()"
                         :options="{
                             preserveScroll: true,
                         }"
@@ -72,9 +72,8 @@ const passwordInput = useTemplateRef('passwordInput');
                             <Label for="password" class="sr-only"
                                 >Password</Label
                             >
-                            <Input
+                            <PasswordInput
                                 id="password"
-                                type="password"
                                 name="password"
                                 ref="passwordInput"
                                 placeholder="Password"

--- a/kits/Inertia/Vue/resources/js/components/PasswordInput.vue
+++ b/kits/Inertia/Vue/resources/js/components/PasswordInput.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { Eye, EyeOff } from 'lucide-vue-next';
+import { ref, useTemplateRef } from 'vue';
+import type { HTMLAttributes } from 'vue';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+defineOptions({ inheritAttrs: false });
+
+const props = defineProps<{
+    class?: HTMLAttributes['class'];
+}>();
+
+const showPassword = ref(false);
+const inputRef = useTemplateRef('inputRef');
+
+defineExpose({
+    $el: inputRef,
+    focus: () => inputRef.value?.$el?.focus(),
+});
+</script>
+
+<template>
+    <div class="relative">
+        <Input
+            ref="inputRef"
+            :type="showPassword ? 'text' : 'password'"
+            :class="cn('pr-10', props.class)"
+            v-bind="$attrs"
+        />
+        <button
+            type="button"
+            @click="showPassword = !showPassword"
+            :class="
+                cn(
+                    'absolute inset-y-0 right-0 flex items-center rounded-r-md px-3 text-muted-foreground hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:outline-none',
+                )
+            "
+            :aria-label="showPassword ? 'Hide password' : 'Show password'"
+            :tabindex="-1"
+        >
+            <EyeOff v-if="showPassword" class="size-4" />
+            <Eye v-else class="size-4" />
+        </button>
+    </div>
+</template>

--- a/kits/Livewire/Base/resources/views/pages/settings/delete-user-modal.blade.php
+++ b/kits/Livewire/Base/resources/views/pages/settings/delete-user-modal.blade.php
@@ -35,7 +35,7 @@ new class extends Component {
             </flux:subheading>
         </div>
 
-        <flux:input wire:model="password" :label="__('Password')" type="password" />
+        <flux:input wire:model="password" :label="__('Password')" type="password" viewable />
 
         <div class="flex justify-end space-x-2 rtl:space-x-reverse">
             <flux:modal.close>

--- a/kits/Livewire/Components/resources/views/livewire/settings/delete-user-form.blade.php
+++ b/kits/Livewire/Components/resources/views/livewire/settings/delete-user-form.blade.php
@@ -20,7 +20,7 @@
                 </flux:subheading>
             </div>
 
-            <flux:input wire:model="password" :label="__('Password')" type="password" />
+            <flux:input wire:model="password" :label="__('Password')" type="password" viewable />
 
             <div class="flex justify-end space-x-2 rtl:space-x-reverse">
                 <flux:modal.close>

--- a/kits/Livewire/Components/resources/views/livewire/settings/password.blade.php
+++ b/kits/Livewire/Components/resources/views/livewire/settings/password.blade.php
@@ -11,6 +11,7 @@
                 type="password"
                 required
                 autocomplete="current-password"
+                viewable
             />
             <flux:input
                 wire:model="password"
@@ -18,6 +19,7 @@
                 type="password"
                 required
                 autocomplete="new-password"
+                viewable
             />
             <flux:input
                 wire:model="password_confirmation"
@@ -25,6 +27,7 @@
                 type="password"
                 required
                 autocomplete="new-password"
+                viewable
             />
 
             <div class="flex items-center gap-4">

--- a/kits/Livewire/Fortify/resources/views/pages/settings/password.blade.php
+++ b/kits/Livewire/Fortify/resources/views/pages/settings/password.blade.php
@@ -52,6 +52,7 @@ new #[Title('Password settings')] class extends Component {
                 type="password"
                 required
                 autocomplete="current-password"
+                viewable
             />
             <flux:input
                 wire:model="password"
@@ -59,6 +60,7 @@ new #[Title('Password settings')] class extends Component {
                 type="password"
                 required
                 autocomplete="new-password"
+                viewable
             />
             <flux:input
                 wire:model="password_confirmation"
@@ -66,6 +68,7 @@ new #[Title('Password settings')] class extends Component {
                 type="password"
                 required
                 autocomplete="new-password"
+                viewable
             />
 
             <div class="flex items-center gap-4">


### PR DESCRIPTION
Password fields across all starter kits have no way to reveal the entered text, which is a common usability expectation — especially on mobile and for long/generated passwords.

### Approach

- Added a `PasswordInput` component for each Inertia framework (React, Svelte, Vue) that wraps the base `Input` with an eye/eye-off toggle button
- Replaced all plain password inputs across auth pages and settings pages with the new component
- For Livewire kits, added Flux's native `viewable` attribute to password inputs for the same behavior