### PR TITLE
Remove unused axios and enable ignore-scripts for all kits

### DIFF
--- a/kits/Inertia/Blank/Base/.npmrc
+++ b/kits/Inertia/Blank/Base/.npmrc
@@ -1,1 +1,2 @@
+ignore-scripts=true
 public-hoist-pattern[]=@inertiajs/core

--- a/kits/Livewire/Blank/package.json
+++ b/kits/Livewire/Blank/package.json
@@ -9,7 +9,6 @@
     "dependencies": {
         "@tailwindcss/vite": "^4.1.11",
         "autoprefixer": "^10.4.20",
-        "axios": "^1.7.4",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^3.0.0",
         "tailwindcss": "^4.0.7",

--- a/kits/Shared/Blank/.npmrc
+++ b/kits/Shared/Blank/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
Axios is listed as a dependency but not imported anywhere. Removing it and
enabling `ignore-scripts=true` in `.npmrc` for all starter kits to prevent
third-party postinstall scripts from running during `npm install`.

### Approach

- Remove axios from the base Livewire package.json
- Add `.npmrc` with `ignore-scripts=true` at the Shared/Blank layer (covers Livewire kits)
  and the Inertia/Blank/Base layer (covers all Inertia kits)