### PR TITLE
Include PR co-authors in starter kit commits

### DIFF
--- a/.github/scripts/get-merged-pr-info.js
+++ b/.github/scripts/get-merged-pr-info.js
@@ -44,6 +44,7 @@ module.exports = async ({ github, context, core }) => {
         core.setOutput('found', 'false');
         core.setOutput('author', '');
         core.setOutput('author_email', '');
+        core.setOutput('co_authors', '');
 
         return;
     }
@@ -55,16 +56,65 @@ module.exports = async ({ github, context, core }) => {
     core.setOutput('url', mergedPr.html_url);
     core.setOutput('found', 'true');
 
-    const fallbackEmail = `${mergedPr.user.id}+${mergedPr.user.login}@users.noreply.github.com`;
+    const resolveEmail = async (username, userId) => {
+        const fallback = `${userId}+${username}@users.noreply.github.com`;
+        try {
+            const { data: user } = await github.rest.users.getByUsername({ username });
+            return user.email || fallback;
+        } catch (e) {
+            core.warning(`Failed to fetch user email for ${username}: ${e.message}`);
+            return fallback;
+        }
+    };
+
+    const authorEmail = await resolveEmail(mergedPr.user.login, mergedPr.user.id);
+    core.setOutput('author_email', authorEmail);
+
+    // Collect co-authors from PR commits and commit message trailers
+    const coAuthors = new Map();
+
     try {
-        const { data: user } = await github.rest.users.getByUsername({
-            username: mergedPr.user.login,
+        const { data: commits } = await github.rest.pulls.listCommits({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: mergedPr.number,
         });
 
-        const email = user.email || fallbackEmail;
-        core.setOutput('author_email', email);
+        for (const commit of commits) {
+            // Add commit authors that differ from the PR author
+            const commitAuthor = commit.author;
+            if (commitAuthor && commitAuthor.login && commitAuthor.login !== mergedPr.user.login) {
+                if (!coAuthors.has(commitAuthor.login)) {
+                    coAuthors.set(commitAuthor.login, { id: commitAuthor.id, login: commitAuthor.login });
+                }
+            }
+
+            // Parse "Co-authored-by" trailers from commit messages
+            const message = commit.commit.message || '';
+            const coAuthorPattern = /^Co-authored-by:\s+(.+?)\s+<(.+?)>\s*$/gim;
+            let match;
+            while ((match = coAuthorPattern.exec(message)) !== null) {
+                const [, name, email] = match;
+                // Skip the PR author and bot accounts
+                if (!email.includes('[bot]') && !coAuthors.has(email)) {
+                    coAuthors.set(email, { name, email });
+                }
+            }
+        }
     } catch (e) {
-        core.warning(`Failed to fetch user email for ${mergedPr.user.login}: ${e.message}`);
-        core.setOutput('author_email', fallbackEmail);
+        core.warning(`Failed to fetch PR commits: ${e.message}`);
     }
+
+    // Resolve co-author emails and build trailer lines
+    const coAuthorLines = [];
+    for (const [key, value] of coAuthors) {
+        if (value.login) {
+            const email = await resolveEmail(value.login, value.id);
+            coAuthorLines.push(`Co-authored-by: ${value.login} <${email}>`);
+        } else {
+            coAuthorLines.push(`Co-authored-by: ${value.name} <${value.email}>`);
+        }
+    }
+
+    core.setOutput('co_authors', coAuthorLines.join('\n'));
 };

--- a/.github/workflows/push-kit-changes.yml
+++ b/.github/workflows/push-kit-changes.yml
@@ -208,14 +208,24 @@ jobs:
           git add -A
 
           COMMIT_MSG="${{ steps.pr-info.outputs.title }}"
-          CO_AUTHOR=""
+          TRAILERS=""
 
           if [[ "${{ steps.pr-info.outputs.found }}" == "true" ]]; then
-            CO_AUTHOR="Co-authored-by: ${{ steps.pr-info.outputs.author }} <${{ steps.pr-info.outputs.author_email }}>"
+            TRAILERS="Co-authored-by: ${{ steps.pr-info.outputs.author }} <${{ steps.pr-info.outputs.author_email }}>"
           fi
 
-          if [[ -n "$CO_AUTHOR" ]]; then
-            git commit -m "$COMMIT_MSG" -m "$CO_AUTHOR"
+          CO_AUTHORS="${{ steps.pr-info.outputs.co_authors }}"
+          if [[ -n "$CO_AUTHORS" ]]; then
+            if [[ -n "$TRAILERS" ]]; then
+              TRAILERS="$TRAILERS
+          $CO_AUTHORS"
+            else
+              TRAILERS="$CO_AUTHORS"
+            fi
+          fi
+
+          if [[ -n "$TRAILERS" ]]; then
+            git commit -m "$COMMIT_MSG" -m "$TRAILERS"
           else
             git commit -m "$COMMIT_MSG"
           fi


### PR DESCRIPTION
When a Maestro PR has multiple contributors (commit authors or `Co-authored-by` trailers), only the PR creator was being credited in the downstream starter kit commits. This adds the missing co-authors.

### Approach

- The PR info script now fetches all commits from the merged PR and collects co-authors from two sources: commit authors that differ from the PR creator, and `Co-authored-by` trailers in commit messages
- The workflow appends these additional co-author trailers to the commit pushed to each starter kit repo