### PR TITLE
Fix permission-only check discarding blank line changes

### DIFF
--- a/.github/workflows/push-kit-changes.yml
+++ b/.github/workflows/push-kit-changes.yml
@@ -173,7 +173,7 @@ jobs:
         run: |
           git diff --diff-filter=M --name-only | while read file; do
             if git diff "$file" | grep -q '^diff --git' && \
-               ! git diff "$file" | grep -qE '^(\+[^+]|-[^-])'; then
+               ! git diff "$file" | grep -qE '^(\+([^+]|$)|-([^-]|$))'; then
               git checkout -- "$file"
             fi
           done


### PR DESCRIPTION
## Summary

- The regex in the "Discard Permission-Only Changes" step of `push-kit-changes.yml` failed to match bare `+` or `-` lines in diffs (added/removed empty lines)
- This caused blank-line content changes to be silently discarded during kit pushes, creating drift between Maestro source and starter kit repos
- For example, `TwoFactorSetupModal.vue` in the Vue starter kit was missing a required blank line that ESLint's `@stylistic/padding-line-between-statements` rule enforces, causing `composer ci:check` to fail when run from the starter kit repo

## Fix

Changed the regex from `'^(\+[^+]|-[^-])'` to `'^(\+([^+]|$)|-([^-]|$))'` so that a bare `+` or `-` at end of line (representing an empty line change) is correctly recognized as a content change.

## Test plan

- [x] Verified the old regex fails to match `+` (added empty line) and `-` (removed empty line)
- [x] Verified the new regex correctly matches both cases
- [x] Verified the new regex still correctly excludes diff headers (`+++`, `---`)
- [x] After merge, the next push to starter kit repos will sync the missing blank lines