### PR TITLE
Fix git index.lock race condition in push-kit-changes workflow

### DIFF
--- a/.github/workflows/push-kit-changes.yml
+++ b/.github/workflows/push-kit-changes.yml
@@ -235,12 +235,15 @@ jobs:
       - name: Discard Permission-Only Changes
         working-directory: ${{ matrix.path }}
         run: |
-          git diff --diff-filter=M --name-only | while read file; do
-            if git diff "$file" | grep -q '^diff --git' && \
-               ! git diff "$file" | grep -qE '^(\+([^+]|$)|-([^-]|$))'; then
-              git checkout -- "$file"
-            fi
-          done
+          FILES=$(git diff --diff-filter=M --name-only)
+          if [[ -n "$FILES" ]]; then
+            while IFS= read -r file; do
+              if git diff "$file" | grep -q '^diff --git' && \
+                 ! git diff "$file" | grep -qE '^(\+([^+]|$)|-([^-]|$))'; then
+                git checkout -- "$file"
+              fi
+            done <<< "$FILES"
+          fi
 
       - name: Check for Changes
         id: changes


### PR DESCRIPTION
The "Discard Permission-Only Changes" step intermittently fails with `fatal: Unable to create index.lock: File exists` because the piped `git diff` process stays alive while `git checkout` inside the loop tries to write-lock the same index.

### Approach

- Capture the file list into a variable before iterating, so the outer   `git diff` completes and releases the index before any `git checkout`   runs