### PR TITLE
Fix SSR window reference error in current URL hooks

### DIFF
--- a/kits/Inertia/React/resources/js/hooks/use-current-url.ts
+++ b/kits/Inertia/React/resources/js/hooks/use-current-url.ts
@@ -28,7 +28,12 @@ export type UseCurrentUrlReturn = {
 
 export function useCurrentUrl(): UseCurrentUrlReturn {
     const page = usePage();
-    const currentUrlPath = new URL(page.url, window?.location.origin).pathname;
+    const currentUrlPath = new URL(
+        page.url,
+        typeof window !== 'undefined'
+            ? window.location.origin
+            : 'http://localhost',
+    ).pathname;
 
     const isCurrentUrl: IsCurrentUrlFn = (
         urlToCheck: NonNullable<InertiaLinkProps['href']>,

--- a/kits/Inertia/Vue/resources/js/composables/useCurrentUrl.ts
+++ b/kits/Inertia/Vue/resources/js/composables/useCurrentUrl.ts
@@ -24,7 +24,13 @@ export type UseCurrentUrlReturn = {
 
 const page = usePage();
 const currentUrlReactive = computed(
-    () => new URL(page.url, window?.location.origin).pathname,
+    () =>
+        new URL(
+            page.url,
+            typeof window !== 'undefined'
+                ? window.location.origin
+                : 'http://localhost',
+        ).pathname,
 );
 
 export function useCurrentUrl(): UseCurrentUrlReturn {


### PR DESCRIPTION
When SSR is running, `window?.location.origin` throws a `ReferenceError` because `window` is an undeclared variable — optional chaining only guards against `null`/`undefined`, not undeclared globals. The Svelte kit already handled this correctly.

Ref: laravel/react-starter-kit#295

### Approach

- Replace `window?.location.origin` with a `typeof window !== 'undefined'` guard in the React and Vue current URL hooks, falling back to `'http://localhost'` during SSR since only the pathname is needed