### PR TITLE
Move Inertia pnpm hoist config to workspace file

### DIFF
--- a/kits/Inertia/Blank/Base/.npmrc
+++ b/kits/Inertia/Blank/Base/.npmrc
@@ -1,2 +1,1 @@
 ignore-scripts=true
-public-hoist-pattern[]=@inertiajs/core

--- a/kits/Inertia/Blank/Base/pnpm-workspace.yaml
+++ b/kits/Inertia/Blank/Base/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+publicHoistPattern:
+  - '@inertiajs/core'


### PR DESCRIPTION
## Summary
Move the pnpm-specific hoist setting out of the shared Inertia `.npmrc` and into `pnpm-workspace.yaml`.

This keeps the pnpm behavior that Inertia needs, while removing an unsupported config key from a file that npm also reads.

## Why this change
`public-hoist-pattern[]` is a pnpm-only setting, but it was living in a shared `.npmrc` file. 

That means npm sees it too, prints a warning on every run, and explicitly says the unknown project config will stop working in the next major version of npm. Since the starter kits are meant to work cleanly for npm users as well, it makes more sense to keep the pnpm-specific setting in a pnpm workspace file instead.

## Changes
- Removed `public-hoist-pattern[]=@inertiajs/core` from `kits/Inertia/Blank/Base/.npmrc`
- Added `kits/Inertia/Blank/Base/pnpm-workspace.yaml` with:
  ```yaml
  publicHoistPattern:
    - '@inertiajs/core'
  ```

## Validation
- **Ran:**
  ```bash
  composer kits:check -- --react --svelte --vue
  ```
- **Result:** all Inertia variants passed

## Notes
This keeps the fix scoped to Inertia starter kits and avoids changing Livewire variants.

**Refs** #68
