### PR TITLE
Harden orchestrator scripts with shared runner, manifest, and watcher reconciliation

### DIFF
--- a/.agents/skills/maestro/SKILL.md
+++ b/.agents/skills/maestro/SKILL.md
@@ -26,11 +26,25 @@ All commands below run from the `orchestrator/` directory unless noted otherwise
 | `php artisan build --kit=svelte --blank`             | Build Blank Svelte kit.                                                    |
 | `php artisan build --kit=livewire --workos`          | Build Livewire WorkOS kit.                                                 |
 | `composer kit:run`                                   | Start dev server + file watcher (syncs `build/` back to `kits/`).          |
-| `composer kits:lint`                                 | Run Pint for `kits/`, then lint/format all Inertia variants and sync back. |
+| `composer kits:pint`                                 | Run Pint on `kits/` and `browser_tests/`.                                  |
+| `composer kits:lint`                                 | Run `kits:pint`, then lint/format Inertia variants and sync back.          |
 | `composer kits:check`                                | Build and run CI checks (`composer setup && composer ci:check`) for all 13 kit variants sequentially. |
 | `composer kits:browser-tests`                        | Build and run browser tests for all 4 Fortify kit variants (Livewire, React, Svelte, Vue). |
 | `npm run watch:kits`                                 | Run only the file watcher (no dev server).                                 |
 | `composer setup && composer ci:check`                | Run inside `build/` — installs deps, builds frontend, runs checks (see below). |
+
+### Selective Framework Execution
+
+Pass `--livewire`, `--react`, `--svelte`, and/or `--vue` to target specific frameworks:
+
+```bash
+composer kits:check -- --react --svelte
+composer kits:lint -- --vue
+composer kits:lint -- --livewire        # runs only the shared Pint step (no frontend lint phase)
+composer kits:browser-tests -- --vue
+```
+
+No flags runs the full default matrix for each command.
 
 Available `--kit` values defined in `orchestrator/app/Enums/StarterKit.php`.
 
@@ -259,5 +273,5 @@ Kit names are case-sensitive here because the workflow matrix uses `Livewire`, `
 2. **Follow sibling patterns**: When creating a Svelte file, check the React and Vue equivalents for expected structure and behavior and vice-versa.
 3. **Layer awareness**: Know which layer a file belongs to. Shared files affect all kits. Framework-specific files only affect that framework.
 4. **Placeholder awareness**: Files in `kits/` contain `{{placeholders}}`. Files in `build/` have resolved values. The watcher handles conversion.
-5. **Lint changes**: Run `composer lint` in `orchestrator` for orchestrator PHP linting, and run `composer kits:lint` to run Pint on `kits/`, run UI lint/format across all Inertia variants, and sync changes back to `kits/`.
+5. **Lint changes**: Run `composer lint` in `orchestrator` for orchestrator PHP linting. Run `composer kits:pint` for fast PHP formatting of `kits/` and `browser_tests/`. Run `composer kits:lint` to run Pint then lint/format all Inertia variants and sync changes back to `kits/`.
 6. **Test after changes**: Run `composer setup && composer ci:check` inside `build/` to verify nothing is broken.

--- a/.claude/skills/maestro/SKILL.md
+++ b/.claude/skills/maestro/SKILL.md
@@ -26,11 +26,25 @@ All commands below run from the `orchestrator/` directory unless noted otherwise
 | `php artisan build --kit=svelte --blank`             | Build Blank Svelte kit.                                                    |
 | `php artisan build --kit=livewire --workos`          | Build Livewire WorkOS kit.                                                 |
 | `composer kit:run`                                   | Start dev server + file watcher (syncs `build/` back to `kits/`).          |
-| `composer kits:lint`                                 | Run Pint for `kits/`, then lint/format all Inertia variants and sync back. |
+| `composer kits:pint`                                 | Run Pint on `kits/` and `browser_tests/`.                                  |
+| `composer kits:lint`                                 | Run `kits:pint`, then lint/format Inertia variants and sync back.          |
 | `composer kits:check`                                | Build and run CI checks (`composer setup && composer ci:check`) for all 13 kit variants sequentially. |
 | `composer kits:browser-tests`                        | Build and run browser tests for all 4 Fortify kit variants (Livewire, React, Svelte, Vue). |
 | `npm run watch:kits`                                 | Run only the file watcher (no dev server).                                 |
 | `composer setup && composer ci:check`                | Run inside `build/` — installs deps, builds frontend, runs checks (see below). |
+
+### Selective Framework Execution
+
+Pass `--livewire`, `--react`, `--svelte`, and/or `--vue` to target specific frameworks:
+
+```bash
+composer kits:check -- --react --svelte
+composer kits:lint -- --vue
+composer kits:lint -- --livewire        # runs only the shared Pint step (no frontend lint phase)
+composer kits:browser-tests -- --vue
+```
+
+No flags runs the full default matrix for each command.
 
 Available `--kit` values defined in `orchestrator/app/Enums/StarterKit.php`.
 
@@ -259,5 +273,5 @@ Kit names are case-sensitive here because the workflow matrix uses `Livewire`, `
 2. **Follow sibling patterns**: When creating a Svelte file, check the React and Vue equivalents for expected structure and behavior and vice-versa.
 3. **Layer awareness**: Know which layer a file belongs to. Shared files affect all kits. Framework-specific files only affect that framework.
 4. **Placeholder awareness**: Files in `kits/` contain `{{placeholders}}`. Files in `build/` have resolved values. The watcher handles conversion.
-5. **Lint changes**: Run `composer lint` in `orchestrator` for orchestrator PHP linting, and run `composer kits:lint` to run Pint on `kits/`, run UI lint/format across all Inertia variants, and sync changes back to `kits/`.
+5. **Lint changes**: Run `composer lint` in `orchestrator` for orchestrator PHP linting. Run `composer kits:pint` for fast PHP formatting of `kits/` and `browser_tests/`. Run `composer kits:lint` to run Pint then lint/format all Inertia variants and sync changes back to `kits/`.
 6. **Test after changes**: Run `composer setup && composer ci:check` inside `build/` to verify nothing is broken.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,20 @@ Maestro is the monorepo orchestrator for the official Laravel starter kits. Use 
 - Dev: `composer kit:run` (from `orchestrator/`)
 - Test: `composer setup && composer ci:check` (from `build/`)
 - Test all kits: `composer kits:check` (from `orchestrator/`) — builds and runs CI checks for all 13 variants
-- Lint: `composer kits:lint` (from `orchestrator/`)
+- Pint only: `composer kits:pint` (from `orchestrator/`) — runs Pint on `kits/` and `browser_tests/`
+- Lint: `composer kits:lint` (from `orchestrator/`) — runs `kits:pint`, then frontend lint/format for Inertia variants
 - Browser tests (all kits): `composer kits:browser-tests` (from `orchestrator/`)
 - Edit in `build/` (when available), commit in `kits/`
+
+### Selective Framework Execution
+
+Pass `--livewire`, `--react`, `--svelte`, and/or `--vue` to target specific frameworks:
+
+```bash
+composer kits:check -- --react --svelte
+composer kits:lint -- --vue
+composer kits:lint -- --livewire        # runs only the shared Pint step (no frontend lint phase)
+composer kits:browser-tests -- --vue
+```
+
+No flags runs the full default matrix for each command.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,20 @@ Maestro is the monorepo orchestrator for the official Laravel starter kits. Use 
 - Dev: `composer kit:run` (from `orchestrator/`)
 - Test: `composer setup && composer ci:check` (from `build/`)
 - Test all kits: `composer kits:check` (from `orchestrator/`) — builds and runs CI checks for all 13 variants
-- Lint: `composer kits:lint` (from `orchestrator/`)
+- Pint only: `composer kits:pint` (from `orchestrator/`) — runs Pint on `kits/` and `browser_tests/`
+- Lint: `composer kits:lint` (from `orchestrator/`) — runs `kits:pint`, then frontend lint/format for Inertia variants
 - Browser tests (all kits): `composer kits:browser-tests` (from `orchestrator/`)
 - Edit in `build/` (when available), commit in `kits/`
