### PR TITLE
Use Fortify config for Teams auth redirects instead of hardcoded routes

### DIFF
--- a/kits/Shared/Teams/Fortify/app/Http/Responses/LoginResponse.php
+++ b/kits/Shared/Teams/Fortify/app/Http/Responses/LoginResponse.php
@@ -5,6 +5,7 @@ namespace App\Http\Responses;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\URL;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
+use Laravel\Fortify\Fortify;
 use Symfony\Component\HttpFoundation\Response;
 
 class LoginResponse implements LoginResponseContract
@@ -22,6 +23,6 @@ class LoginResponse implements LoginResponseContract
 
         return $request->wantsJson()
             ? new JsonResponse(['two_factor' => false], 200)
-            : redirect()->intended(route('dashboard'));
+            : redirect()->intended("/{$team->slug}".Fortify::redirects('login'));
     }
 }

--- a/kits/Shared/Teams/Fortify/app/Http/Responses/RegisterResponse.php
+++ b/kits/Shared/Teams/Fortify/app/Http/Responses/RegisterResponse.php
@@ -5,6 +5,7 @@ namespace App\Http\Responses;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\URL;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
+use Laravel\Fortify\Fortify;
 use Symfony\Component\HttpFoundation\Response;
 
 class RegisterResponse implements RegisterResponseContract
@@ -22,6 +23,6 @@ class RegisterResponse implements RegisterResponseContract
 
         return $request->wantsJson()
             ? new JsonResponse(['two_factor' => false], 201)
-            : redirect()->intended(route('dashboard'));
+            : redirect()->intended("/{$team->slug}".Fortify::redirects('register'));
     }
 }

--- a/kits/Shared/Teams/Fortify/app/Http/Responses/TwoFactorLoginResponse.php
+++ b/kits/Shared/Teams/Fortify/app/Http/Responses/TwoFactorLoginResponse.php
@@ -3,7 +3,9 @@
 namespace App\Http\Responses;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\URL;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
+use Laravel\Fortify\Fortify;
 use Symfony\Component\HttpFoundation\Response;
 
 class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
@@ -17,8 +19,10 @@ class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
             abort(403);
         }
 
+        URL::defaults(['current_team' => $team->slug]);
+
         return $request->wantsJson()
             ? new JsonResponse(['two_factor' => false], 200)
-            : redirect()->intended("/{$team->slug}/dashboard");
+            : redirect()->intended("/{$team->slug}".Fortify::redirects('login'));
     }
 }


### PR DESCRIPTION
The Teams Fortify response classes (LoginResponse, RegisterResponse, TwoFactorLoginResponse) had their redirect paths hardcoded to the dashboard route, ignoring the `home` value in `config/fortify.php`. This meant changing that config had no effect after login or registration.

Now all three responses use `Fortify::redirects()` to resolve the redirect path, which respects both `config('fortify.home')` and the per-action `config('fortify.redirects.login')` / `config('fortify.redirects.register')` overrides. The team slug is still prepended so team-scoped URLs work as expected.

Also added the missing `URL::defaults()` call in `TwoFactorLoginResponse` for consistency with the other two responses.