### PR TITLE
Update contributing docs to point to Maestro and reflect direct push workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ No flags runs the full default matrix for each command.
 
 After making the changes in `build` and testing that they are working, simply commit your code and create a PR with these changes.
 
-After your PR is merged, **Maestro** will automatically create PRs for the affected starter kits with the updated code.
+After your PR is merged, **Maestro** will automatically push the changes directly to the affected starter kit repositories.
 
 ## Starter Kit Flavors
 

--- a/kits/Inertia/Blank/React/README.md
+++ b/kits/Inertia/Blank/React/README.md
@@ -16,6 +16,8 @@ Documentation for all Laravel starter kits can be found on the [Laravel website]
 
 Thank you for considering contributing to our starter kit! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
 
+All contributions to the Starter Kits from now on should be made through [Maestro](https://github.com/laravel/maestro).
+
 ## Code of Conduct
 
 In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).

--- a/kits/Inertia/Blank/Svelte/README.md
+++ b/kits/Inertia/Blank/Svelte/README.md
@@ -16,6 +16,8 @@ Documentation for all Laravel starter kits can be found on the [Laravel website]
 
 Thank you for considering contributing to our starter kit! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
 
+All contributions to the Starter Kits from now on should be made through [Maestro](https://github.com/laravel/maestro).
+
 ## Code of Conduct
 
 In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).

--- a/kits/Inertia/Blank/Vue/README.md
+++ b/kits/Inertia/Blank/Vue/README.md
@@ -16,6 +16,8 @@ Documentation for all Laravel starter kits can be found on the [Laravel website]
 
 Thank you for considering contributing to our starter kit! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
 
+All contributions to the Starter Kits from now on should be made through [Maestro](https://github.com/laravel/maestro).
+
 ## Code of Conduct
 
 In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).

--- a/kits/Inertia/React/README.md
+++ b/kits/Inertia/React/README.md
@@ -16,6 +16,8 @@ Documentation for all Laravel starter kits can be found on the [Laravel website]
 
 Thank you for considering contributing to our starter kit! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
 
+All contributions to the Starter Kits from now on should be made through [Maestro](https://github.com/laravel/maestro).
+
 ## Code of Conduct
 
 In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).

--- a/kits/Inertia/Svelte/README.md
+++ b/kits/Inertia/Svelte/README.md
@@ -16,6 +16,8 @@ Documentation for all Laravel starter kits can be found on the [Laravel website]
 
 Thank you for considering contributing to our starter kit! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
 
+All contributions to the Starter Kits from now on should be made through [Maestro](https://github.com/laravel/maestro).
+
 ## Code of Conduct
 
 In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).

--- a/kits/Inertia/Vue/README.md
+++ b/kits/Inertia/Vue/README.md
@@ -16,6 +16,8 @@ Documentation for all Laravel starter kits can be found on the [Laravel website]
 
 Thank you for considering contributing to our starter kit! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
 
+All contributions to the Starter Kits from now on should be made through [Maestro](https://github.com/laravel/maestro).
+
 ## Code of Conduct
 
 In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).

--- a/kits/Livewire/Base/README.md
+++ b/kits/Livewire/Base/README.md
@@ -20,6 +20,8 @@ Documentation for all Laravel starter kits can be found on the [Laravel website]
 
 Thank you for considering contributing to our starter kit! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
 
+All contributions to the Starter Kits from now on should be made through [Maestro](https://github.com/laravel/maestro).
+
 ## Code of Conduct
 
 In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).

--- a/kits/Livewire/Blank/README.md
+++ b/kits/Livewire/Blank/README.md
@@ -16,6 +16,8 @@ Documentation for all Laravel starter kits can be found on the [Laravel website]
 
 Thank you for considering contributing to our starter kit! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
 
+All contributions to the Starter Kits from now on should be made through [Maestro](https://github.com/laravel/maestro).
+
 ## Code of Conduct
 
 In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).


### PR DESCRIPTION
The starter kit READMEs don't mention that contributions should go through Maestro, and the main README still references the old PR-based workflow that was replaced with direct pushes.

### Approach

- Added a note to all 8 kit READMEs directing contributors to Maestro
- Updated the main README "Submitting Changes" section to reflect the direct push workflow