### PR TITLE
Fix Playwright browser cache never hitting in browser-tests workflow

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -93,6 +93,8 @@ jobs:
       - name: Install Playwright
         working-directory: build
         run: npm install playwright
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: Get Playwright Version
         id: playwright-version


### PR DESCRIPTION
The `npm install playwright` postinstall script downloads browser binaries before `actions/cache` has a chance to restore them, so the cache never actually hits.

### Approach

- Set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` on the `npm install playwright` step so it only installs the npm package without downloading browsers
- The existing conditional steps already handle the rest: download browsers on cache miss, install only system deps on cache hit