### PR TITLE
Add multilanguage support for Team name reserved validation message.

### DIFF
--- a/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamMemberController.php
+++ b/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamMemberController.php
@@ -36,7 +36,7 @@ class TeamMemberController extends Controller
     {
         Gate::authorize('removeMember', $team);
 
-        abort_if($team->owner()?->is($user), 403, 'The team owner cannot be removed.');
+        abort_if($team->owner()?->is($user), 403, __('The team owner cannot be removed.'));
 
         $team->memberships()
             ->where('user_id', $user->id)

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/edit.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/edit.blade.php
@@ -117,8 +117,8 @@ new class extends Component
         $teamName = $this->teamData['name'] ?? $this->teamModel->name;
 
         $title = $this->permissions->canUpdateTeam
-            ? "Edit {$teamName}"
-            : "View {$teamName}";
+            ? __('Edit :name', ['name' => $teamName])
+            : __('View :name', ['name' => $teamName]);
 
         return $this->view()->title($title);
     }

--- a/kits/Shared/Teams/Base/app/Rules/TeamName.php
+++ b/kits/Shared/Teams/Base/app/Rules/TeamName.php
@@ -20,7 +20,7 @@ class TeamName implements ValidationRule
         $name = strtolower(trim($value));
 
         if (in_array($name, $this->reservedNames(), true)) {
-            $fail('This team name is reserved and cannot be used.');
+            $fail(__('This team name is reserved and cannot be used.'));
         }
     }
 


### PR DESCRIPTION
When we create a team and the team's name belongs to reserved list the validation doesn't pass and we see a message that had hardcoded English strings, making it impossible to translate for non-English users.

## Solutions
1. Wraps the validation message with Laravel's `__()` helper so they can be translated via language files: `$fail(__('This team name is reserved and cannot be used.'))`, 
2. Since this translation is an argument of  the `Closure $fail` within a `ValidationRule` class which returns an instance of the `Illuminate\Translation\PotentiallyTranslatedString` class we can chain the `->translate()` method:  `$fail('This team name is reserved and cannot be used.')->translate()`.

I have chosen the first option for consistency with the other translation strings.