### PR TITLE
Fix push-kit-changes workflow permission error

### DIFF
--- a/.github/scripts/get-merged-pr-info.js
+++ b/.github/scripts/get-merged-pr-info.js
@@ -5,13 +5,19 @@ module.exports = async ({ github, context, core }) => {
     const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
     const findMergedPr = async () => {
-        const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            commit_sha: context.sha,
-        });
+        try {
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+            });
 
-        return prs.find((pr) => pr.merged_at);
+            return prs.find((pr) => pr.merged_at) || null;
+        } catch (error) {
+            core.warning(`API request failed: ${error.message}`);
+
+            return null;
+        }
     };
 
     let mergedPr = null;

--- a/.github/workflows/push-kit-changes.yml
+++ b/.github/workflows/push-kit-changes.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   build:


### PR DESCRIPTION
The push-kit-changes workflow has been failing on every run with a 403 "Resource not accessible by integration" error at the "Get Merged PR Information" step.

The `listPullRequestsAssociatedWithCommit` API endpoint requires `pull_requests: read` permission, but the workflow only declared `contents: read`.

### Approach

- Add the missing `pull-requests: read` permission to the workflow
- Wrap the API call in a try/catch so the existing retry loop and fallback commit title ("Update from Maestro") work correctly when the request fails, instead of crashing the entire step