### PR TITLE
Update Vite ecosystem to v8 across all starter kits

### DIFF
--- a/kits/Inertia/Blank/React/package.json
+++ b/kits/Inertia/Blank/React/package.json
@@ -33,7 +33,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
-        "@vitejs/plugin-react": "^6.0.0",
+        "@vitejs/plugin-react": "^5.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",

--- a/kits/Inertia/Blank/React/package.json
+++ b/kits/Inertia/Blank/React/package.json
@@ -33,18 +33,18 @@
         "@tailwindcss/vite": "^4.1.11",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
-        "@vitejs/plugin-react": "^5.0.0",
+        "@vitejs/plugin-react": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
         "globals": "^15.14.0",
-        "laravel-vite-plugin": "^2.0",
+        "laravel-vite-plugin": "^3.0.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tailwind-merge": "^3.0.1",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.2",
-        "vite": "^7.0.4"
+        "vite": "^8.0.0"
     },
     "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.9.5",

--- a/kits/Inertia/Blank/React/vite.config.ts
+++ b/kits/Inertia/Blank/React/vite.config.ts
@@ -21,7 +21,4 @@ export default defineConfig({
             formVariants: true,
         }),
     ],
-    esbuild: {
-        jsx: 'automatic',
-    },
 });

--- a/kits/Inertia/Blank/Svelte/package.json
+++ b/kits/Inertia/Blank/Svelte/package.json
@@ -30,17 +30,17 @@
     },
     "dependencies": {
         "@inertiajs/svelte": "^2.0.0",
-        "@sveltejs/vite-plugin-svelte": "^6.0.0",
+        "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tailwindcss/vite": "^4.1.11",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
-        "laravel-vite-plugin": "^2.0.0",
+        "laravel-vite-plugin": "^3.0.0",
         "svelte": "^5.16.0",
         "tailwind-merge": "^3.2.0",
         "tailwindcss": "^4.1.1",
         "typescript": "^5.7.2",
-        "vite": "^7.0.4"
+        "vite": "^8.0.0"
     },
     "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.9.5",

--- a/kits/Inertia/Blank/Vue/package.json
+++ b/kits/Inertia/Blank/Vue/package.json
@@ -36,11 +36,11 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
-        "laravel-vite-plugin": "^2.0.0",
+        "laravel-vite-plugin": "^3.0.0",
         "tailwind-merge": "^3.2.0",
         "tailwindcss": "^4.1.1",
         "typescript": "^5.2.2",
-        "vite": "^7.0.4",
+        "vite": "^8.0.0",
         "vue": "^3.5.13"
     },
     "optionalDependencies": {

--- a/kits/Inertia/React/package.json
+++ b/kits/Inertia/React/package.json
@@ -47,7 +47,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
-        "@vitejs/plugin-react": "^6.0.0",
+        "@vitejs/plugin-react": "^5.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",

--- a/kits/Inertia/React/package.json
+++ b/kits/Inertia/React/package.json
@@ -47,13 +47,13 @@
         "@tailwindcss/vite": "^4.1.11",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
-        "@vitejs/plugin-react": "^5.0.0",
+        "@vitejs/plugin-react": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
         "globals": "^15.14.0",
         "input-otp": "^1.4.2",
-        "laravel-vite-plugin": "^2.0",
+        "laravel-vite-plugin": "^3.0.0",
         "lucide-react": "^0.475.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -61,7 +61,7 @@
         "tailwindcss": "^4.0.0",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.7.2",
-        "vite": "^7.0.4"
+        "vite": "^8.0.0"
     },
     "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.9.5",

--- a/kits/Inertia/Svelte/package.json
+++ b/kits/Inertia/Svelte/package.json
@@ -30,15 +30,15 @@
         "svelte-check": "^4.1.4",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.23.0",
-        "vite": "^7.0.4"
+        "vite": "^8.0.0"
     },
     "dependencies": {
         "@inertiajs/svelte": "^2.0.0",
-        "@sveltejs/vite-plugin-svelte": "^6.0.0",
+        "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "bits-ui": "^2.15.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "laravel-vite-plugin": "^2.0.0",
+        "laravel-vite-plugin": "^3.0.0",
         "lucide-svelte": "^0.468.0",
         "svelte": "^5.16.0",
         "tailwind-merge": "^3.2.0",

--- a/kits/Inertia/Vue/package.json
+++ b/kits/Inertia/Vue/package.json
@@ -30,7 +30,7 @@
         "prettier-plugin-tailwindcss": "^0.6.11",
         "typescript": "^5.2.2",
         "typescript-eslint": "^8.23.0",
-        "vite": "^7.0.4",
+        "vite": "^8.0.0",
         "vue-tsc": "^2.2.4"
     },
     "dependencies": {
@@ -38,7 +38,7 @@
         "@vueuse/core": "^12.8.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "laravel-vite-plugin": "^2.0.0",
+        "laravel-vite-plugin": "^3.0.0",
         "lucide-vue-next": "^0.468.0",
         "reka-ui": "^2.6.1",
         "tailwind-merge": "^3.2.0",

--- a/kits/Inertia/WorkOS/Vue/package.json
+++ b/kits/Inertia/WorkOS/Vue/package.json
@@ -30,7 +30,7 @@
         "prettier-plugin-tailwindcss": "^0.6.11",
         "typescript": "^5.2.2",
         "typescript-eslint": "^8.23.0",
-        "vite": "^7.0.4",
+        "vite": "^8.0.0",
         "vue-tsc": "^2.2.4"
     },
     "dependencies": {
@@ -38,7 +38,7 @@
         "@vueuse/core": "^12.8.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "laravel-vite-plugin": "^2.0.0",
+        "laravel-vite-plugin": "^3.0.0",
         "lucide-vue-next": "^0.468.0",
         "reka-ui": "^2.6.1",
         "tailwind-merge": "^3.2.0",

--- a/kits/Livewire/Blank/package.json
+++ b/kits/Livewire/Blank/package.json
@@ -11,9 +11,9 @@
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.4",
         "concurrently": "^9.0.1",
-        "laravel-vite-plugin": "^2.0",
+        "laravel-vite-plugin": "^3.0.0",
         "tailwindcss": "^4.0.7",
-        "vite": "^7.0.4"
+        "vite": "^8.0.0"
     },
     "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.9.5",

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -13,8 +13,8 @@
         "chokidar": "^4.0.0",
         "concurrently": "^9.0.1",
         "ignore": "^7.0.0",
-        "laravel-vite-plugin": "^2.0.0",
+        "laravel-vite-plugin": "^3.0.0",
         "tailwindcss": "^4.0.0",
-        "vite": "^7.0.7"
+        "vite": "^8.0.0"
     }
 }


### PR DESCRIPTION
Brings the Vite 8 and laravel-vite-plugin 3 upgrades from [laravel/laravel v13.1.0](https://github.com/laravel/laravel/compare/v13.0.0...v13.1.0) to all starter kits.

### Approach

- Bumped `vite` from ^7 to ^8 and `laravel-vite-plugin` from ^2 to ^3 across all 13 kit variants and the orchestrator
- Bumped `@sveltejs/vite-plugin-svelte` from ^6 to ^7 to satisfy Vite 8 peer dependency requirements
- Kept `@vitejs/plugin-react` at ^5.2.0 (not ^6) — v6 uses Vite 8's OXC-based JSX transform which causes an infinite update loop in `@radix-ui/react-compose-refs` with React 19's ref cleanup mechanism. v5.2.0 supports Vite 8 without this issue.
- Removed the now-unnecessary `esbuild: { jsx: 'automatic' }` from the React vite config