### PR TITLE
Improve CI workflows: PHP version matrix and Playwright caching

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -76,7 +76,7 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('build/package-lock.json') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('orchestrator/composer.lock') }}
 
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,13 @@ permissions:
 
 jobs:
   tests:
-    name: ${{ matrix.name }}
+    name: ${{ matrix.name }} (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
+        php: ['8.3', '8.4', '8.5']
         include:
           # Livewire variants
           - name: Livewire Kit (Blank)
@@ -107,7 +108,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
           coverage: none
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,20 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.3', '8.4', '8.5']
+        name:
+          - Livewire Kit (Blank)
+          - Livewire Kit
+          - Livewire Kit (Components)
+          - Livewire Kit (WorkOS)
+          - React Kit (Blank)
+          - React Kit
+          - React Kit (WorkOS)
+          - Svelte Kit (Blank)
+          - Svelte Kit
+          - Svelte Kit (WorkOS)
+          - Vue Kit (Blank)
+          - Vue Kit
+          - Vue Kit (WorkOS)
         include:
           # Livewire variants
           - name: Livewire Kit (Blank)
@@ -105,10 +119,10 @@ jobs:
       - name: Checkout Maestro
         uses: actions/checkout@v6
 
-      - name: Setup PHP
+      - name: Setup PHP for Orchestrator
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -128,6 +142,13 @@ jobs:
 
       - name: Rename Build
         run: mv build ${{ matrix.path }}
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
+          coverage: none
 
       - name: Setup Kit
         working-directory: ${{ matrix.path }}


### PR DESCRIPTION
The CI test workflow was hardcoded to PHP 8.4, but the starter kits support PHP 8.3, 8.4, and 8.5. Additionally, the browser tests workflow had a Playwright cache that never hit.

### Approach

- Add a PHP version matrix (`8.3`, `8.4`, `8.5`) to the test workflow, producing 13 kits × 3 PHP versions = 39 parallel jobs
- Pin the orchestrator build step to PHP 8.4 (its lockfile requires Symfony 8.x), then switch to the matrix PHP version for the kit's CI checks
- Fix the Playwright browser cache key in the browser tests workflow — it was using `build/package-lock.json` which is regenerated fresh each run, so the cache never hit. Now uses `orchestrator/composer.lock` which is stable across runs and determines the Playwright version via `pest-plugin-browser`