### PR TITLE
Replace deprecated Rule with ValidationRule

### DIFF
--- a/kits/Shared/Fortify/app/Concerns/PasswordValidationRules.php
+++ b/kits/Shared/Fortify/app/Concerns/PasswordValidationRules.php
@@ -2,7 +2,7 @@
 
 namespace App\Concerns;
 
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Validation\Rules\Password;
 
 trait PasswordValidationRules
@@ -10,7 +10,7 @@ trait PasswordValidationRules
     /**
      * Get the validation rules used to validate passwords.
      *
-     * @return array<int, Rule|array<mixed>|string>
+     * @return array<int, ValidationRule|array<mixed>|string>
      */
     protected function passwordRules(): array
     {
@@ -20,7 +20,7 @@ trait PasswordValidationRules
     /**
      * Get the validation rules used to validate the current password.
      *
-     * @return array<int, Rule|array<mixed>|string>
+     * @return array<int, ValidationRule|array<mixed>|string>
      */
     protected function currentPasswordRules(): array
     {

--- a/kits/Shared/Fortify/app/Concerns/ProfileValidationRules.php
+++ b/kits/Shared/Fortify/app/Concerns/ProfileValidationRules.php
@@ -3,6 +3,7 @@
 namespace App\Concerns;
 
 use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Validation\Rule;
 
 trait ProfileValidationRules
@@ -10,7 +11,7 @@ trait ProfileValidationRules
     /**
      * Get the validation rules used to validate user profiles.
      *
-     * @return array<string, array<int, \Illuminate\Contracts\Validation\Rule|array<mixed>|string>>
+     * @return array<string, array<int, ValidationRule|array<mixed>|string>>
      */
     protected function profileRules(?int $userId = null): array
     {
@@ -23,7 +24,7 @@ trait ProfileValidationRules
     /**
      * Get the validation rules used to validate user names.
      *
-     * @return array<int, \Illuminate\Contracts\Validation\Rule|array<mixed>|string>
+     * @return array<int, ValidationRule|array<mixed>|string>
      */
     protected function nameRules(): array
     {
@@ -33,7 +34,7 @@ trait ProfileValidationRules
     /**
      * Get the validation rules used to validate user emails.
      *
-     * @return array<int, \Illuminate\Contracts\Validation\Rule|array<mixed>|string>
+     * @return array<int, ValidationRule|array<mixed>|string>
      */
     protected function emailRules(?int $userId = null): array
     {


### PR DESCRIPTION
This PR replaces the deprecated `Illuminate\Contracts\Validation\Rule` with `Illuminate\Contracts\Validation\ValidationRule`