### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -42,7 +42,7 @@ jobs:
           coverage: none
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -72,7 +72,7 @@ jobs:
         run: npm install playwright
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Setup Node.js
         if: matrix.node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/kits/Inertia/Blank/Base/.github/workflows/tests.yml
+++ b/kits/Inertia/Blank/Base/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
           coverage: xdebug
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/kits/Livewire/Blank/.github/workflows/tests.yml
+++ b/kits/Livewire/Blank/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           coverage: xdebug
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 


### PR DESCRIPTION
Bump `actions/setup-node` from v4 to v6 and `actions/cache` from v4 to v5 across all workflow files. The remaining actions (`actions/checkout@v6`, `shivammathur/setup-php@v2`, `actions/github-script@v8`) were already at their latest major versions.

### Approach

- Audited all 7 workflow files across `.github/workflows/`, `kits/Livewire/Blank/.github/workflows/`, and `kits/Inertia/Blank/Base/.github/workflows/`
- Updated only the actions that were behind their latest major version