### PR TITLE
Add multilanguage support for Delete team validation message

### DIFF
--- a/kits/Inertia/Teams/Base/app/Http/Requests/Teams/DeleteTeamRequest.php
+++ b/kits/Inertia/Teams/Base/app/Http/Requests/Teams/DeleteTeamRequest.php
@@ -39,7 +39,7 @@ class DeleteTeamRequest extends FormRequest
                 $team = $this->route('team');
 
                 if ($this->input('name') !== $team->name) {
-                    $validator->errors()->add('name', 'The team name does not match.');
+                    $validator->errors()->add('name', __('The team name does not match.'));
                 }
             },
         ];

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/delete-team-modal.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/delete-team-modal.blade.php
@@ -31,7 +31,7 @@ new class extends Component {
         ]);
 
         if ($validated['deleteName'] !== $this->team->name) {
-            $this->addError('deleteName', 'The team name does not match.');
+            $this->addError('deleteName', __('The team name does not match.'));
 
             return;
         }


### PR DESCRIPTION
When we delete a team and the team's name doesn't match with typed name, the validation doesn't pass and we see a message that had hardcoded English strings, making it impossible to translate for non-English users.

Wraps the validation message with Laravel's __() helper so they can be translated via language files.