### PR TITLE
Add translation support to team invitation notification mail

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -94,12 +94,17 @@ jobs:
         working-directory: build
         run: npm install playwright
 
+      - name: Get Playwright Version
+        id: playwright-version
+        working-directory: build
+        run: echo "version=$(node -e "console.log(require('playwright/package.json').version)")" >> $GITHUB_OUTPUT
+
       - name: Cache Playwright Browsers
         uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('orchestrator/composer.lock') }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/kits/Shared/Teams/Base/app/Notifications/Teams/TeamInvitation.php
+++ b/kits/Shared/Teams/Base/app/Notifications/Teams/TeamInvitation.php
@@ -39,9 +39,12 @@ class TeamInvitation extends Notification implements ShouldQueue
         $inviter = $this->invitation->inviter;
 
         return (new MailMessage)
-            ->subject("You've been invited to join {$team->name}")
-            ->line("{$inviter->name} has invited you to join the {$team->name} team.")
-            ->action('Accept invitation', url("/invitations/{$this->invitation->code}/accept"));
+            ->subject(__("You've been invited to join :teamName", ['teamName' => $team->name]))
+            ->line(__(':inviterName has invited you to join the :teamName team.', [
+                'inviterName' => $inviter->name,
+                'teamName' => $team->name,
+            ]))
+            ->action(__('Accept invitation'), url("/invitations/{$this->invitation->code}/accept"));
     }
 
     /**


### PR DESCRIPTION
The team invitation notification mail had hardcoded English strings, making it impossible to translate for non-English users.

Wraps the subject, body, and action button text with Laravel's `__()` helper so they can be translated via language files.

Upstream: https://github.com/laravel/livewire-starter-kit/pull/285