+
+### Selective Framework Execution
+
+Pass `--livewire`, `--react`, `--svelte`, and/or `--vue` to target specific frameworks:
+
+```bash
+composer kits:check -- --react --svelte
+composer kits:lint -- --vue
+composer kits:lint -- --livewire        # runs only the shared Pint step (no frontend lint phase)
+composer kits:browser-tests -- --vue
+```
+
+No flags runs the full default matrix for each command.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,26 @@ From the `orchestrator` directory, run:
 composer kits:lint
 ```
 
-This command loops over all Inertia variants, builds each variant, runs frontend linting/formatting in `build` (`npm install`, then lint/format), and then runs `npm run watch:kits -- --initial-sync-only` to perform and verify an initial sync back to `kits`.
+This command runs Pint on `kits/` and `browser_tests/` first, then loops over all Inertia variants, builds each variant, runs frontend linting/formatting in `build` (`npm install`, then lint/format), and then runs `npm run watch:kits -- --initial-sync-only` to sync changes back to `kits`.
 
-`composer kits:lint` also runs Pint on `kits/` before the frontend lint pass.
+To run only the Pint step without the frontend lint pass:
+
+```bash
+composer kits:pint
+```
+
+### Selective Framework Execution
+
+Pass `--livewire`, `--react`, `--svelte`, and/or `--vue` to target specific frameworks:
+
+```bash
+composer kits:check -- --react --svelte
+composer kits:lint -- --vue
+composer kits:lint -- --livewire        # runs only the shared Pint step (no frontend lint phase)
+composer kits:browser-tests -- --vue
+```
+
+No flags runs the full default matrix for each command.
 
 ### Submitting Changes
 

--- a/browser_tests/tests/Browser/Auth/EmailVerificationTest.php
+++ b/browser_tests/tests/Browser/Auth/EmailVerificationTest.php
@@ -29,7 +29,7 @@ test('email can be verified', function () {
     $verificationUrl = URL::temporarySignedRoute(
         'verification.verify',
         now()->addMinutes(60),
-        ['id' => $user->id, 'hash' => sha1($user->email)]
+        ['id' => $user->id, 'hash' => sha1($user->email)],
     );
 
     visit($verificationUrl)
@@ -52,7 +52,7 @@ test('email is not verified with invalid hash', function () {
     $verificationUrl = URL::temporarySignedRoute(
         'verification.verify',
         now()->addMinutes(60),
-        ['id' => $user->id, 'hash' => sha1('wrong-email')]
+        ['id' => $user->id, 'hash' => sha1('wrong-email')],
     );
 
     visit($verificationUrl)
@@ -75,7 +75,7 @@ test('email is not verified with invalid user id', function () {
     $verificationUrl = URL::temporarySignedRoute(
         'verification.verify',
         now()->addMinutes(60),
-        ['id' => 123, 'hash' => sha1($user->email)]
+        ['id' => 123, 'hash' => sha1($user->email)],
     );
 
     visit($verificationUrl)
@@ -117,7 +117,7 @@ test('already verified user visiting verification link is redirected without fir
     $verificationUrl = URL::temporarySignedRoute(
         'verification.verify',
         now()->addMinutes(60),
-        ['id' => $user->id, 'hash' => sha1($user->email)]
+        ['id' => $user->id, 'hash' => sha1($user->email)],
     );
 
     visit($verificationUrl)

--- a/browser_tests/tests/Browser/Settings/TwoFactorAuthenticationTest.php
+++ b/browser_tests/tests/Browser/Settings/TwoFactorAuthenticationTest.php
@@ -1,15 +1,21 @@
 <?php
 
 use App\Models\User;
+use Illuminate\Auth\Middleware\RequirePassword;
 use Pest\Browser\Api\AwaitableWebpage;
 use PragmaRX\Google2FA\Google2FA;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\withoutMiddleware;
+
+beforeEach(function () {
+    withoutMiddleware(RequirePassword::class);
+});
 
 test('two-factor authentication page can be rendered', function () {
     actingAs(User::factory()->create());
 
-    visitPasswordProtectedPage('two-factor.show')
+    visit(route('two-factor.show'))
         ->assertPathEndsWith('/settings/two-factor')
         ->assertSee('Two-factor authentication')
         ->assertSee('Manage your two-factor authentication settings')
@@ -20,7 +26,7 @@ test('two-factor authentication page can be rendered', function () {
 test('two-factor authentication shows disabled state by default', function () {
     actingAs(User::factory()->create());
 
-    visitPasswordProtectedPage('two-factor.show')
+    visit(route('two-factor.show'))
         ->assertPathEndsWith('/settings/two-factor')
         ->assertSee('Disabled')
         ->assertSee('Enable 2FA')
@@ -34,7 +40,7 @@ test('two-factor authentication can be enabled and confirmed', function () {
 
     actingAs($user);
 
-    $browser = visitPasswordProtectedPage('two-factor.show')
+    $browser = visit(route('two-factor.show'))
         ->assertPathEndsWith('/settings/two-factor')
         ->assertSee('Disabled')
         ->click('Enable 2FA')
@@ -66,7 +72,7 @@ test('two-factor authentication shows enabled state', function () {
         ])),
     ]));
 
-    visitPasswordProtectedPage('two-factor.show')
+    visit(route('two-factor.show'))
         ->assertPathEndsWith('/settings/two-factor')
         ->assertSee('Enabled')
         ->assertSee('Disable 2FA')
@@ -85,7 +91,7 @@ test('two-factor authentication recovery codes can be viewed', function () {
         ])),
     ]));
 
-    visitPasswordProtectedPage('two-factor.show')
+    visit(route('two-factor.show'))
         ->assertPathEndsWith('/settings/two-factor')
         ->assertSee('View recovery codes')
         ->click('View recovery codes')

--- a/browser_tests/tests/Browser/Settings/TwoFactorAuthenticationTest.php
+++ b/browser_tests/tests/Browser/Settings/TwoFactorAuthenticationTest.php
@@ -99,7 +99,7 @@ test('two-factor authentication recovery codes can be viewed', function () {
 function fillOTPCode(AwaitableWebpage $browser, string $code): AwaitableWebpage
 {
     $isInertia = $browser->script(
-        "!!document.getElementById('otp')"
+        "!!document.getElementById('otp')",
     );
 
     if ($isInertia) {

--- a/browser_tests/tests/Pest.php
+++ b/browser_tests/tests/Pest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Pest\Browser\Api\AwaitableWebpage;
 use Pest\Browser\Api\Webpage;
+use Tests\TestCase;
 
 /*
 |--------------------------------------------------------------------------
@@ -14,8 +16,8 @@ use Pest\Browser\Api\Webpage;
 |
 */
 
-pest()->extend(Tests\TestCase::class)
-    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
     ->in('Browser');
 
 /*

--- a/browser_tests/tests/Pest.php
+++ b/browser_tests/tests/Pest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Pest\Browser\Api\AwaitableWebpage;
-use Pest\Browser\Api\Webpage;
 use Tests\TestCase;
 
 /*
@@ -45,14 +43,3 @@ expect()->extend('toBeOne', function () {
 | global functions to help you to reduce the number of lines of code in your test files.
 |
 */
-
-function visitPasswordProtectedPage(string $route, string $password = 'password'): AwaitableWebpage|Webpage
-{
-    $destinationUrl = route($route);
-
-    return visit($destinationUrl)
-        ->assertSee('Confirm password')
-        ->fill('password', $password)
-        ->press('@confirm-password-button')
-        ->assertUrlIs($destinationUrl);
-}

--- a/orchestrator/app/Console/Commands/BuildCommand.php
+++ b/orchestrator/app/Console/Commands/BuildCommand.php
@@ -275,6 +275,18 @@ class BuildCommand extends Command
     }
 
     /**
+     * Load the shared kit manifest from the JSON file.
+     *
+     * @return array{placeholderSearchPaths: string[], componentsRelocations: array<int, array{from: string, to: string, directory?: bool}>, componentsDeleteDirectory: string, kitFolderMap: array<string, string[]>}
+     */
+    protected function getManifest(): array
+    {
+        $jsonPath = base_path('scripts/kit-manifest.json');
+
+        return json_decode(File::get($jsonPath), true);
+    }
+
+    /**
      * Get the UI components configuration from the JSON file.
      */
     protected function getUiComponents(): array
@@ -290,13 +302,12 @@ class BuildCommand extends Command
     protected function replacePlaceholders(string $buildPath, string $kit): void
     {
         $uiComponents = $this->getUiComponents();
+        $manifest = $this->getManifest();
 
-        $searchPaths = [
-            $buildPath.'/app/Http/Controllers',
-            $buildPath.'/app/Providers',
-            $buildPath.'/routes',
-            $buildPath.'/tests',
-        ];
+        $searchPaths = array_map(
+            fn (string $relativePath): string => $buildPath.'/'.$relativePath,
+            $manifest['placeholderSearchPaths'],
+        );
 
         foreach ($searchPaths as $searchPath) {
             if (! File::exists($searchPath)) {
@@ -416,29 +427,34 @@ class BuildCommand extends Command
     }
 
     /**
-     * Relocate auth views for the Components variant.
+     * Relocate auth views for the Components variant using rules from the shared manifest.
      */
     protected function relocateAuthViewsForComponents(string $buildPath): void
     {
-        $pagesPath = $buildPath.'/resources/views/pages';
-        $settingsLayoutSource = $pagesPath.'/settings/layout.blade.php';
-        $settingsLayoutDest = $buildPath.'/resources/views/components/settings/layout.blade.php';
+        $manifest = $this->getManifest();
 
-        if (File::exists($settingsLayoutSource)) {
-            File::ensureDirectoryExists(dirname($settingsLayoutDest));
-            File::copy($settingsLayoutSource, $settingsLayoutDest);
+        foreach ($manifest['componentsRelocations'] as $rule) {
+            $source = $buildPath.'/'.$rule['from'];
+            $dest = $buildPath.'/'.$rule['to'];
+            $isDirectory = $rule['directory'] ?? false;
+
+            if (! File::exists(rtrim($source, '/'))) {
+                continue;
+            }
+
+            File::ensureDirectoryExists($isDirectory ? $dest : dirname($dest));
+
+            if ($isDirectory) {
+                File::copyDirectory(rtrim($source, '/'), rtrim($dest, '/'));
+            } else {
+                File::copy($source, $dest);
+            }
         }
 
-        $authSource = $pagesPath.'/auth';
-        $authDest = $buildPath.'/resources/views/livewire/auth';
+        $deleteDir = $buildPath.'/'.$manifest['componentsDeleteDirectory'];
 
-        if (File::exists($authSource)) {
-            File::ensureDirectoryExists($authDest);
-            File::copyDirectory($authSource, $authDest);
-        }
-
-        if (File::exists($pagesPath)) {
-            File::deleteDirectory($pagesPath);
+        if (File::exists($deleteDir)) {
+            File::deleteDirectory($deleteDir);
         }
     }
 

--- a/orchestrator/composer.json
+++ b/orchestrator/composer.json
@@ -18,7 +18,7 @@
         "fakerphp/faker": "^1.23",
         "laravel/boost": "^1.8",
         "laravel/pail": "^1.2.2",
-        "laravel/pint": "^1.24",
+        "laravel/pint": "^1.28",
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",

--- a/orchestrator/composer.json
+++ b/orchestrator/composer.json
@@ -57,9 +57,12 @@
         "lint": [
             "pint --parallel"
         ],
+        "kits:pint": [
+            "pint --parallel ../kits",
+            "pint --parallel ../browser_tests"
+        ],
         "kits:lint": [
             "Composer\\Config::disableProcessTimeout",
-            "pint --parallel ../kits",
             "node scripts/lint-kits.js"
         ],
         "kits:check": [

--- a/orchestrator/composer.lock
+++ b/orchestrator/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fdd7796cdcac72de5960d34abbf0abb9",
+    "content-hash": "9265029747b1e245842af39b969eeaf1",
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.14.1",
+            "version": "0.14.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "f05858549e5f9d7bb45875a75583240a38a281d0"
+                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/f05858549e5f9d7bb45875a75583240a38a281d0",
-                "reference": "f05858549e5f9d7bb45875a75583240a38a281d0",
+                "url": "https://api.github.com/repos/brick/math/zipball/63422359a44b7f06cae63c3b429b59e8efcc0629",
+                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.14.1"
+                "source": "https://github.com/brick/math/tree/0.14.8"
             },
             "funding": [
                 {
@@ -64,7 +64,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-24T14:40:29+00:00"
+            "time": "2026-02-10T14:33:43+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -852,16 +852,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
                 "shasum": ""
             },
             "require": {
@@ -877,6 +877,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
                 "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
@@ -948,7 +949,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
             },
             "funding": [
                 {
@@ -964,7 +965,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-03-10T16:41:02+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -1054,16 +1055,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.47.0",
+            "version": "v12.54.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "ab8114c2e78f32e64eb238fc4b495bea3f8b80ec"
+                "reference": "325497463e7599cd14224c422c6e5dd2fe832868"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/ab8114c2e78f32e64eb238fc4b495bea3f8b80ec",
-                "reference": "ab8114c2e78f32e64eb238fc4b495bea3f8b80ec",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/325497463e7599cd14224c422c6e5dd2fe832868",
+                "reference": "325497463e7599cd14224c422c6e5dd2fe832868",
                 "shasum": ""
             },
             "require": {
@@ -1084,7 +1085,7 @@
                 "guzzlehttp/uri-template": "^1.0",
                 "laravel/prompts": "^0.3.0",
                 "laravel/serializable-closure": "^1.3|^2.0",
-                "league/commonmark": "^2.7",
+                "league/commonmark": "^2.8.1",
                 "league/flysystem": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
                 "league/uri": "^7.5.1",
@@ -1176,7 +1177,7 @@
                 "league/flysystem-sftp-v3": "^3.25.1",
                 "mockery/mockery": "^1.6.10",
                 "opis/json-schema": "^2.4.1",
-                "orchestra/testbench-core": "^10.8.1",
+                "orchestra/testbench-core": "^10.9.0",
                 "pda/pheanstalk": "^5.0.6|^7.0.0",
                 "php-http/discovery": "^1.15",
                 "phpstan/phpstan": "^2.0",
@@ -1272,34 +1273,34 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-01-13T15:29:06+00:00"
+            "time": "2026-03-10T20:25:56+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.10",
+            "version": "v0.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "360ba095ef9f51017473505191fbd4ab73e1cab3"
+                "reference": "9f0e371244eedfe2ebeaa72c79c54bb5df6e0176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/360ba095ef9f51017473505191fbd4ab73e1cab3",
-                "reference": "360ba095ef9f51017473505191fbd4ab73e1cab3",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/9f0e371244eedfe2ebeaa72c79c54bb5df6e0176",
+                "reference": "9f0e371244eedfe2ebeaa72c79c54bb5df6e0176",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "ext-mbstring": "*",
                 "php": "^8.1",
-                "symfony/console": "^6.2|^7.0"
+                "symfony/console": "^6.2|^7.0|^8.0"
             },
             "conflict": {
                 "illuminate/console": ">=10.17.0 <10.25.0",
                 "laravel/framework": ">=10.17.0 <10.25.0"
             },
             "require-dev": {
-                "illuminate/collections": "^10.0|^11.0|^12.0",
+                "illuminate/collections": "^10.0|^11.0|^12.0|^13.0",
                 "mockery/mockery": "^1.5",
                 "pestphp/pest": "^2.3|^3.4|^4.0",
                 "phpstan/phpstan": "^1.12.28",
@@ -1329,33 +1330,33 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.10"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.14"
             },
-            "time": "2026-01-13T20:29:29+00:00"
+            "time": "2026-03-01T09:02:38+00:00"
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v2.0.8",
+            "version": "v2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "7581a4407012f5f53365e11bafc520fd7f36bc9b"
+                "reference": "870fc81d2f879903dfc5b60bf8a0f94a1609e669"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/7581a4407012f5f53365e11bafc520fd7f36bc9b",
-                "reference": "7581a4407012f5f53365e11bafc520fd7f36bc9b",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/870fc81d2f879903dfc5b60bf8a0f94a1609e669",
+                "reference": "870fc81d2f879903dfc5b60bf8a0f94a1609e669",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.1"
             },
             "require-dev": {
-                "illuminate/support": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
                 "nesbot/carbon": "^2.67|^3.0",
                 "pestphp/pest": "^2.36|^3.0|^4.0",
                 "phpstan/phpstan": "^2.0",
-                "symfony/var-dumper": "^6.2.0|^7.0.0"
+                "symfony/var-dumper": "^6.2.0|^7.0.0|^8.0.0"
             },
             "type": "library",
             "extra": {
@@ -1392,20 +1393,20 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2026-01-08T16:22:46+00:00"
+            "time": "2026-02-20T19:59:49+00:00"
         },
         {
             "name": "laravel/tinker",
-            "version": "v2.11.0",
+            "version": "v2.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/tinker.git",
-                "reference": "3d34b97c9a1747a81a3fde90482c092bd8b66468"
+                "reference": "c9f80cc835649b5c1842898fb043f8cc098dd741"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/tinker/zipball/3d34b97c9a1747a81a3fde90482c092bd8b66468",
-                "reference": "3d34b97c9a1747a81a3fde90482c092bd8b66468",
+                "url": "https://api.github.com/repos/laravel/tinker/zipball/c9f80cc835649b5c1842898fb043f8cc098dd741",
+                "reference": "c9f80cc835649b5c1842898fb043f8cc098dd741",
                 "shasum": ""
             },
             "require": {
@@ -1456,22 +1457,22 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/tinker/issues",
-                "source": "https://github.com/laravel/tinker/tree/v2.11.0"
+                "source": "https://github.com/laravel/tinker/tree/v2.11.1"
             },
-            "time": "2025-12-19T19:16:45+00:00"
+            "time": "2026-02-06T14:12:35+00:00"
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb"
+                "reference": "84b1ca48347efdbe775426f108622a42735a6579"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/84b1ca48347efdbe775426f108622a42735a6579",
+                "reference": "84b1ca48347efdbe775426f108622a42735a6579",
                 "shasum": ""
             },
             "require": {
@@ -1496,9 +1497,9 @@
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
-                "symfony/process": "^5.4 | ^6.0 | ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
@@ -1565,7 +1566,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-26T21:48:24+00:00"
+            "time": "2026-03-05T21:37:03+00:00"
         },
         {
             "name": "league/config",
@@ -1651,16 +1652,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.30.2",
+            "version": "3.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "5966a8ba23e62bdb518dd9e0e665c2dbd4b5b277"
+                "reference": "254b1595b16b22dbddaaef9ed6ca9fdac4956725"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/5966a8ba23e62bdb518dd9e0e665c2dbd4b5b277",
-                "reference": "5966a8ba23e62bdb518dd9e0e665c2dbd4b5b277",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/254b1595b16b22dbddaaef9ed6ca9fdac4956725",
+                "reference": "254b1595b16b22dbddaaef9ed6ca9fdac4956725",
                 "shasum": ""
             },
             "require": {
@@ -1728,22 +1729,22 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.30.2"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.32.0"
             },
-            "time": "2025-11-10T17:13:11+00:00"
+            "time": "2026-02-25T17:01:41+00:00"
         },
         {
             "name": "league/flysystem-local",
-            "version": "3.30.2",
+            "version": "3.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-local.git",
-                "reference": "ab4f9d0d672f601b102936aa728801dd1a11968d"
+                "reference": "2f669db18a4c20c755c2bb7d3a7b0b2340488079"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/ab4f9d0d672f601b102936aa728801dd1a11968d",
-                "reference": "ab4f9d0d672f601b102936aa728801dd1a11968d",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/2f669db18a4c20c755c2bb7d3a7b0b2340488079",
+                "reference": "2f669db18a4c20c755c2bb7d3a7b0b2340488079",
                 "shasum": ""
             },
             "require": {
@@ -1777,9 +1778,9 @@
                 "local"
             ],
             "support": {
-                "source": "https://github.com/thephpleague/flysystem-local/tree/3.30.2"
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.31.0"
             },
-            "time": "2025-11-10T11:23:37+00:00"
+            "time": "2026-01-23T15:30:45+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -1839,20 +1840,20 @@
         },
         {
             "name": "league/uri",
-            "version": "7.7.0",
+            "version": "7.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "8d587cddee53490f9b82bf203d3a9aa7ea4f9807"
+                "reference": "4436c6ec8d458e4244448b069cc572d088230b76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/8d587cddee53490f9b82bf203d3a9aa7ea4f9807",
-                "reference": "8d587cddee53490f9b82bf203d3a9aa7ea4f9807",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/4436c6ec8d458e4244448b069cc572d088230b76",
+                "reference": "4436c6ec8d458e4244448b069cc572d088230b76",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.7",
+                "league/uri-interfaces": "^7.8",
                 "php": "^8.1",
                 "psr/http-factory": "^1"
             },
@@ -1866,11 +1867,11 @@
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
                 "ext-uri": "to use the PHP native URI class",
-                "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
-                "league/uri-components": "Needed to easily manipulate URI objects components",
-                "league/uri-polyfill": "Needed to backport the PHP URI extension for older versions of PHP",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
                 "php-64bit": "to improve IPV4 host parsing",
-                "rowbot/url": "to handle WHATWG URL",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -1925,7 +1926,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.7.0"
+                "source": "https://github.com/thephpleague/uri/tree/7.8.0"
             },
             "funding": [
                 {
@@ -1933,20 +1934,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-07T16:02:06+00:00"
+            "time": "2026-01-14T17:24:56+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.7.0",
+            "version": "7.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "62ccc1a0435e1c54e10ee6022df28d6c04c2946c"
+                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/62ccc1a0435e1c54e10ee6022df28d6c04c2946c",
-                "reference": "62ccc1a0435e1c54e10ee6022df28d6c04c2946c",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
+                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
                 "shasum": ""
             },
             "require": {
@@ -1959,7 +1960,7 @@
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
                 "php-64bit": "to improve IPV4 host parsing",
-                "rowbot/url": "to handle WHATWG URL",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -2009,7 +2010,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.7.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.0"
             },
             "funding": [
                 {
@@ -2017,7 +2018,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-07T16:03:21+00:00"
+            "time": "2026-01-15T06:54:53+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -2124,16 +2125,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.0",
+            "version": "3.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "bdb375400dcd162624531666db4799b36b64e4a1"
+                "reference": "f438fcc98f92babee98381d399c65336f3a3827f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/bdb375400dcd162624531666db4799b36b64e4a1",
-                "reference": "bdb375400dcd162624531666db4799b36b64e4a1",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/f438fcc98f92babee98381d399c65336f3a3827f",
+                "reference": "f438fcc98f92babee98381d399c65336f3a3827f",
                 "shasum": ""
             },
             "require": {
@@ -2157,7 +2158,7 @@
                 "phpstan/extension-installer": "^1.4.3",
                 "phpstan/phpstan": "^2.1.22",
                 "phpunit/phpunit": "^10.5.53",
-                "squizlabs/php_codesniffer": "^3.13.4"
+                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0.0"
             },
             "bin": [
                 "bin/carbon"
@@ -2200,14 +2201,14 @@
                 }
             ],
             "description": "An API extension for DateTime that supports 281 different languages.",
-            "homepage": "https://carbon.nesbot.com",
+            "homepage": "https://carbonphp.github.io/carbon/",
             "keywords": [
                 "date",
                 "datetime",
                 "time"
             ],
             "support": {
-                "docs": "https://carbon.nesbot.com/docs",
+                "docs": "https://carbonphp.github.io/carbon/guide/getting-started/introduction.html",
                 "issues": "https://github.com/CarbonPHP/carbon/issues",
                 "source": "https://github.com/CarbonPHP/carbon"
             },
@@ -2225,20 +2226,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-02T21:04:28+00:00"
+            "time": "2026-01-29T09:26:29+00:00"
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.3",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004"
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/2befc2f42d7c715fd9d95efc31b1081e5d765004",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
                 "shasum": ""
             },
             "require": {
@@ -2246,8 +2247,10 @@
                 "php": "8.1 - 8.5"
             },
             "require-dev": {
-                "nette/tester": "^2.5.2",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -2288,22 +2291,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.3"
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
             },
-            "time": "2025-10-30T22:57:59+00:00"
+            "time": "2026-02-23T03:47:12+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.1",
+            "version": "v4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72"
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/c99059c0315591f1a0db7ad6002000288ab8dc72",
-                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72",
+                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
                 "shasum": ""
             },
             "require": {
@@ -2315,8 +2318,10 @@
             },
             "require-dev": {
                 "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.5",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "tracy/tracy": "^2.9"
             },
             "suggest": {
@@ -2377,9 +2382,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.1"
+                "source": "https://github.com/nette/utils/tree/v4.1.3"
             },
-            "time": "2025-12-22T12:14:32+00:00"
+            "time": "2026-02-13T03:05:33+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2441,31 +2446,31 @@
         },
         {
             "name": "nunomaduro/termwind",
-            "version": "v2.3.3",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/termwind.git",
-                "reference": "6fb2a640ff502caace8e05fd7be3b503a7e1c017"
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/6fb2a640ff502caace8e05fd7be3b503a7e1c017",
-                "reference": "6fb2a640ff502caace8e05fd7be3b503a7e1c017",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/712a31b768f5daea284c2169a7d227031001b9a8",
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^8.2",
-                "symfony/console": "^7.3.6"
+                "symfony/console": "^7.4.4 || ^8.0.4"
             },
             "require-dev": {
-                "illuminate/console": "^11.46.1",
-                "laravel/pint": "^1.25.1",
+                "illuminate/console": "^11.47.0",
+                "laravel/pint": "^1.27.1",
                 "mockery/mockery": "^1.6.12",
-                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.1.3",
+                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.3.2",
                 "phpstan/phpstan": "^1.12.32",
                 "phpstan/phpstan-strict-rules": "^1.6.2",
-                "symfony/var-dumper": "^7.3.5",
+                "symfony/var-dumper": "^7.3.5 || ^8.0.4",
                 "thecodingmachine/phpstan-strict-rules": "^1.0.0"
             },
             "type": "library",
@@ -2497,7 +2502,7 @@
                     "email": "enunomaduro@gmail.com"
                 }
             ],
-            "description": "Its like Tailwind CSS, but for the console.",
+            "description": "It's like Tailwind CSS, but for the console.",
             "keywords": [
                 "cli",
                 "console",
@@ -2508,7 +2513,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/termwind/issues",
-                "source": "https://github.com/nunomaduro/termwind/tree/v2.3.3"
+                "source": "https://github.com/nunomaduro/termwind/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -2524,7 +2529,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-20T02:34:59+00:00"
+            "time": "2026-02-16T23:10:27+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -3015,16 +3020,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.18",
+            "version": "v0.12.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "ddff0ac01beddc251786fe70367cd8bbdb258196"
+                "reference": "4821fab5b7cd8c49a673a9fd5754dc9162bb9e97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/ddff0ac01beddc251786fe70367cd8bbdb258196",
-                "reference": "ddff0ac01beddc251786fe70367cd8bbdb258196",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4821fab5b7cd8c49a673a9fd5754dc9162bb9e97",
+                "reference": "4821fab5b7cd8c49a673a9fd5754dc9162bb9e97",
                 "shasum": ""
             },
             "require": {
@@ -3088,9 +3093,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.18"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.21"
             },
-            "time": "2025-12-17T14:35:46+00:00"
+            "time": "2026-03-06T21:21:28+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -3369,16 +3374,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.3",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "732a9ca6cd9dfd940c639062d5edbde2f6727fb6"
+                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/732a9ca6cd9dfd940c639062d5edbde2f6727fb6",
-                "reference": "732a9ca6cd9dfd940c639062d5edbde2f6727fb6",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e1e6770440fb9c9b0cf725f81d1361ad1835329d",
+                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d",
                 "shasum": ""
             },
             "require": {
@@ -3443,7 +3448,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.3"
+                "source": "https://github.com/symfony/console/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -3463,20 +3468,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-23T14:50:43+00:00"
+            "time": "2026-03-06T14:06:20+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v8.0.0",
+            "version": "v8.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "6225bd458c53ecdee056214cb4a2ffaf58bd592b"
+                "reference": "2a178bf80f05dbbe469a337730eba79d61315262"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/6225bd458c53ecdee056214cb4a2ffaf58bd592b",
-                "reference": "6225bd458c53ecdee056214cb4a2ffaf58bd592b",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/2a178bf80f05dbbe469a337730eba79d61315262",
+                "reference": "2a178bf80f05dbbe469a337730eba79d61315262",
                 "shasum": ""
             },
             "require": {
@@ -3512,7 +3517,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v8.0.0"
+                "source": "https://github.com/symfony/css-selector/tree/v8.0.6"
             },
             "funding": [
                 {
@@ -3532,7 +3537,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-30T14:17:19+00:00"
+            "time": "2026-02-17T13:07:04+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3603,16 +3608,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.4.0",
+            "version": "v7.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "48be2b0653594eea32dcef130cca1c811dcf25c2"
+                "reference": "8da531f364ddfee53e36092a7eebbbd0b775f6b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/48be2b0653594eea32dcef130cca1c811dcf25c2",
-                "reference": "48be2b0653594eea32dcef130cca1c811dcf25c2",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8da531f364ddfee53e36092a7eebbbd0b775f6b8",
+                "reference": "8da531f364ddfee53e36092a7eebbbd0b775f6b8",
                 "shasum": ""
             },
             "require": {
@@ -3661,7 +3666,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.4.0"
+                "source": "https://github.com/symfony/error-handler/tree/v7.4.4"
             },
             "funding": [
                 {
@@ -3681,20 +3686,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-05T14:29:59+00:00"
+            "time": "2026-01-20T16:42:42+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.0.0",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "573f95783a2ec6e38752979db139f09fec033f03"
+                "reference": "99301401da182b6cfaa4700dbe9987bb75474b47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/573f95783a2ec6e38752979db139f09fec033f03",
-                "reference": "573f95783a2ec6e38752979db139f09fec033f03",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/99301401da182b6cfaa4700dbe9987bb75474b47",
+                "reference": "99301401da182b6cfaa4700dbe9987bb75474b47",
                 "shasum": ""
             },
             "require": {
@@ -3746,7 +3751,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -3766,7 +3771,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-30T14:17:19+00:00"
+            "time": "2026-01-05T11:45:55+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -3846,16 +3851,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.3",
+            "version": "v7.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "fffe05569336549b20a1be64250b40516d6e8d06"
+                "reference": "8655bf1076b7a3a346cb11413ffdabff50c7ffcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/fffe05569336549b20a1be64250b40516d6e8d06",
-                "reference": "fffe05569336549b20a1be64250b40516d6e8d06",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8655bf1076b7a3a346cb11413ffdabff50c7ffcf",
+                "reference": "8655bf1076b7a3a346cb11413ffdabff50c7ffcf",
                 "shasum": ""
             },
             "require": {
@@ -3890,7 +3895,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.3"
+                "source": "https://github.com/symfony/finder/tree/v7.4.6"
             },
             "funding": [
                 {
@@ -3910,20 +3915,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-23T14:50:43+00:00"
+            "time": "2026-01-29T09:40:50+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.3",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "a70c745d4cea48dbd609f4075e5f5cbce453bd52"
+                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/a70c745d4cea48dbd609f4075e5f5cbce453bd52",
-                "reference": "a70c745d4cea48dbd609f4075e5f5cbce453bd52",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
+                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
                 "shasum": ""
             },
             "require": {
@@ -3972,7 +3977,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.3"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -3992,20 +3997,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-23T14:23:49+00:00"
+            "time": "2026-03-06T13:15:18+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.3",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "885211d4bed3f857b8c964011923528a55702aa5"
+                "reference": "3b3fcf386c809be990c922e10e4c620d6367cab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/885211d4bed3f857b8c964011923528a55702aa5",
-                "reference": "885211d4bed3f857b8c964011923528a55702aa5",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/3b3fcf386c809be990c922e10e4c620d6367cab1",
+                "reference": "3b3fcf386c809be990c922e10e4c620d6367cab1",
                 "shasum": ""
             },
             "require": {
@@ -4047,7 +4052,7 @@
                 "symfony/config": "^6.4|^7.0|^8.0",
                 "symfony/console": "^6.4|^7.0|^8.0",
                 "symfony/css-selector": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4.1|^7.0.1|^8.0",
                 "symfony/dom-crawler": "^6.4|^7.0|^8.0",
                 "symfony/expression-language": "^6.4|^7.0|^8.0",
                 "symfony/finder": "^6.4|^7.0|^8.0",
@@ -4091,7 +4096,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.3"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -4111,20 +4116,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-31T08:43:57+00:00"
+            "time": "2026-03-06T16:33:18+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.3",
+            "version": "v7.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "e472d35e230108231ccb7f51eb6b2100cac02ee4"
+                "reference": "b02726f39a20bc65e30364f5c750c4ddbf1f58e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/e472d35e230108231ccb7f51eb6b2100cac02ee4",
-                "reference": "e472d35e230108231ccb7f51eb6b2100cac02ee4",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/b02726f39a20bc65e30364f5c750c4ddbf1f58e9",
+                "reference": "b02726f39a20bc65e30364f5c750c4ddbf1f58e9",
                 "shasum": ""
             },
             "require": {
@@ -4175,7 +4180,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.3"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.6"
             },
             "funding": [
                 {
@@ -4195,20 +4200,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-16T08:02:06+00:00"
+            "time": "2026-02-25T16:50:00+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.0",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "bdb02729471be5d047a3ac4a69068748f1a6be7a"
+                "reference": "da5ab4fde3f6c88ab06e96185b9922f48b677cd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/bdb02729471be5d047a3ac4a69068748f1a6be7a",
-                "reference": "bdb02729471be5d047a3ac4a69068748f1a6be7a",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/da5ab4fde3f6c88ab06e96185b9922f48b677cd1",
+                "reference": "da5ab4fde3f6c88ab06e96185b9922f48b677cd1",
                 "shasum": ""
             },
             "require": {
@@ -4219,15 +4224,15 @@
             },
             "conflict": {
                 "egulias/email-validator": "~3.0.0",
-                "phpdocumentor/reflection-docblock": "<3.2.2",
-                "phpdocumentor/type-resolver": "<1.4.0",
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
                 "symfony/mailer": "<6.4",
                 "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1|^4",
                 "league/html-to-markdown": "^5.0",
-                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
                 "symfony/dependency-injection": "^6.4|^7.0|^8.0",
                 "symfony/process": "^6.4|^7.0|^8.0",
                 "symfony/property-access": "^6.4|^7.0|^8.0",
@@ -4264,7 +4269,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.0"
+                "source": "https://github.com/symfony/mime/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -4284,7 +4289,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-16T10:14:42+00:00"
+            "time": "2026-03-05T15:24:09+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -5117,16 +5122,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.3",
+            "version": "v7.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "2f8e1a6cdf590ca63715da4d3a7a3327404a523f"
+                "reference": "608476f4604102976d687c483ac63a79ba18cc97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/2f8e1a6cdf590ca63715da4d3a7a3327404a523f",
-                "reference": "2f8e1a6cdf590ca63715da4d3a7a3327404a523f",
+                "url": "https://api.github.com/repos/symfony/process/zipball/608476f4604102976d687c483ac63a79ba18cc97",
+                "reference": "608476f4604102976d687c483ac63a79ba18cc97",
                 "shasum": ""
             },
             "require": {
@@ -5158,7 +5163,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.3"
+                "source": "https://github.com/symfony/process/tree/v7.4.5"
             },
             "funding": [
                 {
@@ -5178,20 +5183,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-19T10:00:43+00:00"
+            "time": "2026-01-26T15:07:59+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.3",
+            "version": "v7.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "5d3fd7adf8896c2fdb54e2f0f35b1bcbd9e45090"
+                "reference": "238d749c56b804b31a9bf3e26519d93b65a60938"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/5d3fd7adf8896c2fdb54e2f0f35b1bcbd9e45090",
-                "reference": "5d3fd7adf8896c2fdb54e2f0f35b1bcbd9e45090",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/238d749c56b804b31a9bf3e26519d93b65a60938",
+                "reference": "238d749c56b804b31a9bf3e26519d93b65a60938",
                 "shasum": ""
             },
             "require": {
@@ -5243,7 +5248,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.3"
+                "source": "https://github.com/symfony/routing/tree/v7.4.6"
             },
             "funding": [
                 {
@@ -5263,7 +5268,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-19T10:00:43+00:00"
+            "time": "2026-02-25T16:50:00+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -5354,16 +5359,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.1",
+            "version": "v8.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ba65a969ac918ce0cc3edfac6cdde847eba231dc"
+                "reference": "6c9e1108041b5dce21a9a4984b531c4923aa9ec4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ba65a969ac918ce0cc3edfac6cdde847eba231dc",
-                "reference": "ba65a969ac918ce0cc3edfac6cdde847eba231dc",
+                "url": "https://api.github.com/repos/symfony/string/zipball/6c9e1108041b5dce21a9a4984b531c4923aa9ec4",
+                "reference": "6c9e1108041b5dce21a9a4984b531c4923aa9ec4",
                 "shasum": ""
             },
             "require": {
@@ -5420,7 +5425,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.1"
+                "source": "https://github.com/symfony/string/tree/v8.0.6"
             },
             "funding": [
                 {
@@ -5440,20 +5445,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-01T09:13:36+00:00"
+            "time": "2026-02-09T10:14:57+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v8.0.3",
+            "version": "v8.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "60a8f11f0e15c48f2cc47c4da53873bb5b62135d"
+                "reference": "13ff19bcf2bea492d3c2fbeaa194dd6f4599ce1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/60a8f11f0e15c48f2cc47c4da53873bb5b62135d",
-                "reference": "60a8f11f0e15c48f2cc47c4da53873bb5b62135d",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/13ff19bcf2bea492d3c2fbeaa194dd6f4599ce1b",
+                "reference": "13ff19bcf2bea492d3c2fbeaa194dd6f4599ce1b",
                 "shasum": ""
             },
             "require": {
@@ -5513,7 +5518,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.0.3"
+                "source": "https://github.com/symfony/translation/tree/v8.0.6"
             },
             "funding": [
                 {
@@ -5533,7 +5538,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-21T10:59:45+00:00"
+            "time": "2026-02-17T13:07:04+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -5619,16 +5624,16 @@
         },
         {
             "name": "symfony/uid",
-            "version": "v7.4.0",
+            "version": "v7.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "2498e9f81b7baa206f44de583f2f48350b90142c"
+                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/2498e9f81b7baa206f44de583f2f48350b90142c",
-                "reference": "2498e9f81b7baa206f44de583f2f48350b90142c",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/7719ce8aba76be93dfe249192f1fbfa52c588e36",
+                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36",
                 "shasum": ""
             },
             "require": {
@@ -5673,7 +5678,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.4.0"
+                "source": "https://github.com/symfony/uid/tree/v7.4.4"
             },
             "funding": [
                 {
@@ -5693,20 +5698,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-25T11:02:55+00:00"
+            "time": "2026-01-03T23:30:35+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.3",
+            "version": "v7.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "7e99bebcb3f90d8721890f2963463280848cba92"
+                "reference": "045321c440ac18347b136c63d2e9bf28a2dc0291"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/7e99bebcb3f90d8721890f2963463280848cba92",
-                "reference": "7e99bebcb3f90d8721890f2963463280848cba92",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/045321c440ac18347b136c63d2e9bf28a2dc0291",
+                "reference": "045321c440ac18347b136c63d2e9bf28a2dc0291",
                 "shasum": ""
             },
             "require": {
@@ -5760,7 +5765,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.3"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.6"
             },
             "funding": [
                 {
@@ -5780,7 +5785,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-18T07:04:31+00:00"
+            "time": "2026-02-15T10:53:20+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -5999,16 +6004,16 @@
     "packages-dev": [
         {
             "name": "brianium/paratest",
-            "version": "v7.16.1",
+            "version": "v7.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paratestphp/paratest.git",
-                "reference": "f0fdfd8e654e0d38bc2ba756a6cabe7be287390b"
+                "reference": "7c6c29af7c4b406b49ce0c6b0a3a81d3684474e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/f0fdfd8e654e0d38bc2ba756a6cabe7be287390b",
-                "reference": "f0fdfd8e654e0d38bc2ba756a6cabe7be287390b",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/7c6c29af7c4b406b49ce0c6b0a3a81d3684474e6",
+                "reference": "7c6c29af7c4b406b49ce0c6b0a3a81d3684474e6",
                 "shasum": ""
             },
             "require": {
@@ -6019,24 +6024,24 @@
                 "fidry/cpu-core-counter": "^1.3.0",
                 "jean85/pretty-package-versions": "^2.1.1",
                 "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-                "phpunit/php-code-coverage": "^12.5.2",
-                "phpunit/php-file-iterator": "^6",
-                "phpunit/php-timer": "^8",
-                "phpunit/phpunit": "^12.5.4",
-                "sebastian/environment": "^8.0.3",
-                "symfony/console": "^7.3.4 || ^8.0.0",
-                "symfony/process": "^7.3.4 || ^8.0.0"
+                "phpunit/php-code-coverage": "^12.5.3 || ^13.0.1",
+                "phpunit/php-file-iterator": "^6.0.1 || ^7",
+                "phpunit/php-timer": "^8 || ^9",
+                "phpunit/phpunit": "^12.5.9 || ^13",
+                "sebastian/environment": "^8.0.3 || ^9",
+                "symfony/console": "^7.4.4 || ^8.0.4",
+                "symfony/process": "^7.4.5 || ^8.0.5"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^14.0.0",
                 "ext-pcntl": "*",
                 "ext-pcov": "*",
                 "ext-posix": "*",
-                "phpstan/phpstan": "^2.1.33",
+                "phpstan/phpstan": "^2.1.38",
                 "phpstan/phpstan-deprecation-rules": "^2.0.3",
-                "phpstan/phpstan-phpunit": "^2.0.11",
-                "phpstan/phpstan-strict-rules": "^2.0.7",
-                "symfony/filesystem": "^7.3.2 || ^8.0.0"
+                "phpstan/phpstan-phpunit": "^2.0.12",
+                "phpstan/phpstan-strict-rules": "^2.0.8",
+                "symfony/filesystem": "^7.4.0 || ^8.0.1"
             },
             "bin": [
                 "bin/paratest",
@@ -6076,7 +6081,7 @@
             ],
             "support": {
                 "issues": "https://github.com/paratestphp/paratest/issues",
-                "source": "https://github.com/paratestphp/paratest/tree/v7.16.1"
+                "source": "https://github.com/paratestphp/paratest/tree/v7.19.0"
             },
             "funding": [
                 {
@@ -6088,33 +6093,33 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2026-01-08T07:23:06+00:00"
+            "time": "2026-02-06T10:53:26+00:00"
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=13"
+                "phpunit/phpunit": "<=7.5 || >=14"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^13",
-                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
@@ -6134,9 +6139,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
-            "time": "2025-04-07T20:06:18+00:00"
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "fakerphp/faker",
@@ -6446,16 +6451,16 @@
         },
         {
             "name": "laravel/boost",
-            "version": "v1.8.10",
+            "version": "v1.8.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/boost.git",
-                "reference": "aad8b2a423b0a886c2ce7ee92abbfde69992ff32"
+                "reference": "485dd7c834bde865a8a174249fc6ffc56e79e63c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/boost/zipball/aad8b2a423b0a886c2ce7ee92abbfde69992ff32",
-                "reference": "aad8b2a423b0a886c2ce7ee92abbfde69992ff32",
+                "url": "https://api.github.com/repos/laravel/boost/zipball/485dd7c834bde865a8a174249fc6ffc56e79e63c",
+                "reference": "485dd7c834bde865a8a174249fc6ffc56e79e63c",
                 "shasum": ""
             },
             "require": {
@@ -6508,39 +6513,39 @@
                 "issues": "https://github.com/laravel/boost/issues",
                 "source": "https://github.com/laravel/boost"
             },
-            "time": "2026-01-14T14:51:16+00:00"
+            "time": "2026-02-20T07:28:22+00:00"
         },
         {
             "name": "laravel/mcp",
-            "version": "v0.5.2",
+            "version": "v0.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/mcp.git",
-                "reference": "b9bdd8d6f8b547c8733fe6826b1819341597ba3c"
+                "reference": "39e8da60eb7bce4737c5d868d35a3fe78938c129"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/mcp/zipball/b9bdd8d6f8b547c8733fe6826b1819341597ba3c",
-                "reference": "b9bdd8d6f8b547c8733fe6826b1819341597ba3c",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/39e8da60eb7bce4737c5d868d35a3fe78938c129",
+                "reference": "39e8da60eb7bce4737c5d868d35a3fe78938c129",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "illuminate/console": "^10.49.0|^11.45.3|^12.41.1",
-                "illuminate/container": "^10.49.0|^11.45.3|^12.41.1",
-                "illuminate/contracts": "^10.49.0|^11.45.3|^12.41.1",
-                "illuminate/http": "^10.49.0|^11.45.3|^12.41.1",
-                "illuminate/json-schema": "^12.41.1",
-                "illuminate/routing": "^10.49.0|^11.45.3|^12.41.1",
-                "illuminate/support": "^10.49.0|^11.45.3|^12.41.1",
-                "illuminate/validation": "^10.49.0|^11.45.3|^12.41.1",
-                "php": "^8.1"
+                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/container": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/http": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/json-schema": "^12.41.1|^13.0",
+                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/validation": "^11.45.3|^12.41.1|^13.0",
+                "php": "^8.2"
             },
             "require-dev": {
                 "laravel/pint": "^1.20",
-                "orchestra/testbench": "^8.36|^9.15|^10.8",
-                "pestphp/pest": "^2.36.0|^3.8.4|^4.1.0",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "pestphp/pest": "^3.8.5|^4.3.2",
                 "phpstan/phpstan": "^2.1.27",
                 "rector/rector": "^2.2.4"
             },
@@ -6581,41 +6586,42 @@
                 "issues": "https://github.com/laravel/mcp/issues",
                 "source": "https://github.com/laravel/mcp"
             },
-            "time": "2025-12-19T19:32:34+00:00"
+            "time": "2026-02-17T19:05:53+00:00"
         },
         {
             "name": "laravel/pail",
-            "version": "v1.2.4",
+            "version": "v1.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pail.git",
-                "reference": "49f92285ff5d6fc09816e976a004f8dec6a0ea30"
+                "reference": "aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pail/zipball/49f92285ff5d6fc09816e976a004f8dec6a0ea30",
-                "reference": "49f92285ff5d6fc09816e976a004f8dec6a0ea30",
+                "url": "https://api.github.com/repos/laravel/pail/zipball/aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf",
+                "reference": "aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "illuminate/console": "^10.24|^11.0|^12.0",
-                "illuminate/contracts": "^10.24|^11.0|^12.0",
-                "illuminate/log": "^10.24|^11.0|^12.0",
-                "illuminate/process": "^10.24|^11.0|^12.0",
-                "illuminate/support": "^10.24|^11.0|^12.0",
+                "illuminate/console": "^10.24|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.24|^11.0|^12.0|^13.0",
+                "illuminate/log": "^10.24|^11.0|^12.0|^13.0",
+                "illuminate/process": "^10.24|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.24|^11.0|^12.0|^13.0",
                 "nunomaduro/termwind": "^1.15|^2.0",
                 "php": "^8.2",
-                "symfony/console": "^6.0|^7.0"
+                "symfony/console": "^6.0|^7.0|^8.0"
             },
             "require-dev": {
-                "laravel/framework": "^10.24|^11.0|^12.0",
+                "laravel/framework": "^10.24|^11.0|^12.0|^13.0",
                 "laravel/pint": "^1.13",
-                "orchestra/testbench-core": "^8.13|^9.17|^10.8",
+                "orchestra/testbench-core": "^8.13|^9.17|^10.8|^11.0",
                 "pestphp/pest": "^2.20|^3.0|^4.0",
                 "pestphp/pest-plugin-type-coverage": "^2.3|^3.0|^4.0",
                 "phpstan/phpstan": "^1.12.27",
-                "symfony/var-dumper": "^6.3|^7.0"
+                "symfony/var-dumper": "^6.3|^7.0|^8.0",
+                "symfony/yaml": "^6.3|^7.0|^8.0"
             },
             "type": "library",
             "extra": {
@@ -6660,20 +6666,20 @@
                 "issues": "https://github.com/laravel/pail/issues",
                 "source": "https://github.com/laravel/pail"
             },
-            "time": "2025-11-20T16:29:35+00:00"
+            "time": "2026-02-09T13:44:54+00:00"
         },
         {
             "name": "laravel/pint",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "c67b4195b75491e4dfc6b00b1c78b68d86f54c90"
+                "reference": "1feae84bf9c1649d99ba8f7b8193bf0f09f04cc9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/c67b4195b75491e4dfc6b00b1c78b68d86f54c90",
-                "reference": "c67b4195b75491e4dfc6b00b1c78b68d86f54c90",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/1feae84bf9c1649d99ba8f7b8193bf0f09f04cc9",
+                "reference": "1feae84bf9c1649d99ba8f7b8193bf0f09f04cc9",
                 "shasum": ""
             },
             "require": {
@@ -6684,13 +6690,14 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.92.4",
-                "illuminate/view": "^12.44.0",
-                "larastan/larastan": "^3.8.1",
-                "laravel-zero/framework": "^12.0.4",
+                "friendsofphp/php-cs-fixer": "^3.94.2",
+                "illuminate/view": "^12.54.1",
+                "larastan/larastan": "^3.9.3",
+                "laravel-zero/framework": "^12.0.5",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^2.3.3",
-                "pestphp/pest": "^3.8.4"
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.5",
+                "shipfastlabs/agent-detector": "^1.0.2"
             },
             "bin": [
                 "builds/pint"
@@ -6727,7 +6734,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-01-05T16:49:17+00:00"
+            "time": "2026-03-10T20:37:18+00:00"
         },
         {
             "name": "laravel/roster",
@@ -6792,28 +6799,28 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.52.0",
+            "version": "v1.53.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "64ac7d8abb2dbcf2b76e61289451bae79066b0b3"
+                "reference": "e340eaa2bea9b99192570c48ed837155dbf24fbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/64ac7d8abb2dbcf2b76e61289451bae79066b0b3",
-                "reference": "64ac7d8abb2dbcf2b76e61289451bae79066b0b3",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/e340eaa2bea9b99192570c48ed837155dbf24fbb",
+                "reference": "e340eaa2bea9b99192570c48ed837155dbf24fbb",
                 "shasum": ""
             },
             "require": {
-                "illuminate/console": "^9.52.16|^10.0|^11.0|^12.0",
-                "illuminate/contracts": "^9.52.16|^10.0|^11.0|^12.0",
-                "illuminate/support": "^9.52.16|^10.0|^11.0|^12.0",
+                "illuminate/console": "^9.52.16|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^9.52.16|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^9.52.16|^10.0|^11.0|^12.0|^13.0",
                 "php": "^8.0",
-                "symfony/console": "^6.0|^7.0",
-                "symfony/yaml": "^6.0|^7.0"
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/yaml": "^6.0|^7.0|^8.0"
             },
             "require-dev": {
-                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
                 "phpstan/phpstan": "^2.0"
             },
             "bin": [
@@ -6851,7 +6858,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2026-01-01T02:46:03+00:00"
+            "time": "2026-02-06T12:16:02+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -6998,39 +7005,36 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.8.3",
+            "version": "v8.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4"
+                "reference": "a1ed3fa530fd60bc515f9303e8520fcb7d4bd935"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
-                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/a1ed3fa530fd60bc515f9303e8520fcb7d4bd935",
+                "reference": "a1ed3fa530fd60bc515f9303e8520fcb7d4bd935",
                 "shasum": ""
             },
             "require": {
-                "filp/whoops": "^2.18.1",
-                "nunomaduro/termwind": "^2.3.1",
+                "filp/whoops": "^2.18.4",
+                "nunomaduro/termwind": "^2.4.0",
                 "php": "^8.2.0",
-                "symfony/console": "^7.3.0"
+                "symfony/console": "^7.4.4 || ^8.0.4"
             },
             "conflict": {
-                "laravel/framework": "<11.44.2 || >=13.0.0",
-                "phpunit/phpunit": "<11.5.15 || >=13.0.0"
+                "laravel/framework": "<11.48.0 || >=14.0.0",
+                "phpunit/phpunit": "<11.5.50 || >=14.0.0"
             },
             "require-dev": {
-                "brianium/paratest": "^7.8.3",
-                "larastan/larastan": "^3.4.2",
-                "laravel/framework": "^11.44.2 || ^12.18",
-                "laravel/pint": "^1.22.1",
-                "laravel/sail": "^1.43.1",
-                "laravel/sanctum": "^4.1.1",
-                "laravel/tinker": "^2.10.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.4",
-                "pestphp/pest": "^3.8.2 || ^4.0.0",
-                "sebastian/environment": "^7.2.1 || ^8.0"
+                "brianium/paratest": "^7.8.5",
+                "larastan/larastan": "^3.9.2",
+                "laravel/framework": "^11.48.0 || ^12.52.0",
+                "laravel/pint": "^1.27.1",
+                "orchestra/testbench-core": "^9.12.0 || ^10.9.0",
+                "pestphp/pest": "^3.8.5 || ^4.4.1 || ^5.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.0.3 || ^9.0.0"
             },
             "type": "library",
             "extra": {
@@ -7093,45 +7097,45 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-11-20T02:55:25+00:00"
+            "time": "2026-02-17T17:33:08+00:00"
         },
         {
             "name": "pestphp/pest",
-            "version": "v4.3.1",
+            "version": "v4.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "bc57a84e77afd4544ff9643a6858f68d05aeab96"
+                "reference": "5d42e8fe3ae1d9fdf7c9f73ee88138fd30265701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/bc57a84e77afd4544ff9643a6858f68d05aeab96",
-                "reference": "bc57a84e77afd4544ff9643a6858f68d05aeab96",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/5d42e8fe3ae1d9fdf7c9f73ee88138fd30265701",
+                "reference": "5d42e8fe3ae1d9fdf7c9f73ee88138fd30265701",
                 "shasum": ""
             },
             "require": {
-                "brianium/paratest": "^7.16.0",
-                "nunomaduro/collision": "^8.8.3",
-                "nunomaduro/termwind": "^2.3.3",
+                "brianium/paratest": "^7.19.0",
+                "nunomaduro/collision": "^8.9.1",
+                "nunomaduro/termwind": "^2.4.0",
                 "pestphp/pest-plugin": "^4.0.0",
                 "pestphp/pest-plugin-arch": "^4.0.0",
                 "pestphp/pest-plugin-mutate": "^4.0.1",
                 "pestphp/pest-plugin-profanity": "^4.2.1",
                 "php": "^8.3.0",
-                "phpunit/phpunit": "^12.5.4",
-                "symfony/process": "^7.4.3|^8.0.0"
+                "phpunit/phpunit": "^12.5.12",
+                "symfony/process": "^7.4.5|^8.0.5"
             },
             "conflict": {
                 "filp/whoops": "<2.18.3",
-                "phpunit/phpunit": ">12.5.4",
+                "phpunit/phpunit": ">12.5.12",
                 "sebastian/exporter": "<7.0.0",
                 "webmozart/assert": "<1.11.0"
             },
             "require-dev": {
-                "pestphp/pest-dev-tools": "^4.0.0",
-                "pestphp/pest-plugin-browser": "^4.1.1",
+                "pestphp/pest-dev-tools": "^4.1.0",
+                "pestphp/pest-plugin-browser": "^4.3.0",
                 "pestphp/pest-plugin-type-coverage": "^4.0.3",
-                "psy/psysh": "^0.12.18"
+                "psy/psysh": "^0.12.21"
             },
             "bin": [
                 "bin/pest"
@@ -7197,7 +7201,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.3.1"
+                "source": "https://github.com/pestphp/pest/tree/v4.4.2"
             },
             "funding": [
                 {
@@ -7209,7 +7213,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-04T16:29:59+00:00"
+            "time": "2026-03-10T21:09:12+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -7353,27 +7357,27 @@
         },
         {
             "name": "pestphp/pest-plugin-laravel",
-            "version": "v4.0.0",
+            "version": "v4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest-plugin-laravel.git",
-                "reference": "e12a07046b826a40b1c8632fd7b80d6b8d7b628e"
+                "reference": "3057a36669ff11416cc0dc2b521b3aec58c488d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-laravel/zipball/e12a07046b826a40b1c8632fd7b80d6b8d7b628e",
-                "reference": "e12a07046b826a40b1c8632fd7b80d6b8d7b628e",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-laravel/zipball/3057a36669ff11416cc0dc2b521b3aec58c488d0",
+                "reference": "3057a36669ff11416cc0dc2b521b3aec58c488d0",
                 "shasum": ""
             },
             "require": {
-                "laravel/framework": "^11.45.2|^12.25.0",
-                "pestphp/pest": "^4.0.0",
+                "laravel/framework": "^11.45.2|^12.52.0|^13.0",
+                "pestphp/pest": "^4.4.1",
                 "php": "^8.3.0"
             },
             "require-dev": {
-                "laravel/dusk": "^8.3.3",
-                "orchestra/testbench": "^9.13.0|^10.5.0",
-                "pestphp/pest-dev-tools": "^4.0.0"
+                "laravel/dusk": "^8.3.6",
+                "orchestra/testbench": "^9.13.0|^10.9.0|^11.0",
+                "pestphp/pest-dev-tools": "^4.1.0"
             },
             "type": "library",
             "extra": {
@@ -7411,7 +7415,7 @@
                 "unit"
             ],
             "support": {
-                "source": "https://github.com/pestphp/pest-plugin-laravel/tree/v4.0.0"
+                "source": "https://github.com/pestphp/pest-plugin-laravel/tree/v4.1.0"
             },
             "funding": [
                 {
@@ -7423,7 +7427,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-20T12:46:37+00:00"
+            "time": "2026-02-21T00:29:45+00:00"
         },
         {
             "name": "pestphp/pest-plugin-mutate",
@@ -7730,16 +7734,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.6",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "5cee1d3dfc2d2aa6599834520911d246f656bcb8"
+                "reference": "897b5986ece6b4f9d8413fea345c7d49c757d6bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/5cee1d3dfc2d2aa6599834520911d246f656bcb8",
-                "reference": "5cee1d3dfc2d2aa6599834520911d246f656bcb8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/897b5986ece6b4f9d8413fea345c7d49c757d6bf",
+                "reference": "897b5986ece6b4f9d8413fea345c7d49c757d6bf",
                 "shasum": ""
             },
             "require": {
@@ -7747,8 +7751,8 @@
                 "ext-filter": "*",
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
                 "webmozart/assert": "^1.9.1 || ^2"
             },
             "require-dev": {
@@ -7758,7 +7762,8 @@
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
                 "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^5.26"
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
             },
             "type": "library",
             "extra": {
@@ -7788,44 +7793,44 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.6"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.2"
             },
-            "time": "2025-12-22T21:13:58+00:00"
+            "time": "2026-03-01T18:43:49+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.12.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
-                "php": "^7.3 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.18|^2.0"
+                "phpstan/phpdoc-parser": "^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
-                "rector/rector": "^0.13.9",
-                "vimeo/psalm": "^4.25"
+                "psalm/phar": "^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.x-dev"
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
@@ -7846,22 +7851,22 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
             },
-            "time": "2025-11-21T15:09:14+00:00"
+            "time": "2026-01-06T21:53:42+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.1",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "16dbf9937da8d4528ceb2145c9c7c0bd29e26374"
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/16dbf9937da8d4528ceb2145c9c7c0bd29e26374",
-                "reference": "16dbf9937da8d4528ceb2145c9c7c0bd29e26374",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
                 "shasum": ""
             },
             "require": {
@@ -7893,22 +7898,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
-            "time": "2026-01-12T11:33:04+00:00"
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.2",
+            "version": "12.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4a9739b51cbcb355f6e95659612f92e282a7077b"
+                "reference": "b015312f28dd75b75d3422ca37dff2cd1a565e8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4a9739b51cbcb355f6e95659612f92e282a7077b",
-                "reference": "4a9739b51cbcb355f6e95659612f92e282a7077b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b015312f28dd75b75d3422ca37dff2cd1a565e8d",
+                "reference": "b015312f28dd75b75d3422ca37dff2cd1a565e8d",
                 "shasum": ""
             },
             "require": {
@@ -7964,7 +7969,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.2"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.3"
             },
             "funding": [
                 {
@@ -7984,20 +7989,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-24T07:03:04+00:00"
+            "time": "2026-02-06T06:01:44+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "961bc913d42fe24a257bfff826a5068079ac7782"
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/961bc913d42fe24a257bfff826a5068079ac7782",
-                "reference": "961bc913d42fe24a257bfff826a5068079ac7782",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
                 "shasum": ""
             },
             "require": {
@@ -8037,15 +8042,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:58:37+00:00"
+            "time": "2026-02-02T14:04:18+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -8233,16 +8250,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.4",
+            "version": "12.5.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4ba0e923f9d3fc655de22f9547c01d15a41fc93a"
+                "reference": "418e06b3b46b0d54bad749ff4907fc7dfb530199"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4ba0e923f9d3fc655de22f9547c01d15a41fc93a",
-                "reference": "4ba0e923f9d3fc655de22f9547c01d15a41fc93a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/418e06b3b46b0d54bad749ff4907fc7dfb530199",
+                "reference": "418e06b3b46b0d54bad749ff4907fc7dfb530199",
                 "shasum": ""
             },
             "require": {
@@ -8256,18 +8273,19 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.1",
-                "phpunit/php-file-iterator": "^6.0.0",
+                "phpunit/php-code-coverage": "^12.5.3",
+                "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
                 "sebastian/cli-parser": "^4.2.0",
-                "sebastian/comparator": "^7.1.3",
+                "sebastian/comparator": "^7.1.4",
                 "sebastian/diff": "^7.0.0",
                 "sebastian/environment": "^8.0.3",
                 "sebastian/exporter": "^7.0.2",
                 "sebastian/global-state": "^8.0.2",
                 "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/recursion-context": "^7.0.1",
                 "sebastian/type": "^6.0.3",
                 "sebastian/version": "^6.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
@@ -8310,7 +8328,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.12"
             },
             "funding": [
                 {
@@ -8334,7 +8352,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-15T06:05:34+00:00"
+            "time": "2026-02-16T08:34:36+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -8407,16 +8425,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.3",
+            "version": "7.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148"
+                "reference": "6a7de5df2e094f9a80b40a522391a7e6022df5f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/dc904b4bb3ab070865fa4068cd84f3da8b945148",
-                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a7de5df2e094f9a80b40a522391a7e6022df5f6",
+                "reference": "6a7de5df2e094f9a80b40a522391a7e6022df5f6",
                 "shasum": ""
             },
             "require": {
@@ -8475,7 +8493,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.4"
             },
             "funding": [
                 {
@@ -8495,7 +8513,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-20T11:27:00+00:00"
+            "time": "2026-01-24T09:28:48+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -9287,16 +9305,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.1",
+            "version": "v7.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "24dd4de28d2e3988b311751ac49e684d783e2345"
+                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/24dd4de28d2e3988b311751ac49e684d783e2345",
-                "reference": "24dd4de28d2e3988b311751ac49e684d783e2345",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/58751048de17bae71c5aa0d13cb19d79bca26391",
+                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391",
                 "shasum": ""
             },
             "require": {
@@ -9339,7 +9357,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.1"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.6"
             },
             "funding": [
                 {
@@ -9359,28 +9377,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-04T18:11:45+00:00"
+            "time": "2026-02-09T09:33:46+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
-            "version": "0.8.5",
+            "version": "0.8.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
-                "reference": "cf6fb197b676ba716837c886baca842e4db29005"
+                "reference": "1248f3f506ca9641d4f68cebcd538fa489754db8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/cf6fb197b676ba716837c886baca842e4db29005",
-                "reference": "cf6fb197b676ba716837c886baca842e4db29005",
+                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/1248f3f506ca9641d4f68cebcd538fa489754db8",
+                "reference": "1248f3f506ca9641d4f68cebcd538fa489754db8",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18.0 || ^5.0.0",
                 "php": "^8.1.0",
-                "phpdocumentor/reflection-docblock": "^5.3.0",
-                "phpunit/phpunit": "^10.5.5  || ^11.0.0 || ^12.0.0",
-                "symfony/finder": "^6.4.0 || ^7.0.0"
+                "phpdocumentor/reflection-docblock": "^5.3.0 || ^6.0.0",
+                "phpunit/phpunit": "^10.5.5 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+                "symfony/finder": "^6.4.0 || ^7.0.0 || ^8.0.0"
             },
             "require-dev": {
                 "laravel/pint": "^1.13.7",
@@ -9416,9 +9434,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
-                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.5"
+                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.7"
             },
-            "time": "2025-04-20T20:23:40+00:00"
+            "time": "2026-02-17T17:25:14+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -9472,16 +9490,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.1.2",
+            "version": "2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649"
+                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
-                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
+                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
                 "shasum": ""
             },
             "require": {
@@ -9528,9 +9546,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.1.2"
+                "source": "https://github.com/webmozarts/assert/tree/2.1.6"
             },
-            "time": "2026-01-13T14:02:24+00:00"
+            "time": "2026-02-27T10:28:38+00:00"
         }
     ],
     "aliases": [],

--- a/orchestrator/scripts/browser-tests-kits.js
+++ b/orchestrator/scripts/browser-tests-kits.js
@@ -121,12 +121,12 @@ async function main() {
     const active = filterVariants(variants, selected);
 
     if (active.length === 0) {
-        log('No variants matched the selected framework flags.', 'yellow');
+        log('No variants matched the selected kit flags.', 'yellow');
         process.exit(0);
     }
 
     if (selected) {
-        log(`Frameworks selected: ${[...selected].join(', ')}`, 'blue');
+        log(`Kits selected: ${[...selected].join(', ')}`, 'blue');
     }
 
     const total = active.length;
@@ -156,7 +156,7 @@ async function main() {
     }
 
     for (const s of skipped) {
-        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'framework not selected' });
+        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'kit not selected' });
     }
 
     printSummary('kits:browser-tests', results);

--- a/orchestrator/scripts/browser-tests-kits.js
+++ b/orchestrator/scripts/browser-tests-kits.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-import { spawn, execSync } from 'child_process';
+import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { colors, filterVariants, log, parseFrameworkFlags, printSummary, runInherit, runQuiet } from './kit-helpers.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -16,70 +17,39 @@ const variants = [
     {
         key: 'livewire',
         display: 'Livewire',
+        framework: 'livewire',
         buildArgs: ['build', '--no-interaction', '--kit=Livewire'],
     },
     {
         key: 'react',
         display: 'React',
+        framework: 'react',
         buildArgs: ['build', '--no-interaction', '--kit=React'],
     },
     {
         key: 'svelte',
         display: 'Svelte',
+        framework: 'svelte',
         buildArgs: ['build', '--no-interaction', '--kit=Svelte'],
     },
     {
         key: 'vue',
         display: 'Vue',
+        framework: 'vue',
         buildArgs: ['build', '--no-interaction', '--kit=Vue'],
     },
 ];
-
-const colors = {
-    reset: '\x1b[0m',
-    blue: '\x1b[34m',
-    green: '\x1b[32m',
-    yellow: '\x1b[33m',
-    red: '\x1b[31m',
-};
-
-function log(message, color = 'reset') {
-    console.log(`${colors[color]}${message}${colors.reset}`);
-}
-
-function runCommand(command, args, options = {}) {
-    return new Promise((resolve, reject) => {
-        const child = spawn(command, args, {
-            stdio: 'inherit',
-            shell: true,
-            ...options,
-        });
-
-        child.on('close', code => {
-            if (code === 0) {
-                resolve();
-
-                return;
-            }
-
-            reject(new Error(`Command failed: ${command} ${args.join(' ')}`));
-        });
-
-        child.on('error', reject);
-    });
-}
 
 function removeBuildDirectory() {
     if (!fs.existsSync(buildDir)) {
         return;
     }
 
-    log('Removing existing build directory...', 'yellow');
     fs.rmSync(buildDir, { recursive: true, force: true });
 }
 
 function copyBrowserTests() {
-    log('Copying browser tests into build...', 'blue');
+    log('  Copying browser tests into build...', 'dim');
     fs.cpSync(browserTestsDir, buildDir, { recursive: true });
 }
 
@@ -102,51 +72,100 @@ function playwrightBrowsersInstalled() {
 
 async function ensurePlaywrightBrowsers() {
     if (playwrightBrowsersInstalled()) {
-        log('Playwright browsers already installed, skipping...', 'green');
+        log('  Playwright browsers already installed, skipping...', 'dim');
 
         return;
     }
 
-    log('Installing Playwright browsers...', 'blue');
-    await runCommand('npx', ['playwright', 'install', '--with-deps'], { cwd: buildDir });
+    log('  Installing Playwright browsers...', 'blue');
+    await runInherit('npx', ['playwright', 'install', '--with-deps'], { cwd: buildDir });
 }
 
 async function runBrowserTestsForCurrentBuild() {
-    await runCommand('composer', ['remove', '--dev', 'phpunit/phpunit', '--no-interaction', '--no-update'], { cwd: buildDir });
-    await runCommand('composer', ['require', '--dev', 'pestphp/pest', 'pestphp/pest-plugin-browser', 'pestphp/pest-plugin-laravel', '--no-interaction'], { cwd: buildDir });
-    await runCommand('npm', ['install'], { cwd: buildDir });
-    await runCommand('npm', ['install', 'playwright'], { cwd: buildDir });
+    log('  Configuring Pest + Playwright deps...', 'dim');
+    await runQuiet('composer', ['remove', '--dev', 'phpunit/phpunit', '--no-interaction', '--no-update'], { cwd: buildDir });
+    await runQuiet('composer', ['require', '--dev', 'pestphp/pest', 'pestphp/pest-plugin-browser', 'pestphp/pest-plugin-laravel', '--no-interaction'], { cwd: buildDir });
+
+    log('  Installing npm deps...', 'dim');
+    await runQuiet('npm', ['install'], { cwd: buildDir });
+    await runQuiet('npm', ['install', 'playwright'], { cwd: buildDir });
+
     await ensurePlaywrightBrowsers();
-    await runCommand('cp', ['.env.example', '.env'], { cwd: buildDir });
-    await runCommand('php', ['artisan', 'key:generate'], { cwd: buildDir });
-    await runCommand('npm', ['run', 'build'], { cwd: buildDir });
-    await runCommand('php', ['vendor/bin/pest', '--parallel'], { cwd: buildDir });
+
+    log('  Preparing environment...', 'dim');
+    await runQuiet('cp', ['.env.example', '.env'], { cwd: buildDir });
+    await runQuiet('php', ['artisan', 'key:generate'], { cwd: buildDir });
+
+    log('  Building frontend...', 'dim');
+    await runQuiet('npm', ['run', 'build'], { cwd: buildDir });
+
+    log('  Running browser tests...', 'blue');
+    await runInherit('php', ['vendor/bin/pest', '--parallel'], { cwd: buildDir });
 }
 
 async function browserTestVariant(variant, index, total) {
-    log(`\n[${index}/${total}] ${variant.display} (${variant.key})`, 'blue');
+    log(`\n[${index}/${total}] ${variant.display}`, 'blue');
 
     removeBuildDirectory();
 
-    log('Building variant...', 'blue');
-    await runCommand('php', ['artisan', ...variant.buildArgs], { cwd: orchestratorDir });
+    log('  Building variant...', 'dim');
+    await runQuiet('php', ['artisan', ...variant.buildArgs], { cwd: orchestratorDir });
 
     copyBrowserTests();
 
-    log('Running browser tests...', 'blue');
     await runBrowserTestsForCurrentBuild();
-
-    log(`Passed ${variant.key}`, 'green');
 }
 
 async function main() {
-    const total = variants.length;
+    const selected = parseFrameworkFlags(process.argv.slice(2));
+    const active = filterVariants(variants, selected);
 
-    for (let index = 0; index < total; index++) {
-        await browserTestVariant(variants[index], index + 1, total);
+    if (active.length === 0) {
+        log('No variants matched the selected framework flags.', 'yellow');
+        process.exit(0);
     }
 
-    log('\nAll starter kit variants passed browser tests.', 'green');
+    if (selected) {
+        log(`Frameworks selected: ${[...selected].join(', ')}`, 'blue');
+    }
+
+    const total = active.length;
+    const results = [];
+
+    // Track skipped variants for summary
+    const skipped = variants.filter(v => !active.includes(v));
+
+    for (let index = 0; index < total; index++) {
+        const variant = active[index];
+        const start = Date.now();
+
+        try {
+            await browserTestVariant(variant, index + 1, total);
+            results.push({ key: variant.key, display: variant.display, status: 'passed', elapsed: Date.now() - start });
+            log(`  ${colors.green}✓ Passed${colors.reset}`);
+        } catch (error) {
+            results.push({ key: variant.key, display: variant.display, status: 'failed', elapsed: Date.now() - start });
+            log(`  ✗ Failed: ${error.message}`, 'red');
+
+            if (error.output) {
+                log('\n--- captured output ---', 'dim');
+                console.log(error.output);
+                log('--- end output ---\n', 'dim');
+            }
+        }
+    }
+
+    for (const s of skipped) {
+        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'framework not selected' });
+    }
+
+    printSummary('kits:browser-tests', results);
+
+    removeBuildDirectory();
+
+    if (results.some(r => r.status === 'failed')) {
+        process.exit(1);
+    }
 }
 
 main().catch(error => {

--- a/orchestrator/scripts/browser-tests-kits.js
+++ b/orchestrator/scripts/browser-tests-kits.js
@@ -2,16 +2,16 @@
 
 import { execSync } from 'child_process';
 import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { colors, filterVariants, log, parseFrameworkFlags, printSummary, runInherit, runQuiet } from './kit-helpers.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const orchestratorDir = path.dirname(__dirname);
-const rootDir = path.dirname(orchestratorDir);
-const buildDir = path.join(rootDir, 'build');
-const browserTestsDir = path.join(rootDir, 'browser_tests');
+import {
+    browserTestsDir,
+    buildDir,
+    log,
+    orchestratorDir,
+    removeBuildDirectory,
+    runInherit,
+    runMatrix,
+    runQuiet,
+} from './kit-helpers.js';
 
 const variants = [
     {
@@ -39,14 +39,6 @@ const variants = [
         buildArgs: ['build', '--no-interaction', '--kit=Vue'],
     },
 ];
-
-function removeBuildDirectory() {
-    if (!fs.existsSync(buildDir)) {
-        return;
-    }
-
-    fs.rmSync(buildDir, { recursive: true, force: true });
-}
 
 function copyBrowserTests() {
     log('  Copying browser tests into build...', 'dim');
@@ -116,59 +108,11 @@ async function browserTestVariant(variant, index, total) {
     await runBrowserTestsForCurrentBuild();
 }
 
-async function main() {
-    const selected = parseFrameworkFlags(process.argv.slice(2));
-    const active = filterVariants(variants, selected);
-
-    if (active.length === 0) {
-        log('No variants matched the selected kit flags.', 'yellow');
-        process.exit(0);
-    }
-
-    if (selected) {
-        log(`Kits selected: ${[...selected].join(', ')}`, 'blue');
-    }
-
-    const total = active.length;
-    const results = [];
-
-    // Track skipped variants for summary
-    const skipped = variants.filter(v => !active.includes(v));
-
-    for (let index = 0; index < total; index++) {
-        const variant = active[index];
-        const start = Date.now();
-
-        try {
-            await browserTestVariant(variant, index + 1, total);
-            results.push({ key: variant.key, display: variant.display, status: 'passed', elapsed: Date.now() - start });
-            log(`  ${colors.green}✓ Passed${colors.reset}`);
-        } catch (error) {
-            results.push({ key: variant.key, display: variant.display, status: 'failed', elapsed: Date.now() - start });
-            log(`  ✗ Failed: ${error.message}`, 'red');
-
-            if (error.output) {
-                log('\n--- captured output ---', 'dim');
-                console.log(error.output);
-                log('--- end output ---\n', 'dim');
-            }
-        }
-    }
-
-    for (const s of skipped) {
-        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'kit not selected' });
-    }
-
-    printSummary('kits:browser-tests', results);
-
-    removeBuildDirectory();
-
-    if (results.some(r => r.status === 'failed')) {
-        process.exit(1);
-    }
-}
-
-main().catch(error => {
+runMatrix({
+    scriptLabel: 'kits:browser-tests',
+    allVariants: variants,
+    runVariant: browserTestVariant,
+}).catch(error => {
     log(`\nBrowser tests failed: ${error.message}`, 'red');
     process.exit(1);
 });

--- a/orchestrator/scripts/check-kits.js
+++ b/orchestrator/scripts/check-kits.js
@@ -1,15 +1,6 @@
 #!/usr/bin/env node
 
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { colors, filterVariants, log, parseFrameworkFlags, printSummary, runQuiet } from './kit-helpers.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const orchestratorDir = path.dirname(__dirname);
-const rootDir = path.dirname(orchestratorDir);
-const buildDir = path.join(rootDir, 'build');
+import { buildDir, log, orchestratorDir, removeBuildDirectory, runMatrix, runQuiet } from './kit-helpers.js';
 
 const variants = [
     {
@@ -92,14 +83,6 @@ const variants = [
     },
 ];
 
-function removeBuildDirectory() {
-    if (!fs.existsSync(buildDir)) {
-        return;
-    }
-
-    fs.rmSync(buildDir, { recursive: true, force: true });
-}
-
 async function checkCurrentBuild() {
     log('  Installing dependencies...', 'dim');
     await runQuiet('composer', ['setup'], { cwd: buildDir });
@@ -119,61 +102,11 @@ async function checkVariant(variant, index, total) {
     await checkCurrentBuild();
 }
 
-async function main() {
-    const selected = parseFrameworkFlags(process.argv.slice(2));
-    const active = filterVariants(variants, selected);
-
-    if (active.length === 0) {
-        log('No variants matched the selected kit flags.', 'yellow');
-        process.exit(0);
-    }
-
-    if (selected) {
-        log(`Kits selected: ${[...selected].join(', ')}`, 'blue');
-    }
-
-    const total = active.length;
-    const results = [];
-
-    // Track skipped variants for summary
-    const skipped = variants.filter(v => !active.includes(v));
-
-    for (let index = 0; index < total; index++) {
-        const variant = active[index];
-        const start = Date.now();
-
-        try {
-            await checkVariant(variant, index + 1, total);
-            results.push({ key: variant.key, display: variant.display, status: 'passed', elapsed: Date.now() - start });
-            log(`  ${colors.green}✓ Passed${colors.reset}`);
-        } catch (error) {
-            results.push({ key: variant.key, display: variant.display, status: 'failed', elapsed: Date.now() - start });
-            log(`  ✗ Failed: ${error.message}`, 'red');
-
-            if (error.output) {
-                log('\n--- captured output ---', 'dim');
-                console.log(error.output);
-                log('--- end output ---\n', 'dim');
-            }
-
-            // Continue to remaining variants
-        }
-    }
-
-    for (const s of skipped) {
-        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'kit not selected' });
-    }
-
-    printSummary('kits:check', results);
-
-    removeBuildDirectory();
-
-    if (results.some(r => r.status === 'failed')) {
-        process.exit(1);
-    }
-}
-
-main().catch(error => {
+runMatrix({
+    scriptLabel: 'kits:check',
+    allVariants: variants,
+    runVariant: checkVariant,
+}).catch(error => {
     log(`\nCheck kits failed: ${error.message}`, 'red');
     process.exit(1);
 });

--- a/orchestrator/scripts/check-kits.js
+++ b/orchestrator/scripts/check-kits.js
@@ -124,12 +124,12 @@ async function main() {
     const active = filterVariants(variants, selected);
 
     if (active.length === 0) {
-        log('No variants matched the selected framework flags.', 'yellow');
+        log('No variants matched the selected kit flags.', 'yellow');
         process.exit(0);
     }
 
     if (selected) {
-        log(`Frameworks selected: ${[...selected].join(', ')}`, 'blue');
+        log(`Kits selected: ${[...selected].join(', ')}`, 'blue');
     }
 
     const total = active.length;
@@ -161,7 +161,7 @@ async function main() {
     }
 
     for (const s of skipped) {
-        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'framework not selected' });
+        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'kit not selected' });
     }
 
     printSummary('kits:check', results);

--- a/orchestrator/scripts/check-kits.js
+++ b/orchestrator/scripts/check-kits.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import { spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { colors, filterVariants, log, parseFrameworkFlags, printSummary, runQuiet } from './kit-helpers.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -15,140 +15,162 @@ const variants = [
     {
         key: 'react-blank',
         display: 'React Blank',
+        framework: 'react',
         buildArgs: ['build', '--no-interaction', '--kit=React', '--blank'],
     },
     {
         key: 'react',
         display: 'React Fortify',
+        framework: 'react',
         buildArgs: ['build', '--no-interaction', '--kit=React'],
     },
     {
         key: 'react-workos',
         display: 'React WorkOS',
+        framework: 'react',
         buildArgs: ['build', '--no-interaction', '--kit=React', '--workos'],
     },
     {
         key: 'svelte-blank',
         display: 'Svelte Blank',
+        framework: 'svelte',
         buildArgs: ['build', '--no-interaction', '--kit=Svelte', '--blank'],
     },
     {
         key: 'svelte',
         display: 'Svelte Fortify',
+        framework: 'svelte',
         buildArgs: ['build', '--no-interaction', '--kit=Svelte'],
     },
     {
         key: 'svelte-workos',
         display: 'Svelte WorkOS',
+        framework: 'svelte',
         buildArgs: ['build', '--no-interaction', '--kit=Svelte', '--workos'],
     },
     {
         key: 'vue-blank',
         display: 'Vue Blank',
+        framework: 'vue',
         buildArgs: ['build', '--no-interaction', '--kit=Vue', '--blank'],
     },
     {
         key: 'vue',
         display: 'Vue Fortify',
+        framework: 'vue',
         buildArgs: ['build', '--no-interaction', '--kit=Vue'],
     },
     {
         key: 'vue-workos',
         display: 'Vue WorkOS',
+        framework: 'vue',
         buildArgs: ['build', '--no-interaction', '--kit=Vue', '--workos'],
     },
     {
         key: 'livewire-blank',
         display: 'Livewire Blank',
+        framework: 'livewire',
         buildArgs: ['build', '--no-interaction', '--kit=Livewire', '--blank'],
     },
     {
         key: 'livewire',
         display: 'Livewire Fortify',
+        framework: 'livewire',
         buildArgs: ['build', '--no-interaction', '--kit=Livewire'],
     },
     {
         key: 'livewire-components',
         display: 'Livewire Components',
+        framework: 'livewire',
         buildArgs: ['build', '--no-interaction', '--kit=Livewire', '--components'],
     },
     {
         key: 'livewire-workos',
         display: 'Livewire WorkOS',
+        framework: 'livewire',
         buildArgs: ['build', '--no-interaction', '--kit=Livewire', '--workos'],
     },
 ];
-
-const colors = {
-    reset: '\x1b[0m',
-    blue: '\x1b[34m',
-    green: '\x1b[32m',
-    yellow: '\x1b[33m',
-    red: '\x1b[31m',
-};
-
-function log(message, color = 'reset') {
-    console.log(`${colors[color]}${message}${colors.reset}`);
-}
-
-function runCommand(command, args, options = {}) {
-    return new Promise((resolve, reject) => {
-        const child = spawn(command, args, {
-            stdio: 'inherit',
-            shell: true,
-            ...options,
-        });
-
-        child.on('close', code => {
-            if (code === 0) {
-                resolve();
-
-                return;
-            }
-
-            reject(new Error(`Command failed: ${command} ${args.join(' ')}`));
-        });
-
-        child.on('error', reject);
-    });
-}
 
 function removeBuildDirectory() {
     if (!fs.existsSync(buildDir)) {
         return;
     }
 
-    log('Removing existing build directory...', 'yellow');
     fs.rmSync(buildDir, { recursive: true, force: true });
 }
 
 async function checkCurrentBuild() {
-    await runCommand('composer', ['setup'], { cwd: buildDir });
-    await runCommand('composer', ['ci:check'], { cwd: buildDir });
+    log('  Installing dependencies...', 'dim');
+    await runQuiet('composer', ['setup'], { cwd: buildDir });
+
+    log('  Running ci:check...', 'dim');
+    await runQuiet('composer', ['ci:check'], { cwd: buildDir });
 }
 
 async function checkVariant(variant, index, total) {
-    log(`\n[${index}/${total}] ${variant.display} (${variant.key})`, 'blue');
+    log(`\n[${index}/${total}] ${variant.display}`, 'blue');
 
     removeBuildDirectory();
 
-    log('Building variant...', 'blue');
-    await runCommand('php', ['artisan', ...variant.buildArgs], { cwd: orchestratorDir });
+    log('  Building variant...', 'dim');
+    await runQuiet('php', ['artisan', ...variant.buildArgs], { cwd: orchestratorDir });
 
-    log('Running CI checks...', 'blue');
     await checkCurrentBuild();
-
-    log(`Passed ${variant.key}`, 'green');
 }
 
 async function main() {
-    const total = variants.length;
+    const selected = parseFrameworkFlags(process.argv.slice(2));
+    const active = filterVariants(variants, selected);
 
-    for (let index = 0; index < total; index++) {
-        await checkVariant(variants[index], index + 1, total);
+    if (active.length === 0) {
+        log('No variants matched the selected framework flags.', 'yellow');
+        process.exit(0);
     }
 
-    log('\nAll starter kit variants passed CI checks.', 'green');
+    if (selected) {
+        log(`Frameworks selected: ${[...selected].join(', ')}`, 'blue');
+    }
+
+    const total = active.length;
+    const results = [];
+
+    // Track skipped variants for summary
+    const skipped = variants.filter(v => !active.includes(v));
+
+    for (let index = 0; index < total; index++) {
+        const variant = active[index];
+        const start = Date.now();
+
+        try {
+            await checkVariant(variant, index + 1, total);
+            results.push({ key: variant.key, display: variant.display, status: 'passed', elapsed: Date.now() - start });
+            log(`  ${colors.green}✓ Passed${colors.reset}`);
+        } catch (error) {
+            results.push({ key: variant.key, display: variant.display, status: 'failed', elapsed: Date.now() - start });
+            log(`  ✗ Failed: ${error.message}`, 'red');
+
+            if (error.output) {
+                log('\n--- captured output ---', 'dim');
+                console.log(error.output);
+                log('--- end output ---\n', 'dim');
+            }
+
+            // Continue to remaining variants
+        }
+    }
+
+    for (const s of skipped) {
+        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'framework not selected' });
+    }
+
+    printSummary('kits:check', results);
+
+    removeBuildDirectory();
+
+    if (results.some(r => r.status === 'failed')) {
+        process.exit(1);
+    }
 }
 
 main().catch(error => {

--- a/orchestrator/scripts/kit-helpers.js
+++ b/orchestrator/scripts/kit-helpers.js
@@ -60,7 +60,9 @@ export function filterVariants(variants, selected) {
  */
 export function runQuiet(command, args, options = {}) {
     return new Promise((resolve, reject) => {
-        const child = spawn(command, args, {
+        const fullCommand = [command, ...args].join(' ');
+
+        const child = spawn(fullCommand, [], {
             stdio: ['ignore', 'pipe', 'pipe'],
             shell: true,
             ...options,
@@ -85,7 +87,7 @@ export function runQuiet(command, args, options = {}) {
             }
 
             const output = [stdout, stderr].filter(Boolean).join('\n');
-            const error = new Error(`Command failed: ${command} ${args.join(' ')}`);
+            const error = new Error(`Command failed: ${fullCommand}`);
             error.output = output;
             reject(error);
         });
@@ -99,7 +101,9 @@ export function runQuiet(command, args, options = {}) {
  */
 export function runInherit(command, args, options = {}) {
     return new Promise((resolve, reject) => {
-        const child = spawn(command, args, {
+        const fullCommand = [command, ...args].join(' ');
+
+        const child = spawn(fullCommand, [], {
             stdio: 'inherit',
             shell: true,
             ...options,
@@ -112,7 +116,7 @@ export function runInherit(command, args, options = {}) {
                 return;
             }
 
-            reject(new Error(`Command failed: ${command} ${args.join(' ')}`));
+            reject(new Error(`Command failed: ${fullCommand}`));
         });
 
         child.on('error', reject);

--- a/orchestrator/scripts/kit-helpers.js
+++ b/orchestrator/scripts/kit-helpers.js
@@ -1,11 +1,25 @@
 #!/usr/bin/env node
 
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { spawn } from 'child_process';
 
 /**
  * All recognized framework flags.
  */
 const FRAMEWORK_FLAGS = ['--livewire', '--react', '--svelte', '--vue'];
+
+/**
+ * Resolved directory paths shared across scripts.
+ */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+export const orchestratorDir = path.dirname(__dirname);
+export const rootDir = path.dirname(orchestratorDir);
+export const buildDir = path.join(rootDir, 'build');
+export const kitsDir = path.join(rootDir, 'kits');
+export const browserTestsDir = path.join(rootDir, 'browser_tests');
 
 /**
  * ANSI color codes for terminal output.
@@ -30,8 +44,17 @@ export function log(message, color = 'reset') {
 /**
  * Parse process.argv (after slice(2)) and return the set of selected frameworks.
  * Returns null when no framework flags are present (means "run all").
+ * Exits with a non-zero code if any unrecognized --* flag is found.
  */
 export function parseFrameworkFlags(argv) {
+    const unknownFlags = argv.filter(arg => arg.startsWith('--') && !FRAMEWORK_FLAGS.includes(arg));
+
+    if (unknownFlags.length > 0) {
+        log(`Unknown flag(s): ${unknownFlags.join(', ')}`, 'red');
+        log(`Recognized flags: ${FRAMEWORK_FLAGS.join(', ')}`, 'yellow');
+        process.exit(1);
+    }
+
     const selected = FRAMEWORK_FLAGS
         .filter(flag => argv.includes(flag))
         .map(flag => flag.replace('--', ''));
@@ -54,17 +77,15 @@ export function filterVariants(variants, selected) {
 
 /**
  * Run a command with buffered (quiet) output.
- * - stdout/stderr are captured and only printed if the command fails.
- * - stderr is always forwarded in real-time so warnings are visible.
- * Returns a promise that resolves on exit 0 and rejects otherwise.
+ * Both stdout and stderr are captured in memory and only printed if the
+ * command exits with a non-zero code.
+ * Returns a promise that resolves with { stdout, stderr } on exit 0
+ * and rejects with an Error (with an `output` property) otherwise.
  */
 export function runQuiet(command, args, options = {}) {
     return new Promise((resolve, reject) => {
-        const fullCommand = [command, ...args].join(' ');
-
-        const child = spawn(fullCommand, [], {
+        const child = spawn(command, args, {
             stdio: ['ignore', 'pipe', 'pipe'],
-            shell: true,
             ...options,
         });
 
@@ -86,8 +107,9 @@ export function runQuiet(command, args, options = {}) {
                 return;
             }
 
+            const display = [command, ...args].join(' ');
             const output = [stdout, stderr].filter(Boolean).join('\n');
-            const error = new Error(`Command failed: ${fullCommand}`);
+            const error = new Error(`Command failed: ${display}`);
             error.output = output;
             reject(error);
         });
@@ -101,11 +123,8 @@ export function runQuiet(command, args, options = {}) {
  */
 export function runInherit(command, args, options = {}) {
     return new Promise((resolve, reject) => {
-        const fullCommand = [command, ...args].join(' ');
-
-        const child = spawn(fullCommand, [], {
+        const child = spawn(command, args, {
             stdio: 'inherit',
-            shell: true,
             ...options,
         });
 
@@ -116,7 +135,8 @@ export function runInherit(command, args, options = {}) {
                 return;
             }
 
-            reject(new Error(`Command failed: ${fullCommand}`));
+            const display = [command, ...args].join(' ');
+            reject(new Error(`Command failed: ${display}`));
         });
 
         child.on('error', reject);
@@ -182,4 +202,75 @@ export function printSummary(scriptLabel, results) {
 
     log(`  ${parts.join(', ')}`, failed.length > 0 ? 'red' : 'green');
     log('', 'reset');
+}
+
+/**
+ * Remove and recreate the build directory.
+ */
+export function removeBuildDirectory() {
+    if (!fs.existsSync(buildDir)) {
+        return;
+    }
+
+    fs.rmSync(buildDir, { recursive: true, force: true });
+}
+
+/**
+ * Run the matrix loop shared by check-kits, lint-kits, and browser-tests-kits.
+ *
+ * @param {object}   options
+ * @param {string}   options.scriptLabel     Label for summary output (e.g. 'kits:check').
+ * @param {Array}    options.allVariants     Full variant list before filtering.
+ * @param {Function} options.runVariant      Async (variant, index, total) => void.
+ * @param {string}   [options.successVerb]   Verb for the per-variant success line (default 'Passed').
+ */
+export async function runMatrix({ scriptLabel, allVariants, runVariant, successVerb = 'Passed' }) {
+    const selected = parseFrameworkFlags(process.argv.slice(2));
+    const active = filterVariants(allVariants, selected);
+
+    if (active.length === 0) {
+        log('No variants matched the selected kit flags.', 'yellow');
+        process.exit(0);
+    }
+
+    if (selected) {
+        log(`Kits selected: ${[...selected].join(', ')}`, 'blue');
+    }
+
+    const total = active.length;
+    const results = [];
+
+    const skipped = allVariants.filter(v => !active.includes(v));
+
+    for (let index = 0; index < total; index++) {
+        const variant = active[index];
+        const start = Date.now();
+
+        try {
+            await runVariant(variant, index + 1, total);
+            results.push({ key: variant.key, display: variant.display, status: 'passed', elapsed: Date.now() - start });
+            log(`  ${colors.green}✓ ${successVerb}${colors.reset}`);
+        } catch (error) {
+            results.push({ key: variant.key, display: variant.display, status: 'failed', elapsed: Date.now() - start });
+            log(`  ✗ Failed: ${error.message}`, 'red');
+
+            if (error.output) {
+                log('\n--- captured output ---', 'dim');
+                console.log(error.output);
+                log('--- end output ---\n', 'dim');
+            }
+        }
+    }
+
+    for (const s of skipped) {
+        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'kit not selected' });
+    }
+
+    printSummary(scriptLabel, results);
+
+    removeBuildDirectory();
+
+    if (results.some(r => r.status === 'failed')) {
+        process.exit(1);
+    }
 }

--- a/orchestrator/scripts/kit-helpers.js
+++ b/orchestrator/scripts/kit-helpers.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+import { spawn } from 'child_process';
+
+/**
+ * All recognized framework flags.
+ */
+const FRAMEWORK_FLAGS = ['--livewire', '--react', '--svelte', '--vue'];
+
+/**
+ * ANSI color codes for terminal output.
+ */
+export const colors = {
+    reset: '\x1b[0m',
+    blue: '\x1b[34m',
+    green: '\x1b[32m',
+    yellow: '\x1b[33m',
+    red: '\x1b[31m',
+    dim: '\x1b[2m',
+    bold: '\x1b[1m',
+};
+
+/**
+ * Print a colored log line to stdout.
+ */
+export function log(message, color = 'reset') {
+    console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+/**
+ * Parse process.argv (after slice(2)) and return the set of selected frameworks.
+ * Returns null when no framework flags are present (means "run all").
+ */
+export function parseFrameworkFlags(argv) {
+    const selected = FRAMEWORK_FLAGS
+        .filter(flag => argv.includes(flag))
+        .map(flag => flag.replace('--', ''));
+
+    return selected.length > 0 ? new Set(selected) : null;
+}
+
+/**
+ * Filter an array of variant objects by the selected frameworks.
+ * Each variant must have a `framework` property (e.g. 'react', 'livewire').
+ * When `selected` is null every variant passes.
+ */
+export function filterVariants(variants, selected) {
+    if (!selected) {
+        return variants;
+    }
+
+    return variants.filter(v => selected.has(v.framework));
+}
+
+/**
+ * Run a command with buffered (quiet) output.
+ * - stdout/stderr are captured and only printed if the command fails.
+ * - stderr is always forwarded in real-time so warnings are visible.
+ * Returns a promise that resolves on exit 0 and rejects otherwise.
+ */
+export function runQuiet(command, args, options = {}) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            stdio: ['ignore', 'pipe', 'pipe'],
+            shell: true,
+            ...options,
+        });
+
+        let stdout = '';
+        let stderr = '';
+
+        child.stdout.on('data', data => {
+            stdout += data.toString();
+        });
+
+        child.stderr.on('data', data => {
+            stderr += data.toString();
+        });
+
+        child.on('close', code => {
+            if (code === 0) {
+                resolve({ stdout, stderr });
+
+                return;
+            }
+
+            const output = [stdout, stderr].filter(Boolean).join('\n');
+            const error = new Error(`Command failed: ${command} ${args.join(' ')}`);
+            error.output = output;
+            reject(error);
+        });
+
+        child.on('error', reject);
+    });
+}
+
+/**
+ * Run a command with inherited stdio (verbose mode, used as fallback).
+ */
+export function runInherit(command, args, options = {}) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            stdio: 'inherit',
+            shell: true,
+            ...options,
+        });
+
+        child.on('close', code => {
+            if (code === 0) {
+                resolve();
+
+                return;
+            }
+
+            reject(new Error(`Command failed: ${command} ${args.join(' ')}`));
+        });
+
+        child.on('error', reject);
+    });
+}
+
+/**
+ * Human-readable elapsed time.
+ */
+function formatElapsed(ms) {
+    if (ms < 1000) {
+        return `${ms}ms`;
+    }
+
+    const seconds = (ms / 1000).toFixed(1);
+
+    if (seconds < 60) {
+        return `${seconds}s`;
+    }
+
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = (seconds % 60).toFixed(0);
+
+    return `${minutes}m ${remainingSeconds}s`;
+}
+
+/**
+ * Print an end-of-run summary table.
+ *
+ * `results` is an array of { key, display, status, elapsed, reason? } objects.
+ * `status` is one of 'passed', 'failed', or 'skipped'.
+ */
+export function printSummary(scriptLabel, results) {
+    const passed = results.filter(r => r.status === 'passed');
+    const failed = results.filter(r => r.status === 'failed');
+    const skipped = results.filter(r => r.status === 'skipped');
+
+    log(`\n${'─'.repeat(60)}`, 'dim');
+    log(`${scriptLabel} Summary`, 'bold');
+    log(`${'─'.repeat(60)}`, 'dim');
+
+    for (const r of results) {
+        const icon = r.status === 'passed' ? '✓' : r.status === 'failed' ? '✗' : '○';
+        const statusColor = r.status === 'passed' ? 'green' : r.status === 'failed' ? 'red' : 'yellow';
+        const elapsed = r.elapsed ? ` (${formatElapsed(r.elapsed)})` : '';
+        const reason = r.reason ? ` — ${r.reason}` : '';
+
+        log(`  ${icon} ${r.display}${elapsed}${reason}`, statusColor);
+    }
+
+    log(`${'─'.repeat(60)}`, 'dim');
+
+    const parts = [];
+    if (passed.length > 0) {
+        parts.push(`${passed.length} passed`);
+    }
+    if (failed.length > 0) {
+        parts.push(`${failed.length} failed`);
+    }
+    if (skipped.length > 0) {
+        parts.push(`${skipped.length} skipped`);
+    }
+
+    log(`  ${parts.join(', ')}`, failed.length > 0 ? 'red' : 'green');
+    log('', 'reset');
+}

--- a/orchestrator/scripts/kit-manifest.json
+++ b/orchestrator/scripts/kit-manifest.json
@@ -1,0 +1,41 @@
+{
+    "placeholderSearchPaths": [
+        "app/Http/Controllers",
+        "app/Providers",
+        "routes",
+        "tests"
+    ],
+
+    "componentsRelocations": [
+        {
+            "from": "resources/views/pages/settings/layout.blade.php",
+            "to": "resources/views/components/settings/layout.blade.php"
+        },
+        {
+            "from": "resources/views/pages/auth/",
+            "to": "resources/views/livewire/auth/",
+            "directory": true
+        }
+    ],
+
+    "componentsDeleteDirectory": "resources/views/pages",
+
+    "kitFolderMap": {
+        "livewire-blank": ["Shared/Blank", "Livewire/Blank"],
+        "livewire": ["Shared/Blank", "Livewire/Blank", "Shared/Base", "Livewire/Base", "Shared/Fortify", "Livewire/Fortify"],
+        "livewire-components": ["Shared/Blank", "Livewire/Blank", "Shared/Base", "Livewire/Base", "Shared/Fortify", "Livewire/Fortify", "Livewire/Components"],
+        "livewire-workos": ["Shared/Blank", "Livewire/Blank", "Shared/Base", "Livewire/Base", "Shared/WorkOS", "Livewire/WorkOS"],
+
+        "react-blank": ["Shared/Blank", "Inertia/Blank/Base", "Inertia/Blank/React"],
+        "react": ["Shared/Blank", "Inertia/Blank/Base", "Inertia/Blank/React", "Shared/Base", "Inertia/Base", "Inertia/React", "Shared/Fortify", "Inertia/Fortify/Base", "Inertia/Fortify/React"],
+        "react-workos": ["Shared/Blank", "Inertia/Blank/Base", "Inertia/Blank/React", "Shared/Base", "Inertia/Base", "Inertia/React", "Shared/WorkOS", "Inertia/WorkOS/Base", "Inertia/WorkOS/React"],
+
+        "svelte-blank": ["Shared/Blank", "Inertia/Blank/Base", "Inertia/Blank/Svelte"],
+        "svelte": ["Shared/Blank", "Inertia/Blank/Base", "Inertia/Blank/Svelte", "Shared/Base", "Inertia/Base", "Inertia/Svelte", "Shared/Fortify", "Inertia/Fortify/Base", "Inertia/Fortify/Svelte"],
+        "svelte-workos": ["Shared/Blank", "Inertia/Blank/Base", "Inertia/Blank/Svelte", "Shared/Base", "Inertia/Base", "Inertia/Svelte", "Shared/WorkOS", "Inertia/WorkOS/Base", "Inertia/WorkOS/Svelte"],
+
+        "vue-blank": ["Shared/Blank", "Inertia/Blank/Base", "Inertia/Blank/Vue"],
+        "vue": ["Shared/Blank", "Inertia/Blank/Base", "Inertia/Blank/Vue", "Shared/Base", "Inertia/Base", "Inertia/Vue", "Shared/Fortify", "Inertia/Fortify/Base", "Inertia/Fortify/Vue"],
+        "vue-workos": ["Shared/Blank", "Inertia/Blank/Base", "Inertia/Blank/Vue", "Shared/Base", "Inertia/Base", "Inertia/Vue", "Shared/WorkOS", "Inertia/WorkOS/Base", "Inertia/WorkOS/Vue"]
+    }
+}

--- a/orchestrator/scripts/lint-kits.js
+++ b/orchestrator/scripts/lint-kits.js
@@ -1,15 +1,17 @@
 #!/usr/bin/env node
 
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { colors, filterVariants, log, parseFrameworkFlags, printSummary, runInherit, runQuiet } from './kit-helpers.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const orchestratorDir = path.dirname(__dirname);
-const rootDir = path.dirname(orchestratorDir);
-const buildDir = path.join(rootDir, 'build');
+import {
+    buildDir,
+    filterVariants,
+    log,
+    orchestratorDir,
+    parseFrameworkFlags,
+    printSummary,
+    removeBuildDirectory,
+    runInherit,
+    runQuiet,
+    colors,
+} from './kit-helpers.js';
 
 /**
  * Only Inertia variants need frontend lint/format. Livewire has no frontend
@@ -73,13 +75,7 @@ const variants = [
     },
 ];
 
-function removeBuildDirectory() {
-    if (!fs.existsSync(buildDir)) {
-        return;
-    }
-
-    fs.rmSync(buildDir, { recursive: true, force: true });
-}
+const MAX_LINT_PASSES = 2;
 
 async function lintCurrentBuild() {
     log('  Installing composer deps...', 'dim');
@@ -91,17 +87,13 @@ async function lintCurrentBuild() {
     log('  Building frontend...', 'dim');
     await runQuiet('npm', ['run', 'build'], { cwd: buildDir });
 
-    log('  Running lint pass 1...', 'dim');
-    await runQuiet('npm', ['run', 'lint'], { cwd: buildDir });
+    for (let pass = 1; pass <= MAX_LINT_PASSES; pass++) {
+        log(`  Running lint pass ${pass}...`, 'dim');
+        await runQuiet('npm', ['run', 'lint'], { cwd: buildDir });
 
-    log('  Running format pass 1...', 'dim');
-    await runQuiet('npm', ['run', 'format'], { cwd: buildDir });
-
-    log('  Running lint pass 2...', 'dim');
-    await runQuiet('npm', ['run', 'lint'], { cwd: buildDir });
-
-    log('  Running format pass 2...', 'dim');
-    await runQuiet('npm', ['run', 'format'], { cwd: buildDir });
+        log(`  Running format pass ${pass}...`, 'dim');
+        await runQuiet('npm', ['run', 'format'], { cwd: buildDir });
+    }
 }
 
 function runWatcherInitialSync() {

--- a/orchestrator/scripts/lint-kits.js
+++ b/orchestrator/scripts/lint-kits.js
@@ -142,14 +142,14 @@ async function main() {
         if (selected && selected.has('livewire') && selected.size === 1) {
             log('Livewire has no frontend lint phase. Only the shared Pint step applies.', 'yellow');
         } else {
-            log('No Inertia variants matched the selected framework flags.', 'yellow');
+            log('No Inertia variants matched the selected kit flags.', 'yellow');
         }
 
         process.exit(0);
     }
 
     if (selected) {
-        log(`Frameworks selected: ${[...selected].join(', ')}`, 'blue');
+        log(`Kits selected: ${[...selected].join(', ')}`, 'blue');
     }
 
     const total = active.length;
@@ -179,7 +179,7 @@ async function main() {
     }
 
     for (const s of skipped) {
-        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'framework not selected' });
+        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'kit not selected' });
     }
 
     printSummary('kits:lint', results);

--- a/orchestrator/scripts/lint-kits.js
+++ b/orchestrator/scripts/lint-kits.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import { spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { colors, filterVariants, log, parseFrameworkFlags, printSummary, runInherit, runQuiet } from './kit-helpers.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -11,138 +11,184 @@ const orchestratorDir = path.dirname(__dirname);
 const rootDir = path.dirname(orchestratorDir);
 const buildDir = path.join(rootDir, 'build');
 
+/**
+ * Only Inertia variants need frontend lint/format. Livewire has no frontend
+ * lint phase — its PHP formatting is handled by `kits:pint` (called before
+ * this script by the `kits:lint` composer command).
+ */
 const variants = [
     {
         key: 'react-blank',
         display: 'React Blank',
+        framework: 'react',
         buildArgs: ['build', '--no-interaction', '--kit=React', '--blank'],
     },
     {
         key: 'react',
         display: 'React Fortify',
+        framework: 'react',
         buildArgs: ['build', '--no-interaction', '--kit=React'],
     },
     {
         key: 'react-workos',
         display: 'React WorkOS',
+        framework: 'react',
         buildArgs: ['build', '--no-interaction', '--kit=React', '--workos'],
     },
     {
         key: 'svelte-blank',
         display: 'Svelte Blank',
+        framework: 'svelte',
         buildArgs: ['build', '--no-interaction', '--kit=Svelte', '--blank'],
     },
     {
         key: 'svelte',
         display: 'Svelte Fortify',
+        framework: 'svelte',
         buildArgs: ['build', '--no-interaction', '--kit=Svelte'],
     },
     {
         key: 'svelte-workos',
         display: 'Svelte WorkOS',
+        framework: 'svelte',
         buildArgs: ['build', '--no-interaction', '--kit=Svelte', '--workos'],
     },
     {
         key: 'vue-blank',
         display: 'Vue Blank',
+        framework: 'vue',
         buildArgs: ['build', '--no-interaction', '--kit=Vue', '--blank'],
     },
     {
         key: 'vue',
         display: 'Vue Fortify',
+        framework: 'vue',
         buildArgs: ['build', '--no-interaction', '--kit=Vue'],
     },
     {
         key: 'vue-workos',
         display: 'Vue WorkOS',
+        framework: 'vue',
         buildArgs: ['build', '--no-interaction', '--kit=Vue', '--workos'],
     },
 ];
-
-const colors = {
-    reset: '\x1b[0m',
-    blue: '\x1b[34m',
-    green: '\x1b[32m',
-    yellow: '\x1b[33m',
-    red: '\x1b[31m',
-};
-
-function log(message, color = 'reset') {
-    console.log(`${colors[color]}${message}${colors.reset}`);
-}
-
-function runCommand(command, args, options = {}) {
-    return new Promise((resolve, reject) => {
-        const child = spawn(command, args, {
-            stdio: 'inherit',
-            shell: true,
-            ...options,
-        });
-
-        child.on('close', code => {
-            if (code === 0) {
-                resolve();
-
-                return;
-            }
-
-            reject(new Error(`Command failed: ${command} ${args.join(' ')}`));
-        });
-
-        child.on('error', reject);
-    });
-}
 
 function removeBuildDirectory() {
     if (!fs.existsSync(buildDir)) {
         return;
     }
 
-    log('Removing existing build directory...', 'yellow');
     fs.rmSync(buildDir, { recursive: true, force: true });
 }
 
 async function lintCurrentBuild() {
-    await runCommand('composer', ['install'], { cwd: buildDir });
-    await runCommand('npm', ['install'], { cwd: buildDir });
-    await runCommand('npm', ['run', 'build'], { cwd: buildDir });
-    await runCommand('npm', ['run', 'lint'], { cwd: buildDir });
-    await runCommand('npm', ['run', 'format'], { cwd: buildDir });
-    await runCommand('npm', ['run', 'lint'], { cwd: buildDir });
-    await runCommand('npm', ['run', 'format'], { cwd: buildDir });
+    log('  Installing composer deps...', 'dim');
+    await runQuiet('composer', ['install'], { cwd: buildDir });
+
+    log('  Installing npm deps...', 'dim');
+    await runQuiet('npm', ['install'], { cwd: buildDir });
+
+    log('  Building frontend...', 'dim');
+    await runQuiet('npm', ['run', 'build'], { cwd: buildDir });
+
+    log('  Running lint pass 1...', 'dim');
+    await runQuiet('npm', ['run', 'lint'], { cwd: buildDir });
+
+    log('  Running format pass 1...', 'dim');
+    await runQuiet('npm', ['run', 'format'], { cwd: buildDir });
+
+    log('  Running lint pass 2...', 'dim');
+    await runQuiet('npm', ['run', 'lint'], { cwd: buildDir });
+
+    log('  Running format pass 2...', 'dim');
+    await runQuiet('npm', ['run', 'format'], { cwd: buildDir });
 }
 
 function runWatcherInitialSync() {
-    return runCommand('node', ['scripts/watch.js', '--initial-sync-only'], {
+    log('  Syncing changes back to kits...', 'dim');
+
+    return runQuiet('node', ['scripts/watch.js', '--initial-sync-only'], {
         cwd: orchestratorDir,
     });
 }
 
 async function lintVariant(variant, index, total) {
-    log(`\n[${index}/${total}] ${variant.display} (${variant.key})`, 'blue');
+    log(`\n[${index}/${total}] ${variant.display}`, 'blue');
 
     removeBuildDirectory();
 
-    log('Building variant...', 'blue');
-    await runCommand('php', ['artisan', ...variant.buildArgs], { cwd: orchestratorDir });
+    log('  Building variant...', 'dim');
+    await runQuiet('php', ['artisan', ...variant.buildArgs], { cwd: orchestratorDir });
 
-    log('Running frontend lint and format commands...', 'blue');
     await lintCurrentBuild();
-
-    log('Running watcher initial sync...', 'blue');
     await runWatcherInitialSync();
+}
 
-    log(`Finished ${variant.key}`, 'green');
+async function runPint() {
+    log('Running Pint on kits/ and browser_tests/...', 'blue');
+    await runInherit('pint', ['--parallel', '../kits'], { cwd: orchestratorDir });
+    await runInherit('pint', ['--parallel', '../browser_tests'], { cwd: orchestratorDir });
 }
 
 async function main() {
-    const total = variants.length;
+    const selected = parseFrameworkFlags(process.argv.slice(2));
+    const active = filterVariants(variants, selected);
 
-    for (let index = 0; index < total; index++) {
-        await lintVariant(variants[index], index + 1, total);
+    // Always run Pint first (it applies to all frameworks including Livewire).
+    await runPint();
+
+    // If only --livewire was selected, there are no Inertia variants to run.
+    if (active.length === 0) {
+        if (selected && selected.has('livewire') && selected.size === 1) {
+            log('Livewire has no frontend lint phase. Only the shared Pint step applies.', 'yellow');
+        } else {
+            log('No Inertia variants matched the selected framework flags.', 'yellow');
+        }
+
+        process.exit(0);
     }
 
-    log('\nAll Inertia kit variants linted successfully.', 'green');
+    if (selected) {
+        log(`Frameworks selected: ${[...selected].join(', ')}`, 'blue');
+    }
+
+    const total = active.length;
+    const results = [];
+
+    // Track skipped variants for summary
+    const skipped = variants.filter(v => !active.includes(v));
+
+    for (let index = 0; index < total; index++) {
+        const variant = active[index];
+        const start = Date.now();
+
+        try {
+            await lintVariant(variant, index + 1, total);
+            results.push({ key: variant.key, display: variant.display, status: 'passed', elapsed: Date.now() - start });
+            log(`  ${colors.green}✓ Finished${colors.reset}`);
+        } catch (error) {
+            results.push({ key: variant.key, display: variant.display, status: 'failed', elapsed: Date.now() - start });
+            log(`  ✗ Failed: ${error.message}`, 'red');
+
+            if (error.output) {
+                log('\n--- captured output ---', 'dim');
+                console.log(error.output);
+                log('--- end output ---\n', 'dim');
+            }
+        }
+    }
+
+    for (const s of skipped) {
+        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'framework not selected' });
+    }
+
+    printSummary('kits:lint', results);
+
+    removeBuildDirectory();
+
+    if (results.some(r => r.status === 'failed')) {
+        process.exit(1);
+    }
 }
 
 main().catch(error => {

--- a/orchestrator/scripts/run.js
+++ b/orchestrator/scripts/run.js
@@ -1,51 +1,8 @@
 #!/usr/bin/env node
 
-import { spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const orchestratorDir = path.dirname(__dirname);
-const rootDir = path.dirname(orchestratorDir);
-const buildDir = path.join(rootDir, 'build');
-
-const colors = {
-    reset: '\x1b[0m',
-    blue: '\x1b[34m',
-    green: '\x1b[32m',
-    red: '\x1b[31m',
-};
-
-function log(message, color = 'reset') {
-    console.log(`${colors[color]}${message}${colors.reset}`);
-}
-
-/**
- * Run a command and return a promise.
- */
-function runCommand(command, args, options = {}) {
-    return new Promise((resolve, reject) => {
-        const fullCommand = [command, ...args].join(' ');
-
-        const proc = spawn(fullCommand, [], {
-            stdio: 'inherit',
-            shell: true,
-            ...options,
-        });
-
-        proc.on('close', code => {
-            if (code === 0) {
-                resolve();
-            } else {
-                reject(new Error(`Command failed with code ${code}`));
-            }
-        });
-
-        proc.on('error', reject);
-    });
-}
+import { buildDir, log, orchestratorDir, runInherit } from './kit-helpers.js';
 
 function readEnvValue(envPath, key) {
     if (!fs.existsSync(envPath)) {
@@ -103,15 +60,13 @@ async function main() {
         process.exit(1);
     }
 
-    process.chdir(buildDir);
-
     log('Running composer setup...', 'blue');
-    await runCommand('composer', ['setup']);
+    await runInherit('composer', ['setup'], { cwd: buildDir });
 
     configureEnv();
 
     log('Starting development server...', 'green');
-    await runCommand('composer', ['dev']);
+    await runInherit('composer', ['dev'], { cwd: buildDir });
 }
 
 main().catch(error => {

--- a/orchestrator/scripts/run.js
+++ b/orchestrator/scripts/run.js
@@ -27,7 +27,9 @@ function log(message, color = 'reset') {
  */
 function runCommand(command, args, options = {}) {
     return new Promise((resolve, reject) => {
-        const proc = spawn(command, args, {
+        const fullCommand = [command, ...args].join(' ');
+
+        const proc = spawn(fullCommand, [], {
             stdio: 'inherit',
             shell: true,
             ...options,

--- a/orchestrator/scripts/watch.js
+++ b/orchestrator/scripts/watch.js
@@ -234,7 +234,7 @@ function fileNeedsSync(srcPath, destPath, processedContent) {
  * Perform initial sync of all files from build to kits.
  * This catches any changes that occurred while the watcher wasn't running.
  */
-function performInitialSync(folders, ig, kitType, uiComponents) {
+function performInitialSync(folders, ig, kitType, uiComponents, starterKit) {
     log('Performing initial sync to catch any missed changes...', 'blue');
 
     const allFiles = getAllFiles(buildDir);
@@ -248,8 +248,9 @@ function performInitialSync(folders, ig, kitType, uiComponents) {
             continue;
         }
 
-        const targetFolder = getTargetFolder(relativePath, folders);
-        const destPath = path.join(kitsDir, targetFolder, relativePath);
+        const destRelativePath = remapComponentsPath(relativePath, starterKit);
+        const targetFolder = getTargetFolder(destRelativePath, folders);
+        const destPath = path.join(kitsDir, targetFolder, destRelativePath);
         const processedContent = processFileContent(filePath, relativePath, targetFolder, kitType, uiComponents);
 
         if (isBlockedEmptyTextSync(relativePath, processedContent, destPath)) {
@@ -264,7 +265,10 @@ function performInitialSync(folders, ig, kitType, uiComponents) {
 
         try {
             writeToKit(filePath, destPath, processedContent);
-            log(`Synced: ${relativePath} -> kits/${targetFolder}`, 'green');
+            const syncLabel = destRelativePath !== relativePath
+                ? `${relativePath} (remapped to ${destRelativePath})`
+                : relativePath;
+            log(`Synced: ${syncLabel} -> kits/${targetFolder}`, 'green');
             syncedCount++;
         } catch (error) {
             log(`Error syncing ${relativePath}: ${error.message}`, 'red');
@@ -426,6 +430,35 @@ function isBlockedEmptyTextSync(relativePath, processedContent, destPath) {
 }
 
 /**
+ * Remap relocated paths for the livewire-components variant.
+ *
+ * The build process (relocateAuthViewsForComponents in BuildCommand.php) moves:
+ *   pages/settings/layout.blade.php  → components/settings/layout.blade.php
+ *   pages/auth/**                    → livewire/auth/**
+ *
+ * When syncing back to kits/ we need to reverse this so the file lands in
+ * its original source layer (Livewire/Base or Livewire/Fortify).
+ */
+function remapComponentsPath(relativePath, starterKit) {
+    if (starterKit !== 'livewire-components') {
+        return relativePath;
+    }
+
+    // components/settings/layout.blade.php → pages/settings/layout.blade.php
+    if (relativePath === normalizePath('resources/views/components/settings/layout.blade.php')) {
+        return 'resources/views/pages/settings/layout.blade.php';
+    }
+
+    // livewire/auth/** → pages/auth/**
+    const livewireAuthPrefix = normalizePath('resources/views/livewire/auth/');
+    if (relativePath.startsWith(livewireAuthPrefix)) {
+        return 'resources/views/pages/auth/' + relativePath.slice(livewireAuthPrefix.length);
+    }
+
+    return relativePath;
+}
+
+/**
  * Get the target kit folder for a file.
  * Returns the highest-priority folder that contains the file, or the highest-priority folder if not found.
  */
@@ -481,9 +514,10 @@ function writeToKit(srcPath, destPath, processedContent) {
  * Copy a file from build to the appropriate kit folder.
  * Restores placeholders for files in placeholder paths.
  */
-function copyToKit(srcPath, relativePath, folders, kitType, uiComponents) {
-    const targetFolder = getTargetFolder(relativePath, folders);
-    const destPath = path.join(kitsDir, targetFolder, relativePath);
+function copyToKit(srcPath, relativePath, folders, kitType, uiComponents, starterKit) {
+    const destRelativePath = remapComponentsPath(relativePath, starterKit);
+    const targetFolder = getTargetFolder(destRelativePath, folders);
+    const destPath = path.join(kitsDir, targetFolder, destRelativePath);
 
     try {
         const processedContent = processFileContent(srcPath, relativePath, targetFolder, kitType, uiComponents);
@@ -495,7 +529,10 @@ function copyToKit(srcPath, relativePath, folders, kitType, uiComponents) {
         }
 
         writeToKit(srcPath, destPath, processedContent);
-        log(`Copied: ${relativePath} -> kits/${targetFolder}`, 'green');
+        const copyLabel = destRelativePath !== relativePath
+            ? `${relativePath} (remapped to ${destRelativePath})`
+            : relativePath;
+        log(`Copied: ${copyLabel} -> kits/${targetFolder}`, 'green');
     } catch (error) {
         log(`Error copying ${relativePath}: ${error.message}`, 'red');
     }
@@ -504,30 +541,32 @@ function copyToKit(srcPath, relativePath, folders, kitType, uiComponents) {
 /**
  * Delete a file from the appropriate kit folder.
  */
-function deleteFromKit(relativePath, folders) {
+function deleteFromKit(relativePath, folders, starterKit) {
+    const destRelativePath = remapComponentsPath(relativePath, starterKit);
+
     // Find the highest-priority folder that has this file
-    const targetFolder = findSourceKitFolder(relativePath, folders);
+    const targetFolder = findSourceKitFolder(destRelativePath, folders);
 
     if (!targetFolder) {
         return;
     }
 
-    const targetPath = path.join(kitsDir, targetFolder, relativePath);
+    const targetPath = path.join(kitsDir, targetFolder, destRelativePath);
 
     try {
         if (fs.existsSync(targetPath)) {
             fs.unlinkSync(targetPath);
-            log(`Deleted: kits/${targetFolder}/${relativePath}`, 'yellow');
+            log(`Deleted: kits/${targetFolder}/${destRelativePath}`, 'yellow');
         }
     } catch (error) {
-        log(`Error deleting ${relativePath}: ${error.message}`, 'red');
+        log(`Error deleting ${destRelativePath}: ${error.message}`, 'red');
     }
 }
 
 /**
  * Handle file change events from the build directory.
  */
-function handleFileChange(eventType, filePath, folders, ig, kitType, uiComponents) {
+function handleFileChange(eventType, filePath, folders, ig, kitType, uiComponents, starterKit) {
     const relativePath = getRelativePath(filePath);
 
     // Skip files that match .gitignore patterns
@@ -536,12 +575,12 @@ function handleFileChange(eventType, filePath, folders, ig, kitType, uiComponent
     }
 
     if (eventType === 'unlink') {
-        deleteFromKit(relativePath, folders);
+        deleteFromKit(relativePath, folders, starterKit);
 
         return;
     }
 
-    copyToKit(filePath, relativePath, folders, kitType, uiComponents);
+    copyToKit(filePath, relativePath, folders, kitType, uiComponents, starterKit);
 }
 
 function startWatching() {
@@ -578,7 +617,7 @@ function startWatching() {
     const ig = loadGitignores();
 
     // Perform initial sync to catch any changes that occurred while watcher wasn't running
-    performInitialSync(folders, ig, kitType, uiComponents);
+    performInitialSync(folders, ig, kitType, uiComponents, starterKit);
 
     if (initialSyncOnly) {
         log('Initial sync only mode enabled. Exiting without starting watcher.', 'blue');
@@ -593,9 +632,9 @@ function startWatching() {
     });
 
     watcher
-        .on('add', filePath => handleFileChange('add', filePath, folders, ig, kitType, uiComponents))
-        .on('change', filePath => handleFileChange('change', filePath, folders, ig, kitType, uiComponents))
-        .on('unlink', filePath => handleFileChange('unlink', filePath, folders, ig, kitType, uiComponents))
+        .on('add', filePath => handleFileChange('add', filePath, folders, ig, kitType, uiComponents, starterKit))
+        .on('change', filePath => handleFileChange('change', filePath, folders, ig, kitType, uiComponents, starterKit))
+        .on('unlink', filePath => handleFileChange('unlink', filePath, folders, ig, kitType, uiComponents, starterKit))
         .on('ready', () => {
             log('Watcher ready. Waiting for changes in build directory...', 'green');
         })

--- a/orchestrator/scripts/watch.js
+++ b/orchestrator/scripts/watch.js
@@ -14,6 +14,7 @@ const kitsDir = path.join(rootDir, 'kits');
 const buildDir = path.join(rootDir, 'build');
 const starterKitFile = path.join(orchestratorDir, 'storage', 'app', 'private', 'starter_kit');
 const uiComponentsFile = path.join(__dirname, 'ui-components.json');
+const manifestFile = path.join(__dirname, 'kit-manifest.json');
 const args = process.argv.slice(2);
 const initialSyncOnly = args.includes('--initial-sync-only');
 
@@ -32,33 +33,11 @@ function log(message, color = 'reset') {
 }
 
 /**
- * Kit folder mapping based on starter kit value.
- * Folders are listed in priority order (lowest to highest).
- * Higher priority folders override lower priority ones.
- * Shared folders contain files common to both Livewire and Inertia kits.
+ * Load the shared kit manifest.
  */
-const kitFolderMap = {
-    // Livewire variants
-    'livewire-blank': ['Shared/Blank', 'Livewire/Blank'],
-    'livewire': ['Shared/Blank', 'Livewire/Blank', 'Shared/Base', 'Livewire/Base', 'Shared/Fortify', 'Livewire/Fortify'],
-    'livewire-components': ['Shared/Blank', 'Livewire/Blank', 'Shared/Base', 'Livewire/Base', 'Shared/Fortify', 'Livewire/Fortify', 'Livewire/Components'],
-    'livewire-workos': ['Shared/Blank', 'Livewire/Blank', 'Shared/Base', 'Livewire/Base', 'Shared/WorkOS', 'Livewire/WorkOS'],
-
-    // React variants
-    'react-blank': ['Shared/Blank', 'Inertia/Blank/Base', 'Inertia/Blank/React'],
-    'react': ['Shared/Blank', 'Inertia/Blank/Base', 'Inertia/Blank/React', 'Shared/Base', 'Inertia/Base', 'Inertia/React', 'Shared/Fortify', 'Inertia/Fortify/Base', 'Inertia/Fortify/React'],
-    'react-workos': ['Shared/Blank', 'Inertia/Blank/Base', 'Inertia/Blank/React', 'Shared/Base', 'Inertia/Base', 'Inertia/React', 'Shared/WorkOS', 'Inertia/WorkOS/Base', 'Inertia/WorkOS/React'],
-
-    // Svelte variants
-    'svelte-blank': ['Shared/Blank', 'Inertia/Blank/Base', 'Inertia/Blank/Svelte'],
-    'svelte': ['Shared/Blank', 'Inertia/Blank/Base', 'Inertia/Blank/Svelte', 'Shared/Base', 'Inertia/Base', 'Inertia/Svelte', 'Shared/Fortify', 'Inertia/Fortify/Base', 'Inertia/Fortify/Svelte'],
-    'svelte-workos': ['Shared/Blank', 'Inertia/Blank/Base', 'Inertia/Blank/Svelte', 'Shared/Base', 'Inertia/Base', 'Inertia/Svelte', 'Shared/WorkOS', 'Inertia/WorkOS/Base', 'Inertia/WorkOS/Svelte'],
-
-    // Vue variants
-    'vue-blank': ['Shared/Blank', 'Inertia/Blank/Base', 'Inertia/Blank/Vue'],
-    'vue': ['Shared/Blank', 'Inertia/Blank/Base', 'Inertia/Blank/Vue', 'Shared/Base', 'Inertia/Base', 'Inertia/Vue', 'Shared/Fortify', 'Inertia/Fortify/Base', 'Inertia/Fortify/Vue'],
-    'vue-workos': ['Shared/Blank', 'Inertia/Blank/Base', 'Inertia/Blank/Vue', 'Shared/Base', 'Inertia/Base', 'Inertia/Vue', 'Shared/WorkOS', 'Inertia/WorkOS/Base', 'Inertia/WorkOS/Vue'],
-};
+function loadManifest() {
+    return JSON.parse(fs.readFileSync(manifestFile, 'utf-8'));
+}
 
 /**
  * Load UI components mapping from the JSON configuration file.
@@ -68,17 +47,6 @@ function loadUiComponents() {
 
     return JSON.parse(content);
 }
-
-/**
- * Paths (relative to build) where placeholders should be restored.
- * These match the searchPaths in BuildCommand.php replacePlaceholders method.
- */
-const placeholderPaths = [
-    'app/Http/Controllers',
-    'app/Providers',
-    'routes',
-    'tests',
-];
 
 const allowedEmptyTextFiles = new Set([
     'resources/js/app.js',
@@ -102,7 +70,7 @@ function getKitType(starterKit) {
     return null;
 }
 
-function shouldRestorePlaceholders(relativePath) {
+function shouldRestorePlaceholders(relativePath, placeholderPaths) {
     return placeholderPaths.some(p => relativePath.startsWith(p));
 }
 
@@ -231,14 +199,41 @@ function fileNeedsSync(srcPath, destPath, processedContent) {
 }
 
 /**
+ * Collect all file paths across the active layer set for the current starter kit.
+ * Returns a Set of relative paths (posix-style) that should exist in kits/.
+ */
+function collectKitFiles(folders) {
+    const files = new Set();
+
+    for (const folder of folders) {
+        const folderPath = path.join(kitsDir, folder);
+
+        if (!fs.existsSync(folderPath)) {
+            continue;
+        }
+
+        for (const file of getAllFiles(folderPath)) {
+            files.add(path.relative(folderPath, file).replace(/\\/g, '/'));
+        }
+    }
+
+    return files;
+}
+
+/**
  * Perform initial sync of all files from build to kits.
  * This catches any changes that occurred while the watcher wasn't running.
+ * When reconcile is true, also removes stale files in kits/ that no longer
+ * exist in the built tree.
  */
-function performInitialSync(folders, ig, kitType, uiComponents, starterKit) {
+function performInitialSync(folders, ig, kitType, uiComponents, starterKit, manifest, reconcile = true) {
     log('Performing initial sync to catch any missed changes...', 'blue');
 
     const allFiles = getAllFiles(buildDir);
     let syncedCount = 0;
+
+    // Track which kit-relative paths exist in the build so we can reconcile.
+    const buildRelPaths = new Set();
 
     for (const filePath of allFiles) {
         const relativePath = getRelativePath(filePath);
@@ -248,10 +243,12 @@ function performInitialSync(folders, ig, kitType, uiComponents, starterKit) {
             continue;
         }
 
-        const destRelativePath = remapComponentsPath(relativePath, starterKit);
+        const destRelativePath = remapComponentsPath(relativePath, starterKit, manifest);
+        buildRelPaths.add(destRelativePath);
+
         const targetFolder = getTargetFolder(destRelativePath, folders);
         const destPath = path.join(kitsDir, targetFolder, destRelativePath);
-        const processedContent = processFileContent(filePath, relativePath, targetFolder, kitType, uiComponents);
+        const processedContent = processFileContent(filePath, relativePath, targetFolder, kitType, uiComponents, manifest);
 
         if (isBlockedEmptyTextSync(relativePath, processedContent, destPath)) {
             log(`Blocked empty file sync: ${relativePath} -> kits/${targetFolder}`, 'red');
@@ -277,11 +274,84 @@ function performInitialSync(folders, ig, kitType, uiComponents, starterKit) {
 
     if (syncedCount > 0) {
         log(`Initial sync complete: ${syncedCount} file(s) updated`, 'green');
-
-        return;
+    } else {
+        log('Initial sync complete: all files up to date', 'green');
     }
 
-    log('Initial sync complete: all files up to date', 'green');
+    // Reconcile stale files that exist in kits/ but not in the build.
+    if (reconcile) {
+        reconcileStaleFiles(folders, buildRelPaths, ig);
+    }
+}
+
+/**
+ * Remove files from kits/ that no longer exist in the build output.
+ * Only operates within the active layer set for the current starter kit.
+ */
+function reconcileStaleFiles(folders, buildRelPaths, ig) {
+    const kitFiles = collectKitFiles(folders);
+    let removedCount = 0;
+
+    for (const relPath of kitFiles) {
+        // If the file exists in the build output, keep it.
+        if (buildRelPaths.has(relPath)) {
+            continue;
+        }
+
+        // If the file would be ignored by .gitignore, skip it.
+        if (ig.ignores(relPath)) {
+            continue;
+        }
+
+        // Find which layer owns this file and remove it.
+        for (let i = folders.length - 1; i >= 0; i--) {
+            const candidate = path.join(kitsDir, folders[i], relPath);
+
+            if (!fs.existsSync(candidate)) {
+                continue;
+            }
+
+            try {
+                fs.unlinkSync(candidate);
+                log(`Reconciled (removed stale): kits/${folders[i]}/${relPath}`, 'yellow');
+                removedCount++;
+
+                // Clean up empty parent directories.
+                removeEmptyParents(path.dirname(candidate), path.join(kitsDir, folders[i]));
+            } catch (error) {
+                log(`Error removing stale file ${relPath}: ${error.message}`, 'red');
+            }
+        }
+    }
+
+    if (removedCount > 0) {
+        log(`Reconciliation complete: ${removedCount} stale file(s) removed`, 'yellow');
+    } else {
+        log('Reconciliation complete: no stale files found', 'green');
+    }
+}
+
+/**
+ * Remove empty directories upward until `stopAt` is reached.
+ */
+function removeEmptyParents(dir, stopAt) {
+    let current = dir;
+
+    while (current !== stopAt && current.startsWith(stopAt)) {
+        try {
+            const entries = fs.readdirSync(current);
+
+            if (entries.length > 0) {
+                break;
+            }
+
+            fs.rmdirSync(current);
+        } catch {
+            break;
+        }
+
+        current = path.dirname(current);
+    }
 }
 
 /**
@@ -433,26 +503,36 @@ function isBlockedEmptyTextSync(relativePath, processedContent, destPath) {
  * Remap relocated paths for the livewire-components variant.
  *
  * The build process (relocateAuthViewsForComponents in BuildCommand.php) moves:
- *   pages/settings/layout.blade.php  → components/settings/layout.blade.php
- *   pages/auth/**                    → livewire/auth/**
+ *   pages/settings/layout.blade.php  -> components/settings/layout.blade.php
+ *   pages/auth/**                    -> livewire/auth/**
  *
  * When syncing back to kits/ we need to reverse this so the file lands in
  * its original source layer (Livewire/Base or Livewire/Fortify).
+ *
+ * Uses componentsRelocations from the shared manifest.
  */
-function remapComponentsPath(relativePath, starterKit) {
+function remapComponentsPath(relativePath, starterKit, manifest) {
     if (starterKit !== 'livewire-components') {
         return relativePath;
     }
 
-    // components/settings/layout.blade.php → pages/settings/layout.blade.php
-    if (relativePath === normalizePath('resources/views/components/settings/layout.blade.php')) {
-        return 'resources/views/pages/settings/layout.blade.php';
-    }
+    const normalized = normalizePath(relativePath);
 
-    // livewire/auth/** → pages/auth/**
-    const livewireAuthPrefix = normalizePath('resources/views/livewire/auth/');
-    if (relativePath.startsWith(livewireAuthPrefix)) {
-        return 'resources/views/pages/auth/' + relativePath.slice(livewireAuthPrefix.length);
+    for (const rule of manifest.componentsRelocations) {
+        const toNorm = normalizePath(rule.to);
+        const fromNorm = normalizePath(rule.from);
+
+        if (rule.directory) {
+            // Directory prefix match: livewire/auth/** -> pages/auth/**
+            if (normalized.startsWith(toNorm)) {
+                return fromNorm + normalized.slice(toNorm.length);
+            }
+        } else {
+            // Exact file match
+            if (normalized === toNorm) {
+                return fromNorm;
+            }
+        }
     }
 
     return relativePath;
@@ -470,7 +550,7 @@ function getTargetFolder(relativePath, folders) {
  * Process file content, applying placeholder restoration if needed.
  * Returns the processed content for text files, or null for binary files.
  */
-function processFileContent(srcPath, relativePath, targetFolder, kitType, uiComponents) {
+function processFileContent(srcPath, relativePath, targetFolder, kitType, uiComponents, manifest) {
     if (!isTextFile(relativePath)) {
         return null;
     }
@@ -478,7 +558,7 @@ function processFileContent(srcPath, relativePath, targetFolder, kitType, uiComp
     let content = fs.readFileSync(srcPath, 'utf-8');
 
     // Apply placeholder restoration for specific paths
-    if (kitType && shouldRestorePlaceholders(relativePath)) {
+    if (kitType && shouldRestorePlaceholders(relativePath, manifest.placeholderSearchPaths)) {
         content = restorePlaceholders(content, kitType, uiComponents);
     }
 
@@ -514,13 +594,13 @@ function writeToKit(srcPath, destPath, processedContent) {
  * Copy a file from build to the appropriate kit folder.
  * Restores placeholders for files in placeholder paths.
  */
-function copyToKit(srcPath, relativePath, folders, kitType, uiComponents, starterKit) {
-    const destRelativePath = remapComponentsPath(relativePath, starterKit);
+function copyToKit(srcPath, relativePath, folders, kitType, uiComponents, starterKit, manifest) {
+    const destRelativePath = remapComponentsPath(relativePath, starterKit, manifest);
     const targetFolder = getTargetFolder(destRelativePath, folders);
     const destPath = path.join(kitsDir, targetFolder, destRelativePath);
 
     try {
-        const processedContent = processFileContent(srcPath, relativePath, targetFolder, kitType, uiComponents);
+        const processedContent = processFileContent(srcPath, relativePath, targetFolder, kitType, uiComponents, manifest);
 
         if (isBlockedEmptyTextSync(relativePath, processedContent, destPath)) {
             log(`Blocked empty file sync: ${relativePath} -> kits/${targetFolder}`, 'red');
@@ -541,8 +621,8 @@ function copyToKit(srcPath, relativePath, folders, kitType, uiComponents, starte
 /**
  * Delete a file from the appropriate kit folder.
  */
-function deleteFromKit(relativePath, folders, starterKit) {
-    const destRelativePath = remapComponentsPath(relativePath, starterKit);
+function deleteFromKit(relativePath, folders, starterKit, manifest) {
+    const destRelativePath = remapComponentsPath(relativePath, starterKit, manifest);
 
     // Find the highest-priority folder that has this file
     const targetFolder = findSourceKitFolder(destRelativePath, folders);
@@ -557,6 +637,9 @@ function deleteFromKit(relativePath, folders, starterKit) {
         if (fs.existsSync(targetPath)) {
             fs.unlinkSync(targetPath);
             log(`Deleted: kits/${targetFolder}/${destRelativePath}`, 'yellow');
+
+            // Clean up empty parent directories.
+            removeEmptyParents(path.dirname(targetPath), path.join(kitsDir, targetFolder));
         }
     } catch (error) {
         log(`Error deleting ${destRelativePath}: ${error.message}`, 'red');
@@ -564,9 +647,33 @@ function deleteFromKit(relativePath, folders, starterKit) {
 }
 
 /**
+ * Delete a directory and its contents from the appropriate kit folder(s).
+ */
+function deleteDirFromKit(relativePath, folders, starterKit, manifest) {
+    const destRelativePath = remapComponentsPath(relativePath, starterKit, manifest);
+
+    for (let i = folders.length - 1; i >= 0; i--) {
+        const targetDir = path.join(kitsDir, folders[i], destRelativePath);
+
+        if (!fs.existsSync(targetDir)) {
+            continue;
+        }
+
+        try {
+            fs.rmSync(targetDir, { recursive: true, force: true });
+            log(`Deleted directory: kits/${folders[i]}/${destRelativePath}`, 'yellow');
+
+            removeEmptyParents(path.dirname(targetDir), path.join(kitsDir, folders[i]));
+        } catch (error) {
+            log(`Error deleting directory ${destRelativePath}: ${error.message}`, 'red');
+        }
+    }
+}
+
+/**
  * Handle file change events from the build directory.
  */
-function handleFileChange(eventType, filePath, folders, ig, kitType, uiComponents, starterKit) {
+function handleFileChange(eventType, filePath, folders, ig, kitType, uiComponents, starterKit, manifest) {
     const relativePath = getRelativePath(filePath);
 
     // Skip files that match .gitignore patterns
@@ -575,12 +682,18 @@ function handleFileChange(eventType, filePath, folders, ig, kitType, uiComponent
     }
 
     if (eventType === 'unlink') {
-        deleteFromKit(relativePath, folders, starterKit);
+        deleteFromKit(relativePath, folders, starterKit, manifest);
 
         return;
     }
 
-    copyToKit(filePath, relativePath, folders, kitType, uiComponents, starterKit);
+    if (eventType === 'unlinkDir') {
+        deleteDirFromKit(relativePath, folders, starterKit, manifest);
+
+        return;
+    }
+
+    copyToKit(filePath, relativePath, folders, kitType, uiComponents, starterKit, manifest);
 }
 
 function startWatching() {
@@ -591,7 +704,8 @@ function startWatching() {
         process.exit(1);
     }
 
-    const folders = kitFolderMap[starterKit];
+    const manifest = loadManifest();
+    const folders = manifest.kitFolderMap[starterKit];
 
     if (!folders) {
         log(`Unknown starter kit: ${starterKit}`, 'red');
@@ -617,7 +731,7 @@ function startWatching() {
     const ig = loadGitignores();
 
     // Perform initial sync to catch any changes that occurred while watcher wasn't running
-    performInitialSync(folders, ig, kitType, uiComponents, starterKit);
+    performInitialSync(folders, ig, kitType, uiComponents, starterKit, manifest);
 
     if (initialSyncOnly) {
         log('Initial sync only mode enabled. Exiting without starting watcher.', 'blue');
@@ -632,9 +746,10 @@ function startWatching() {
     });
 
     watcher
-        .on('add', filePath => handleFileChange('add', filePath, folders, ig, kitType, uiComponents, starterKit))
-        .on('change', filePath => handleFileChange('change', filePath, folders, ig, kitType, uiComponents, starterKit))
-        .on('unlink', filePath => handleFileChange('unlink', filePath, folders, ig, kitType, uiComponents, starterKit))
+        .on('add', filePath => handleFileChange('add', filePath, folders, ig, kitType, uiComponents, starterKit, manifest))
+        .on('change', filePath => handleFileChange('change', filePath, folders, ig, kitType, uiComponents, starterKit, manifest))
+        .on('unlink', filePath => handleFileChange('unlink', filePath, folders, ig, kitType, uiComponents, starterKit, manifest))
+        .on('unlinkDir', filePath => handleFileChange('unlinkDir', filePath, folders, ig, kitType, uiComponents, starterKit, manifest))
         .on('ready', () => {
             log('Watcher ready. Waiting for changes in build directory...', 'green');
         })


### PR DESCRIPTION
The orchestrator scripts had significant duplication across the three matrix runners (check, lint, browser-tests), duplicated source-of-truth data between BuildCommand.php and watch.js, no validation of CLI flags, and no stale-file cleanup in the watcher.

### Approach

- Extract a shared `runMatrix()` helper and common path constants into `kit-helpers.js`, eliminating the duplicated loop/timing/summary/exit logic from all three matrix scripts
- Harden `parseFrameworkFlags()` to reject unknown `--*` flags with a clear error instead of silently running the full matrix
- Fix `runQuiet`/`runInherit` to use spawn args arrays instead of shell string joining (resolves Node DEP0190 warnings)
- Introduce `kit-manifest.json` as a single source of truth for placeholder search paths, components relocation rules, and kit-folder mappings — consumed by both PHP and Node
- Add stale-file reconciliation and `unlinkDir` handling to the watcher so startup sync removes files from `kits/` that no longer exist in the build
- Refactor `run.js` onto the shared helper layer, removing its duplicated color/log/process runner
- Add selective framework execution (`--react`, `--vue`, etc.) and quiet output mode to all matrix scripts
- Stabilize browser tests with middleware bypass instead of UI navigation