### PR TITLE
Toast requires at least livewire/flux ^2.13.1

### DIFF
--- a/kits/Livewire/Base/composer.json
+++ b/kits/Livewire/Base/composer.json
@@ -13,7 +13,7 @@
         "laravel/fortify": "^1.34",
         "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",
-        "livewire/flux": "^2.12.0",
+        "livewire/flux": "^2.13.1",
         "livewire/livewire": "^4.1"
     },
     "require-dev": {


### PR DESCRIPTION
Toast was added as a free component in v2.13.1 of flux.

so minimum version should be updated to that in starterkit

https://github.com/livewire/flux/releases/tag/v2.13.1