### PR TITLE
Add TeamPermission enum for type-safe permissions

### DIFF
--- a/kits/Shared/Teams/Base/app/Concerns/HasTeams.php
+++ b/kits/Shared/Teams/Base/app/Concerns/HasTeams.php
@@ -2,6 +2,7 @@
 
 namespace App\Concerns;
 
+use App\Enums\TeamPermission;
 use App\Enums\TeamRole;
 use App\Models\Membership;
 use App\Models\Team;
@@ -167,13 +168,13 @@ trait HasTeams
         $role = $this->teamRole($team);
 
         return new TeamPermissions(
-            canUpdateTeam: $role?->hasPermission('team:update') ?? false,
-            canDeleteTeam: $role?->hasPermission('team:delete') ?? false,
-            canAddMember: $role?->hasPermission('member:add') ?? false,
-            canUpdateMember: $role?->hasPermission('member:update') ?? false,
-            canRemoveMember: $role?->hasPermission('member:remove') ?? false,
-            canCreateInvitation: $role?->hasPermission('invitation:create') ?? false,
-            canCancelInvitation: $role?->hasPermission('invitation:cancel') ?? false,
+            canUpdateTeam: $role?->hasPermission(TeamPermission::UpdateTeam) ?? false,
+            canDeleteTeam: $role?->hasPermission(TeamPermission::DeleteTeam) ?? false,
+            canAddMember: $role?->hasPermission(TeamPermission::AddMember) ?? false,
+            canUpdateMember: $role?->hasPermission(TeamPermission::UpdateMember) ?? false,
+            canRemoveMember: $role?->hasPermission(TeamPermission::RemoveMember) ?? false,
+            canCreateInvitation: $role?->hasPermission(TeamPermission::CreateInvitation) ?? false,
+            canCancelInvitation: $role?->hasPermission(TeamPermission::CancelInvitation) ?? false,
         );
     }
 
@@ -188,7 +189,7 @@ trait HasTeams
     /**
      * Determine if the user has the given permission on the team.
      */
-    public function hasTeamPermission(Team $team, string $permission): bool
+    public function hasTeamPermission(Team $team, TeamPermission $permission): bool
     {
         return $this->teamRole($team)?->hasPermission($permission) ?? false;
     }

--- a/kits/Shared/Teams/Base/app/Enums/TeamPermission.php
+++ b/kits/Shared/Teams/Base/app/Enums/TeamPermission.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums;
+
+enum TeamPermission: string
+{
+    case UpdateTeam = 'team:update';
+    case DeleteTeam = 'team:delete';
+
+    case AddMember = 'member:add';
+    case UpdateMember = 'member:update';
+    case RemoveMember = 'member:remove';
+
+    case CreateInvitation = 'invitation:create';
+    case CancelInvitation = 'invitation:cancel';
+}

--- a/kits/Shared/Teams/Base/app/Enums/TeamRole.php
+++ b/kits/Shared/Teams/Base/app/Enums/TeamRole.php
@@ -19,24 +19,16 @@ enum TeamRole: string
     /**
      * Get all the permissions for this role.
      *
-     * @return array<string>
+     * @return array<TeamPermission>
      */
     public function permissions(): array
     {
         return match ($this) {
-            self::Owner => [
-                'team:update',
-                'team:delete',
-                'member:add',
-                'member:update',
-                'member:remove',
-                'invitation:create',
-                'invitation:cancel',
-            ],
+            self::Owner => TeamPermission::cases(),
             self::Admin => [
-                'team:update',
-                'invitation:create',
-                'invitation:cancel',
+                TeamPermission::UpdateTeam,
+                TeamPermission::CreateInvitation,
+                TeamPermission::CancelInvitation,
             ],
             self::Member => [],
         };
@@ -45,7 +37,7 @@ enum TeamRole: string
     /**
      * Determine if the role has the given permission.
      */
-    public function hasPermission(string $permission): bool
+    public function hasPermission(TeamPermission $permission): bool
     {
         return in_array($permission, $this->permissions());
     }

--- a/kits/Shared/Teams/Base/app/Policies/TeamPolicy.php
+++ b/kits/Shared/Teams/Base/app/Policies/TeamPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Enums\TeamPermission;
 use App\Models\Team;
 use App\Models\User;
 
@@ -36,7 +37,7 @@ class TeamPolicy
      */
     public function update(User $user, Team $team): bool
     {
-        return $user->hasTeamPermission($team, 'team:update');
+        return $user->hasTeamPermission($team, TeamPermission::UpdateTeam);
     }
 
     /**
@@ -44,7 +45,7 @@ class TeamPolicy
      */
     public function addMember(User $user, Team $team): bool
     {
-        return $user->hasTeamPermission($team, 'member:add');
+        return $user->hasTeamPermission($team, TeamPermission::AddMember);
     }
 
     /**
@@ -52,7 +53,7 @@ class TeamPolicy
      */
     public function updateMember(User $user, Team $team): bool
     {
-        return $user->hasTeamPermission($team, 'member:update');
+        return $user->hasTeamPermission($team, TeamPermission::UpdateMember);
     }
 
     /**
@@ -60,7 +61,7 @@ class TeamPolicy
      */
     public function removeMember(User $user, Team $team): bool
     {
-        return $user->hasTeamPermission($team, 'member:remove');
+        return $user->hasTeamPermission($team, TeamPermission::RemoveMember);
     }
 
     /**
@@ -68,7 +69,7 @@ class TeamPolicy
      */
     public function inviteMember(User $user, Team $team): bool
     {
-        return $user->hasTeamPermission($team, 'invitation:create');
+        return $user->hasTeamPermission($team, TeamPermission::CreateInvitation);
     }
 
     /**
@@ -76,7 +77,7 @@ class TeamPolicy
      */
     public function cancelInvitation(User $user, Team $team): bool
     {
-        return $user->hasTeamPermission($team, 'invitation:cancel');
+        return $user->hasTeamPermission($team, TeamPermission::CancelInvitation);
     }
 
     /**
@@ -84,6 +85,6 @@ class TeamPolicy
      */
     public function delete(User $user, Team $team): bool
     {
-        return ! $team->is_personal && $user->hasTeamPermission($team, 'team:delete');
+        return ! $team->is_personal && $user->hasTeamPermission($team, TeamPermission::DeleteTeam);
     }
 }


### PR DESCRIPTION
Replace raw permission strings with a dedicated `TeamPermission` backed enum across the teams layer, improving type safety and reducing the risk of typos in permission checks.

Ports the relevant changes from laravel/react-starter-kit#328.

### Approach

- Add a new `TeamPermission` string-backed enum with cases for all seven team permissions
- Update `TeamRole` to return and accept `TeamPermission` values instead of strings
- Update `HasTeams` trait and `TeamPolicy` to use the enum throughout