### PR TITLE
Make Inertia/Fortify kits resilient to disabled Fortify features

### DIFF
--- a/kits/Inertia/Base/app/Http/Controllers/Settings/ProfileController.php
+++ b/kits/Inertia/Base/app/Http/Controllers/Settings/ProfileController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Settings;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\ProfileDeleteRequest;
 use App\Http\Requests\Settings\ProfileUpdateRequest;
+use App\Support\FortifyFeaturePayload;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -21,6 +22,7 @@ class ProfileController extends Controller
     {
         return Inertia::render('{{profile_settings}}', [
             'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
+            'verificationSendUrl' => FortifyFeaturePayload::verificationSendUrl(),
             'status' => $request->session()->get('status'),
         ]);
     }

--- a/kits/Inertia/Base/routes/web.php
+++ b/kits/Inertia/Base/routes/web.php
@@ -1,10 +1,12 @@
 <?php
 
+use App\Support\FortifyFeaturePayload;
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
 
 Route::inertia('/', '{{welcome}}', [
-    'canRegister' => Features::enabled(Features::registration()),
+    'canRegister' => fn () => Features::enabled(Features::registration()),
+    'registerUrl' => fn () => FortifyFeaturePayload::registerUrl(),
 ])->name('home');
 
 Route::middleware(['auth', 'verified'])->group(function () {

--- a/kits/Inertia/Base/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/kits/Inertia/Base/tests/Feature/Settings/ProfileUpdateTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature\Settings;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class ProfileUpdateTest extends TestCase
@@ -19,6 +21,29 @@ class ProfileUpdateTest extends TestCase
             ->get(route('profile.edit'));
 
         $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{profile_settings}}')
+            ->where('verificationSendUrl', Features::enabled(Features::emailVerification()) ? route('verification.send') : null),
+        );
+    }
+
+    public function test_profile_page_omits_verification_url_when_feature_is_disabled()
+    {
+        config(['fortify.features' => []]);
+
+        $user = User::factory()->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->get(route('profile.edit'));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{profile_settings}}')
+            ->where('verificationSendUrl', null),
+        );
     }
 
     public function test_profile_information_can_be_updated()

--- a/kits/Inertia/Fortify/Base/app/Http/Controllers/Settings/SecurityController.php
+++ b/kits/Inertia/Fortify/Base/app/Http/Controllers/Settings/SecurityController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Settings;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\PasswordUpdateRequest;
 use App\Http\Requests\Settings\TwoFactorAuthenticationRequest;
+use App\Support\FortifyFeaturePayload;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Controllers\Middleware;
@@ -32,6 +33,7 @@ class SecurityController extends Controller implements HasMiddleware
     {
         $props = [
             'canManageTwoFactor' => Features::canManageTwoFactorAuthentication(),
+            'twoFactorUrls' => FortifyFeaturePayload::twoFactorUrls(),
         ];
 
         if (Features::canManageTwoFactorAuthentication()) {

--- a/kits/Inertia/Fortify/Base/app/Providers/FortifyServiceProvider.php
+++ b/kits/Inertia/Fortify/Base/app/Providers/FortifyServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Actions\Fortify\CreateNewUser;
 use App\Actions\Fortify\ResetUserPassword;
+use App\Support\FortifyFeaturePayload;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
@@ -50,25 +51,34 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::loginView(fn (Request $request) => Inertia::render('{{auth_login}}', [
             'canResetPassword' => Features::enabled(Features::resetPasswords()),
             'canRegister' => Features::enabled(Features::registration()),
+            'registerUrl' => FortifyFeaturePayload::registerUrl(),
+            'forgotPasswordUrl' => FortifyFeaturePayload::forgotPasswordUrl(),
             'status' => $request->session()->get('status'),
         ]));
 
         Fortify::resetPasswordView(fn (Request $request) => Inertia::render('{{auth_reset_password}}', [
             'email' => $request->email,
             'token' => $request->route('token'),
+            'resetPasswordSubmitUrl' => FortifyFeaturePayload::resetPasswordSubmitUrl(),
         ]));
 
         Fortify::requestPasswordResetLinkView(fn (Request $request) => Inertia::render('{{auth_forgot_password}}', [
             'status' => $request->session()->get('status'),
+            'forgotPasswordSubmitUrl' => FortifyFeaturePayload::forgotPasswordSubmitUrl(),
         ]));
 
         Fortify::verifyEmailView(fn (Request $request) => Inertia::render('{{auth_verify_email}}', [
             'status' => $request->session()->get('status'),
+            'verificationSendUrl' => FortifyFeaturePayload::verificationSendUrl(),
         ]));
 
-        Fortify::registerView(fn () => Inertia::render('{{auth_register}}'));
+        Fortify::registerView(fn () => Inertia::render('{{auth_register}}', [
+            'registerUrl' => FortifyFeaturePayload::registerUrl(),
+        ]));
 
-        Fortify::twoFactorChallengeView(fn () => Inertia::render('{{auth_two_factor_challenge}}'));
+        Fortify::twoFactorChallengeView(fn () => Inertia::render('{{auth_two_factor_challenge}}', [
+            'twoFactorLoginUrl' => FortifyFeaturePayload::twoFactorLoginUrl(),
+        ]));
 
         Fortify::confirmPasswordView(fn () => Inertia::render('{{auth_confirm_password}}'));
     }

--- a/kits/Inertia/Fortify/Base/app/Support/FortifyFeaturePayload.php
+++ b/kits/Inertia/Fortify/Base/app/Support/FortifyFeaturePayload.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Support;
+
+use Laravel\Fortify\Features;
+
+class FortifyFeaturePayload
+{
+    public static function registerUrl(): ?string
+    {
+        return Features::enabled(Features::registration()) ? route('register') : null;
+    }
+
+    public static function forgotPasswordUrl(): ?string
+    {
+        return Features::enabled(Features::resetPasswords()) ? route('password.request') : null;
+    }
+
+    public static function forgotPasswordSubmitUrl(): ?string
+    {
+        return Features::enabled(Features::resetPasswords()) ? route('password.email') : null;
+    }
+
+    public static function resetPasswordSubmitUrl(): ?string
+    {
+        return Features::enabled(Features::resetPasswords()) ? route('password.update') : null;
+    }
+
+    public static function verificationSendUrl(): ?string
+    {
+        return Features::enabled(Features::emailVerification()) ? route('verification.send') : null;
+    }
+
+    public static function twoFactorLoginUrl(): ?string
+    {
+        return Features::enabled(Features::twoFactorAuthentication()) ? route('two-factor.login.store') : null;
+    }
+
+    /**
+     * @return array{enableUrl: string, disableUrl: string, confirmUrl: string, qrCodeUrl: string, secretKeyUrl: string, recoveryCodesUrl: string, regenerateUrl: string}|null
+     */
+    public static function twoFactorUrls(): ?array
+    {
+        if (! Features::canManageTwoFactorAuthentication()) {
+            return null;
+        }
+
+        return [
+            'enableUrl' => route('two-factor.enable'),
+            'disableUrl' => route('two-factor.disable'),
+            'confirmUrl' => route('two-factor.confirm'),
+            'qrCodeUrl' => route('two-factor.qr-code'),
+            'secretKeyUrl' => route('two-factor.secret-key'),
+            'recoveryCodesUrl' => route('two-factor.recovery-codes'),
+            'regenerateUrl' => route('two-factor.regenerate-recovery-codes'),
+        ];
+    }
+}

--- a/kits/Inertia/Fortify/Base/tests/Feature/Auth/AuthenticationTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Auth/AuthenticationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Auth;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\RateLimiter;
+use Inertia\Testing\AssertableInertia as Assert;
 use Laravel\Fortify\Features;
 use Tests\TestCase;
 
@@ -17,6 +18,31 @@ class AuthenticationTest extends TestCase
         $response = $this->get(route('login'));
 
         $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{auth_login}}')
+            ->where('canRegister', Features::enabled(Features::registration()))
+            ->where('canResetPassword', Features::enabled(Features::resetPasswords()))
+            ->where('registerUrl', Features::enabled(Features::registration()) ? route('register') : null)
+            ->where('forgotPasswordUrl', Features::enabled(Features::resetPasswords()) ? route('password.request') : null),
+        );
+    }
+
+    public function test_login_screen_omits_feature_urls_when_features_are_disabled()
+    {
+        config(['fortify.features' => []]);
+
+        $response = $this->get(route('login'));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{auth_login}}')
+            ->where('canRegister', false)
+            ->where('canResetPassword', false)
+            ->where('registerUrl', null)
+            ->where('forgotPasswordUrl', null),
+        );
     }
 
     public function test_users_can_authenticate_using_the_login_screen()

--- a/kits/Inertia/Fortify/Base/tests/Feature/Auth/EmailVerificationTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Auth/EmailVerificationTest.php
@@ -7,6 +7,7 @@ use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
+use Inertia\Testing\AssertableInertia as Assert;
 use Laravel\Fortify\Features;
 use Tests\TestCase;
 
@@ -28,6 +29,11 @@ class EmailVerificationTest extends TestCase
         $response = $this->actingAs($user)->get(route('verification.notice'));
 
         $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{auth_verify_email}}')
+            ->where('verificationSendUrl', route('verification.send')),
+        );
     }
 
     public function test_email_can_be_verified()

--- a/kits/Inertia/Fortify/Base/tests/Feature/Auth/PasswordResetTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Auth/PasswordResetTest.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
+use Inertia\Testing\AssertableInertia as Assert;
 use Laravel\Fortify\Features;
 use Tests\TestCase;
 
@@ -25,6 +26,11 @@ class PasswordResetTest extends TestCase
         $response = $this->get(route('password.request'));
 
         $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{auth_forgot_password}}')
+            ->where('forgotPasswordSubmitUrl', route('password.email')),
+        );
     }
 
     public function test_reset_password_link_can_be_requested()
@@ -50,6 +56,11 @@ class PasswordResetTest extends TestCase
             $response = $this->get(route('password.reset', $notification->token));
 
             $response->assertOk();
+
+            $response->assertInertia(fn (Assert $page) => $page
+                ->component('{{auth_reset_password}}')
+                ->where('resetPasswordSubmitUrl', route('password.update')),
+            );
 
             return true;
         });

--- a/kits/Inertia/Fortify/Base/tests/Feature/Auth/RegistrationTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Auth/RegistrationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Auth;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
 use Laravel\Fortify\Features;
 use Tests\TestCase;
 
@@ -22,6 +23,11 @@ class RegistrationTest extends TestCase
         $response = $this->get(route('register'));
 
         $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{auth_register}}')
+            ->where('registerUrl', route('register')),
+        );
     }
 
     public function test_new_users_can_register()

--- a/kits/Inertia/Fortify/Base/tests/Feature/Auth/TwoFactorChallengeTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Auth/TwoFactorChallengeTest.php
@@ -49,7 +49,8 @@ class TwoFactorChallengeTest extends TestCase
         $this->get(route('two-factor.login'))
             ->assertOk()
             ->assertInertia(fn (Assert $page) => $page
-                ->component('{{auth_two_factor_challenge}}'),
+                ->component('{{auth_two_factor_challenge}}')
+                ->where('twoFactorLoginUrl', route('two-factor.login.store')),
             );
     }
 }

--- a/kits/Inertia/Fortify/Base/tests/Feature/FeatureToggleTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/FeatureToggleTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Laravel\Fortify\Features;
+use Tests\TestCase;
+
+class FeatureToggleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_login_payload_is_safe_when_registration_is_disabled(): void
+    {
+        $features = config('fortify.features', []);
+
+        config(['fortify.features' => array_values(array_diff($features, [Features::registration()]))]);
+
+        $this->get(route('login'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('{{auth_login}}')
+                ->where('canRegister', false)
+                ->where('registerUrl', null),
+            );
+    }
+
+    public function test_login_payload_is_safe_when_password_resets_are_disabled(): void
+    {
+        $features = config('fortify.features', []);
+
+        config(['fortify.features' => array_values(array_diff($features, [Features::resetPasswords()]))]);
+
+        $this->get(route('login'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('{{auth_login}}')
+                ->where('canResetPassword', false)
+                ->where('forgotPasswordUrl', null),
+            );
+    }
+
+    public function test_profile_payload_is_safe_when_email_verification_is_disabled(): void
+    {
+        $features = config('fortify.features', []);
+
+        config(['fortify.features' => array_values(array_diff($features, [Features::emailVerification()]))]);
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('profile.edit'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('{{profile_settings}}')
+                ->where('verificationSendUrl', null),
+            );
+    }
+
+    public function test_security_payload_is_safe_when_two_factor_authentication_is_disabled(): void
+    {
+        $features = config('fortify.features', []);
+
+        config(['fortify.features' => array_values(array_diff($features, [Features::twoFactorAuthentication()]))]);
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('security.edit'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('{{security_settings}}')
+                ->where('canManageTwoFactor', false)
+                ->where('twoFactorUrls', null),
+            );
+    }
+}

--- a/kits/Inertia/Fortify/Base/tests/Feature/Settings/SecurityTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/Settings/SecurityTest.php
@@ -30,7 +30,16 @@ class SecurityTest extends TestCase
             ->assertInertia(fn (Assert $page) => $page
                 ->component('{{security_settings}}')
                 ->where('canManageTwoFactor', true)
-                ->where('twoFactorEnabled', false),
+                ->where('twoFactorEnabled', false)
+                ->where('twoFactorUrls', [
+                    'enableUrl' => route('two-factor.enable'),
+                    'disableUrl' => route('two-factor.disable'),
+                    'confirmUrl' => route('two-factor.confirm'),
+                    'qrCodeUrl' => route('two-factor.qr-code'),
+                    'secretKeyUrl' => route('two-factor.secret-key'),
+                    'recoveryCodesUrl' => route('two-factor.recovery-codes'),
+                    'regenerateUrl' => route('two-factor.regenerate-recovery-codes'),
+                ]),
             );
     }
 
@@ -84,6 +93,7 @@ class SecurityTest extends TestCase
             ->assertInertia(fn (Assert $page) => $page
                 ->component('{{security_settings}}')
                 ->where('canManageTwoFactor', false)
+                ->where('twoFactorUrls', null)
                 ->missing('twoFactorEnabled')
                 ->missing('requiresConfirmation'),
             );

--- a/kits/Inertia/Fortify/Base/tests/Feature/WelcomeTest.php
+++ b/kits/Inertia/Fortify/Base/tests/Feature/WelcomeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Laravel\Fortify\Features;
+use Tests\TestCase;
+
+class WelcomeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_welcome_screen_can_be_rendered(): void
+    {
+        $response = $this->get(route('home'));
+
+        $response->assertOk();
+
+        $featureEnabled = Features::enabled(Features::registration());
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{welcome}}')
+            ->where('canRegister', $featureEnabled)
+            ->where('registerUrl', $featureEnabled ? route('register') : null),
+        );
+    }
+
+    public function test_welcome_screen_omits_register_url_when_registration_is_disabled(): void
+    {
+        config(['fortify.features' => []]);
+
+        $response = $this->get(route('home'));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{welcome}}')
+            ->where('canRegister', false)
+            ->where('registerUrl', null),
+        );
+    }
+}

--- a/kits/Inertia/Fortify/React/resources/js/components/two-factor-recovery-codes.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/components/two-factor-recovery-codes.tsx
@@ -10,18 +10,19 @@ import {
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
-import { regenerateRecoveryCodes } from '@/routes/two-factor';
 
 type Props = {
     recoveryCodesList: string[];
     fetchRecoveryCodes: () => Promise<void>;
     errors: string[];
+    regenerateUrl: string;
 };
 
 export default function TwoFactorRecoveryCodes({
     recoveryCodesList,
     fetchRecoveryCodes,
     errors,
+    regenerateUrl,
 }: Props) {
     const [codesAreVisible, setCodesAreVisible] = useState<boolean>(false);
     const codesSectionRef = useRef<HTMLDivElement | null>(null);
@@ -81,7 +82,8 @@ export default function TwoFactorRecoveryCodes({
 
                     {canRegenerateCodes && (
                         <Form
-                            {...regenerateRecoveryCodes.form()}
+                            action={regenerateUrl}
+                            method="post"
                             options={{ preserveScroll: true }}
                             onSuccess={fetchRecoveryCodes}
                         >

--- a/kits/Inertia/Fortify/React/resources/js/components/two-factor-setup-modal.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/components/two-factor-setup-modal.tsx
@@ -21,7 +21,6 @@ import { Spinner } from '@/components/ui/spinner';
 import { useAppearance } from '@/hooks/use-appearance';
 import { useClipboard } from '@/hooks/use-clipboard';
 import { OTP_MAX_LENGTH } from '@/hooks/use-two-factor-auth';
-import { confirm } from '@/routes/two-factor';
 
 function GridScanIcon() {
     return (
@@ -141,9 +140,11 @@ function TwoFactorSetupStep({
 function TwoFactorVerificationStep({
     onClose,
     onBack,
+    confirmUrl,
 }: {
     onClose: () => void;
     onBack: () => void;
+    confirmUrl: string;
 }) {
     const [code, setCode] = useState<string>('');
     const pinInputContainerRef = useRef<HTMLDivElement>(null);
@@ -156,7 +157,8 @@ function TwoFactorVerificationStep({
 
     return (
         <Form
-            {...confirm.form()}
+            action={confirmUrl}
+            method="post"
             onSuccess={() => onClose()}
             resetOnError
             resetOnSuccess
@@ -238,6 +240,7 @@ type Props = {
     clearSetupData: () => void;
     fetchSetupData: () => Promise<void>;
     errors: string[];
+    confirmUrl: string;
 };
 
 export default function TwoFactorSetupModal({
@@ -250,6 +253,7 @@ export default function TwoFactorSetupModal({
     clearSetupData,
     fetchSetupData,
     errors,
+    confirmUrl,
 }: Props) {
     const [showVerificationStep, setShowVerificationStep] =
         useState<boolean>(false);
@@ -333,6 +337,7 @@ export default function TwoFactorSetupModal({
                         <TwoFactorVerificationStep
                             onClose={handleClose}
                             onBack={() => setShowVerificationStep(false)}
+                            confirmUrl={confirmUrl}
                         />
                     ) : (
                         <TwoFactorSetupStep

--- a/kits/Inertia/Fortify/React/resources/js/hooks/use-two-factor-auth.ts
+++ b/kits/Inertia/Fortify/React/resources/js/hooks/use-two-factor-auth.ts
@@ -1,6 +1,11 @@
 import { useHttp } from '@inertiajs/react';
 import { useCallback, useState } from 'react';
-import { qrCode, recoveryCodes, secretKey } from '@/routes/two-factor';
+
+export type UseTwoFactorAuthArgs = {
+    qrCodeUrl: string;
+    secretKeyUrl: string;
+    recoveryCodesUrl: string;
+};
 
 export type UseTwoFactorAuthReturn = {
     qrCodeSvg: string | null;
@@ -19,7 +24,11 @@ export type UseTwoFactorAuthReturn = {
 
 export const OTP_MAX_LENGTH = 6;
 
-export const useTwoFactorAuth = (): UseTwoFactorAuthReturn => {
+export const useTwoFactorAuth = ({
+    qrCodeUrl,
+    secretKeyUrl,
+    recoveryCodesUrl,
+}: UseTwoFactorAuthArgs): UseTwoFactorAuthReturn => {
     const { submit } = useHttp();
 
     const [qrCodeSvg, setQrCodeSvg] = useState<string | null>(null);
@@ -48,7 +57,10 @@ export const useTwoFactorAuth = (): UseTwoFactorAuthReturn => {
 
     const fetchQrCode = useCallback(async (): Promise<void> => {
         try {
-            const { svg } = (await submit(qrCode())) as {
+            const { svg } = (await submit({
+                url: qrCodeUrl,
+                method: 'get',
+            })) as {
                 svg: string;
                 url: string;
             };
@@ -58,11 +70,14 @@ export const useTwoFactorAuth = (): UseTwoFactorAuthReturn => {
             setErrors((prev) => [...prev, 'Failed to fetch QR code']);
             setQrCodeSvg(null);
         }
-    }, [submit]);
+    }, [submit, qrCodeUrl]);
 
     const fetchSetupKey = useCallback(async (): Promise<void> => {
         try {
-            const { secretKey: key } = (await submit(secretKey())) as {
+            const { secretKey: key } = (await submit({
+                url: secretKeyUrl,
+                method: 'get',
+            })) as {
                 secretKey: string;
             };
 
@@ -71,18 +86,21 @@ export const useTwoFactorAuth = (): UseTwoFactorAuthReturn => {
             setErrors((prev) => [...prev, 'Failed to fetch a setup key']);
             setManualSetupKey(null);
         }
-    }, [submit]);
+    }, [submit, secretKeyUrl]);
 
     const fetchRecoveryCodes = useCallback(async (): Promise<void> => {
         try {
             setErrors([]);
-            const codes = (await submit(recoveryCodes())) as string[];
+            const codes = (await submit({
+                url: recoveryCodesUrl,
+                method: 'get',
+            })) as string[];
             setRecoveryCodesList(codes);
         } catch {
             setErrors((prev) => [...prev, 'Failed to fetch recovery codes']);
             setRecoveryCodesList([]);
         }
-    }, [submit]);
+    }, [submit, recoveryCodesUrl]);
 
     const fetchSetupData = useCallback(async (): Promise<void> => {
         try {

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/forgot-password.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/forgot-password.tsx
@@ -7,9 +7,16 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { login } from '@/routes';
-import { email } from '@/routes/password';
 
-export default function ForgotPassword({ status }: { status?: string }) {
+type Props = {
+    status?: string;
+    forgotPasswordSubmitUrl: string;
+};
+
+export default function ForgotPassword({
+    status,
+    forgotPasswordSubmitUrl,
+}: Props) {
     return (
         <>
             <Head title="Forgot password" />
@@ -21,7 +28,7 @@ export default function ForgotPassword({ status }: { status?: string }) {
             )}
 
             <div className="space-y-6">
-                <Form {...email.form()}>
+                <Form action={forgotPasswordSubmitUrl} method="post">
                     {({ processing, errors }) => (
                         <>
                             <div className="grid gap-2">

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/login.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/login.tsx
@@ -7,20 +7,22 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
-import { register } from '@/routes';
 import { store } from '@/routes/login';
-import { request } from '@/routes/password';
 
 type Props = {
     status?: string;
     canResetPassword: boolean;
     canRegister: boolean;
+    registerUrl: string | null;
+    forgotPasswordUrl: string | null;
 };
 
 export default function Login({
     status,
     canResetPassword,
     canRegister,
+    registerUrl,
+    forgotPasswordUrl,
 }: Props) {
     return (
         <>
@@ -52,9 +54,9 @@ export default function Login({
                             <div className="grid gap-2">
                                 <div className="flex items-center">
                                     <Label htmlFor="password">Password</Label>
-                                    {canResetPassword && (
+                                    {canResetPassword && forgotPasswordUrl && (
                                         <TextLink
-                                            href={request()}
+                                            href={forgotPasswordUrl}
                                             className="ml-auto text-sm"
                                             tabIndex={5}
                                         >
@@ -94,10 +96,10 @@ export default function Login({
                             </Button>
                         </div>
 
-                        {canRegister && (
+                        {canRegister && registerUrl && (
                             <div className="text-center text-sm text-muted-foreground">
                                 Don't have an account?{' '}
-                                <TextLink href={register()} tabIndex={5}>
+                                <TextLink href={registerUrl} tabIndex={5}>
                                     Sign up
                                 </TextLink>
                             </div>

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/register.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/register.tsx
@@ -7,14 +7,18 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
 import { login } from '@/routes';
-import { store } from '@/routes/register';
 
-export default function Register() {
+type Props = {
+    registerUrl: string;
+};
+
+export default function Register({ registerUrl }: Props) {
     return (
         <>
             <Head title="Register" />
             <Form
-                {...store.form()}
+                action={registerUrl}
+                method="post"
                 resetOnSuccess={['password', 'password_confirmation']}
                 disableWhileProcessing
                 className="flex flex-col gap-6"

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/reset-password.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/reset-password.tsx
@@ -5,20 +5,25 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
-import { update } from '@/routes/password';
 
 type Props = {
     token: string;
     email: string;
+    resetPasswordSubmitUrl: string;
 };
 
-export default function ResetPassword({ token, email }: Props) {
+export default function ResetPassword({
+    token,
+    email,
+    resetPasswordSubmitUrl,
+}: Props) {
     return (
         <>
             <Head title="Reset password" />
 
             <Form
-                {...update.form()}
+                action={resetPasswordSubmitUrl}
+                method="post"
                 transform={(data) => ({ ...data, token, email })}
                 resetOnSuccess={['password', 'password_confirmation']}
             >

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/two-factor-challenge.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/two-factor-challenge.tsx
@@ -10,9 +10,12 @@ import {
     InputOTPSlot,
 } from '@/components/ui/input-otp';
 import { OTP_MAX_LENGTH } from '@/hooks/use-two-factor-auth';
-import { store } from '@/routes/two-factor/login';
 
-export default function TwoFactorChallenge() {
+type Props = {
+    twoFactorLoginUrl: string;
+};
+
+export default function TwoFactorChallenge({ twoFactorLoginUrl }: Props) {
     const [showRecoveryInput, setShowRecoveryInput] = useState<boolean>(false);
     const [code, setCode] = useState<string>('');
 
@@ -55,7 +58,8 @@ export default function TwoFactorChallenge() {
 
             <div className="space-y-6">
                 <Form
-                    {...store.form()}
+                    action={twoFactorLoginUrl}
+                    method="post"
                     className="space-y-4"
                     resetOnError
                     resetOnSuccess={!showRecoveryInput}

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/verify-email.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/verify-email.tsx
@@ -4,9 +4,13 @@ import TextLink from '@/components/text-link';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 import { logout } from '@/routes';
-import { send } from '@/routes/verification';
 
-export default function VerifyEmail({ status }: { status?: string }) {
+type Props = {
+    status?: string;
+    verificationSendUrl: string;
+};
+
+export default function VerifyEmail({ status, verificationSendUrl }: Props) {
     return (
         <>
             <Head title="Email verification" />
@@ -18,7 +22,11 @@ export default function VerifyEmail({ status }: { status?: string }) {
                 </div>
             )}
 
-            <Form {...send.form()} className="space-y-6 text-center">
+            <Form
+                action={verificationSendUrl}
+                method="post"
+                className="space-y-6 text-center"
+            >
                 {({ processing }) => (
                     <>
                         <Button disabled={processing} variant="secondary">

--- a/kits/Inertia/Fortify/React/resources/js/pages/settings/security.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/settings/security.tsx
@@ -11,21 +11,34 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { useTwoFactorAuth } from '@/hooks/use-two-factor-auth';
 import { edit } from '@/routes/security';
-import { disable, enable } from '@/routes/two-factor';
+
+export type TwoFactorUrls = {
+    enableUrl: string;
+    disableUrl: string;
+    confirmUrl: string;
+    qrCodeUrl: string;
+    secretKeyUrl: string;
+    recoveryCodesUrl: string;
+    regenerateUrl: string;
+};
 
 type Props = {
     canManageTwoFactor?: boolean;
     requiresConfirmation?: boolean;
     twoFactorEnabled?: boolean;
+    twoFactorUrls?: TwoFactorUrls | null;
 };
 
 export default function Security({
     canManageTwoFactor = false,
     requiresConfirmation = false,
     twoFactorEnabled = false,
+    twoFactorUrls = null,
 }: Props) {
     const passwordInput = useRef<HTMLInputElement>(null);
     const currentPasswordInput = useRef<HTMLInputElement>(null);
+
+    const showTwoFactor = canManageTwoFactor && twoFactorUrls !== null;
 
     const {
         qrCodeSvg,
@@ -37,7 +50,11 @@ export default function Security({
         recoveryCodesList,
         fetchRecoveryCodes,
         errors,
-    } = useTwoFactorAuth();
+    } = useTwoFactorAuth({
+        qrCodeUrl: twoFactorUrls?.qrCodeUrl ?? '',
+        secretKeyUrl: twoFactorUrls?.secretKeyUrl ?? '',
+        recoveryCodesUrl: twoFactorUrls?.recoveryCodesUrl ?? '',
+    });
     const [showSetupModal, setShowSetupModal] = useState<boolean>(false);
     const prevTwoFactorEnabled = useRef(twoFactorEnabled);
 
@@ -149,7 +166,7 @@ export default function Security({
                 </Form>
             </div>
 
-            {canManageTwoFactor && (
+            {showTwoFactor && twoFactorUrls && (
                 <div className="space-y-6">
                     <Heading
                         variant="small"
@@ -165,7 +182,10 @@ export default function Security({
                             </p>
 
                             <div className="relative inline">
-                                <Form {...disable.form()}>
+                                <Form
+                                    action={twoFactorUrls.disableUrl}
+                                    method="delete"
+                                >
                                     {({ processing }) => (
                                         <Button
                                             variant="destructive"
@@ -182,6 +202,7 @@ export default function Security({
                                 recoveryCodesList={recoveryCodesList}
                                 fetchRecoveryCodes={fetchRecoveryCodes}
                                 errors={errors}
+                                regenerateUrl={twoFactorUrls.regenerateUrl}
                             />
                         </div>
                     ) : (
@@ -203,7 +224,8 @@ export default function Security({
                                     </Button>
                                 ) : (
                                     <Form
-                                        {...enable.form()}
+                                        action={twoFactorUrls.enableUrl}
+                                        method="post"
                                         onSuccess={() =>
                                             setShowSetupModal(true)
                                         }
@@ -232,6 +254,7 @@ export default function Security({
                         clearSetupData={clearSetupData}
                         fetchSetupData={fetchSetupData}
                         errors={errors}
+                        confirmUrl={twoFactorUrls.confirmUrl}
                     />
                 </div>
             )}

--- a/kits/Inertia/Fortify/Svelte/resources/js/components/TwoFactorRecoveryCodes.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/components/TwoFactorRecoveryCodes.svelte
@@ -15,7 +15,12 @@
         CardTitle,
     } from '@/components/ui/card';
     import { twoFactorAuthState } from '@/lib/twoFactorAuth.svelte';
-    import { regenerateRecoveryCodes } from '@/routes/two-factor';
+
+    let {
+        regenerateUrl,
+    }: {
+        regenerateUrl: string;
+    } = $props();
 
     const twoFactorAuth = twoFactorAuthState();
     let isRecoveryCodesVisible = $state(false);
@@ -69,7 +74,8 @@
 
             {#if isRecoveryCodesVisible && twoFactorAuth.state.recoveryCodesList.length}
                 <Form
-                    {...regenerateRecoveryCodes.form()}
+                    action={regenerateUrl}
+                    method="post"
                     options={{ preserveScroll: true }}
                     onSuccess={() => twoFactorAuth.fetchRecoveryCodes()}
                 >

--- a/kits/Inertia/Fortify/Svelte/resources/js/components/TwoFactorSetupModal.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/components/TwoFactorSetupModal.svelte
@@ -21,16 +21,17 @@
     import { Spinner } from '@/components/ui/spinner';
     import { themeState } from '@/lib/theme.svelte';
     import { twoFactorAuthState } from '@/lib/twoFactorAuth.svelte';
-    import { confirm } from '@/routes/two-factor';
     import type { TwoFactorConfigContent } from '@/types';
 
     let {
         requiresConfirmation,
         twoFactorEnabled,
+        confirmUrl,
         isOpen = $bindable(false),
     }: {
         requiresConfirmation: boolean;
         twoFactorEnabled: boolean;
+        confirmUrl: string;
         isOpen?: boolean;
     } = $props();
 
@@ -250,7 +251,8 @@
                 {/if}
             {:else}
                 <Form
-                    {...confirm.form()}
+                    action={confirmUrl}
+                    method="post"
                     resetOnError
                     onFinish={() => (code = '')}
                     onSuccess={() => (isOpen = false)}

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/ForgotPassword.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/ForgotPassword.svelte
@@ -15,12 +15,13 @@
     import { Label } from '@/components/ui/label';
     import { Spinner } from '@/components/ui/spinner';
     import { login } from '@/routes';
-    import { email } from '@/routes/password';
 
     let {
         status = '',
+        forgotPasswordSubmitUrl,
     }: {
         status?: string;
+        forgotPasswordSubmitUrl: string;
     } = $props();
 </script>
 
@@ -33,7 +34,7 @@
 {/if}
 
 <div class="space-y-6">
-    <Form {...email.form()}>
+    <Form action={forgotPasswordSubmitUrl} method="post">
         {#snippet children({ errors, processing })}
             <div class="grid gap-2">
                 <Label for="email">Email address</Label>

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Login.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Login.svelte
@@ -16,18 +16,20 @@
     import { Input } from '@/components/ui/input';
     import { Label } from '@/components/ui/label';
     import { Spinner } from '@/components/ui/spinner';
-    import { register } from '@/routes';
     import { store } from '@/routes/login';
-    import { request } from '@/routes/password';
 
     let {
         status = '',
         canResetPassword,
         canRegister,
+        registerUrl,
+        forgotPasswordUrl,
     }: {
         status?: string;
         canResetPassword: boolean;
         canRegister: boolean;
+        registerUrl: string | null;
+        forgotPasswordUrl: string | null;
     } = $props();
 </script>
 
@@ -62,8 +64,8 @@
             <div class="grid gap-2">
                 <div class="flex items-center justify-between">
                     <Label for="password">Password</Label>
-                    {#if canResetPassword}
-                        <TextLink href={request()} class="text-sm">
+                    {#if canResetPassword && forgotPasswordUrl}
+                        <TextLink href={forgotPasswordUrl} class="text-sm">
                             Forgot password?
                         </TextLink>
                     {/if}
@@ -96,10 +98,10 @@
             </Button>
         </div>
 
-        {#if canRegister}
+        {#if canRegister && registerUrl}
             <div class="text-center text-sm text-muted-foreground">
                 Don't have an account?
-                <TextLink href={register()}>Sign up</TextLink>
+                <TextLink href={registerUrl}>Sign up</TextLink>
             </div>
         {/if}
     {/snippet}

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Register.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Register.svelte
@@ -16,13 +16,19 @@
     import { Label } from '@/components/ui/label';
     import { Spinner } from '@/components/ui/spinner';
     import { login } from '@/routes';
-    import { store } from '@/routes/register';
+
+    let {
+        registerUrl,
+    }: {
+        registerUrl: string;
+    } = $props();
 </script>
 
 <AppHead title="Register" />
 
 <Form
-    {...store.form()}
+    action={registerUrl}
+    method="post"
     resetOnSuccess={['password', 'password_confirmation']}
     class="flex flex-col gap-6"
 >

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/ResetPassword.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/ResetPassword.svelte
@@ -14,21 +14,23 @@
     import { Input } from '@/components/ui/input';
     import { Label } from '@/components/ui/label';
     import { Spinner } from '@/components/ui/spinner';
-    import { update } from '@/routes/password';
 
     let {
         token,
         email,
+        resetPasswordSubmitUrl,
     }: {
         token: string;
         email: string;
+        resetPasswordSubmitUrl: string;
     } = $props();
 </script>
 
 <AppHead title="Reset password" />
 
 <Form
-    {...update.form()}
+    action={resetPasswordSubmitUrl}
+    method="post"
     transform={(data) => ({ ...data, token, email })}
     resetOnSuccess={['password', 'password_confirmation']}
 >

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/TwoFactorChallenge.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/TwoFactorChallenge.svelte
@@ -9,8 +9,13 @@
         InputOTPGroup,
         InputOTPSlot,
     } from '@/components/ui/input-otp';
-    import { store } from '@/routes/two-factor/login';
     import type { TwoFactorConfigContent } from '@/types';
+
+    let {
+        twoFactorLoginUrl,
+    }: {
+        twoFactorLoginUrl: string;
+    } = $props();
 
     let showRecoveryInput = $state(false);
     let code = $state('');
@@ -52,7 +57,8 @@
 <div class="space-y-6">
     {#if !showRecoveryInput}
         <Form
-            {...store.form()}
+            action={twoFactorLoginUrl}
+            method="post"
             class="space-y-4"
             resetOnError
             onError={() => (code = '')}
@@ -94,7 +100,12 @@
             {/snippet}
         </Form>
     {:else}
-        <Form {...store.form()} class="space-y-4" resetOnError>
+        <Form
+            action={twoFactorLoginUrl}
+            method="post"
+            class="space-y-4"
+            resetOnError
+        >
             {#snippet children({ errors, processing, clearErrors })}
                 <Input
                     name="recovery_code"

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/VerifyEmail.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/VerifyEmail.svelte
@@ -13,12 +13,13 @@
     import { Button } from '@/components/ui/button';
     import { Spinner } from '@/components/ui/spinner';
     import { logout } from '@/routes';
-    import { send } from '@/routes/verification';
 
     let {
         status = '',
+        verificationSendUrl,
     }: {
         status?: string;
+        verificationSendUrl: string;
     } = $props();
 </script>
 
@@ -31,7 +32,7 @@
     </div>
 {/if}
 
-<Form {...send.form()} class="space-y-6 text-center">
+<Form action={verificationSendUrl} method="post" class="space-y-6 text-center">
     {#snippet children({ processing })}
         <Button type="submit" disabled={processing} variant="secondary">
             {#if processing}<Spinner />{/if}

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/settings/Security.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/settings/Security.svelte
@@ -25,19 +25,38 @@
     import { Button } from '@/components/ui/button';
     import { Label } from '@/components/ui/label';
     import { twoFactorAuthState } from '@/lib/twoFactorAuth.svelte';
-    import { disable, enable } from '@/routes/two-factor';
+
+    export type TwoFactorUrls = {
+        enableUrl: string;
+        disableUrl: string;
+        confirmUrl: string;
+        qrCodeUrl: string;
+        secretKeyUrl: string;
+        recoveryCodesUrl: string;
+        regenerateUrl: string;
+    };
 
     let {
         canManageTwoFactor = false,
         requiresConfirmation = false,
         twoFactorEnabled = false,
+        twoFactorUrls = null,
     }: {
         canManageTwoFactor?: boolean;
         requiresConfirmation?: boolean;
         twoFactorEnabled?: boolean;
+        twoFactorUrls?: TwoFactorUrls | null;
     } = $props();
 
-    const twoFactorAuth = twoFactorAuthState();
+    const twoFactorAuth = twoFactorAuthState(
+        twoFactorUrls
+            ? {
+                  qrCodeUrl: twoFactorUrls.qrCodeUrl,
+                  secretKeyUrl: twoFactorUrls.secretKeyUrl,
+                  recoveryCodesUrl: twoFactorUrls.recoveryCodesUrl,
+              }
+            : undefined,
+    );
     let showSetupModal = $state(false);
 
     onDestroy(() => twoFactorAuth.clearTwoFactorAuthData());
@@ -111,7 +130,7 @@
     </Form>
 </div>
 
-{#if canManageTwoFactor}
+{#if canManageTwoFactor && twoFactorUrls}
     <div class="space-y-6">
         <Heading
             variant="small"
@@ -134,7 +153,8 @@
                         </Button>
                     {:else}
                         <Form
-                            {...enable.form()}
+                            action={twoFactorUrls.enableUrl}
+                            method="post"
                             onSuccess={() => (showSetupModal = true)}
                         >
                             {#snippet children({ processing })}
@@ -155,7 +175,7 @@
                 </p>
 
                 <div class="relative inline">
-                    <Form {...disable.form()}>
+                    <Form action={twoFactorUrls.disableUrl} method="delete">
                         {#snippet children({ processing })}
                             <Button
                                 variant="destructive"
@@ -168,7 +188,9 @@
                     </Form>
                 </div>
 
-                <TwoFactorRecoveryCodes />
+                <TwoFactorRecoveryCodes
+                    regenerateUrl={twoFactorUrls.regenerateUrl}
+                />
             </div>
         {/if}
 
@@ -176,6 +198,7 @@
             bind:isOpen={showSetupModal}
             {requiresConfirmation}
             {twoFactorEnabled}
+            confirmUrl={twoFactorUrls.confirmUrl}
         />
     </div>
 {/if}

--- a/kits/Inertia/Fortify/Vue/resources/js/components/TwoFactorRecoveryCodes.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/components/TwoFactorRecoveryCodes.vue
@@ -12,7 +12,10 @@ import {
     CardTitle,
 } from '@/components/ui/card';
 import { useTwoFactorAuth } from '@/composables/useTwoFactorAuth';
-import { regenerateRecoveryCodes } from '@/routes/two-factor';
+
+defineProps<{
+    regenerateUrl: string;
+}>();
 
 const { recoveryCodesList, fetchRecoveryCodes, errors } = useTwoFactorAuth();
 const isRecoveryCodesVisible = ref<boolean>(false);
@@ -64,7 +67,7 @@ onMounted(async () => {
 
                 <Form
                     v-if="isRecoveryCodesVisible && recoveryCodesList.length"
-                    v-bind="regenerateRecoveryCodes.form()"
+                    :action="regenerateUrl"
                     method="post"
                     :options="{ preserveScroll: true }"
                     @success="fetchRecoveryCodes"

--- a/kits/Inertia/Fortify/Vue/resources/js/components/TwoFactorSetupModal.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/components/TwoFactorSetupModal.vue
@@ -21,12 +21,12 @@ import {
 import { Spinner } from '@/components/ui/spinner';
 import { useAppearance } from '@/composables/useAppearance';
 import { useTwoFactorAuth } from '@/composables/useTwoFactorAuth';
-import { confirm } from '@/routes/two-factor';
 import type { TwoFactorConfigContent } from '@/types';
 
 type Props = {
     requiresConfirmation: boolean;
     twoFactorEnabled: boolean;
+    confirmUrl: string;
 };
 
 const { resolvedAppearance } = useAppearance();
@@ -238,7 +238,8 @@ watch(
 
                 <template v-else>
                     <Form
-                        v-bind="confirm.form()"
+                        :action="confirmUrl"
+                        method="post"
                         error-bag="confirmTwoFactorAuthentication"
                         reset-on-error
                         @finish="code = ''"

--- a/kits/Inertia/Fortify/Vue/resources/js/composables/useTwoFactorAuth.ts
+++ b/kits/Inertia/Fortify/Vue/resources/js/composables/useTwoFactorAuth.ts
@@ -1,7 +1,12 @@
 import { useHttp } from '@inertiajs/vue3';
 import type { ComputedRef, Ref } from 'vue';
 import { computed, ref } from 'vue';
-import { qrCode, recoveryCodes, secretKey } from '@/routes/two-factor';
+
+export type TwoFactorAuthUrls = {
+    qrCodeUrl: string;
+    secretKeyUrl: string;
+    recoveryCodesUrl: string;
+};
 
 export type UseTwoFactorAuthReturn = {
     qrCodeSvg: Ref<string | null>;
@@ -22,17 +27,31 @@ const errors = ref<string[]>([]);
 const manualSetupKey = ref<string | null>(null);
 const qrCodeSvg = ref<string | null>(null);
 const recoveryCodesList = ref<string[]>([]);
+const cachedUrls = ref<TwoFactorAuthUrls | null>(null);
 
 const hasSetupData = computed<boolean>(
     () => qrCodeSvg.value !== null && manualSetupKey.value !== null,
 );
 
-export const useTwoFactorAuth = (): UseTwoFactorAuthReturn => {
+export const useTwoFactorAuth = (
+    urls?: TwoFactorAuthUrls,
+): UseTwoFactorAuthReturn => {
     const http = useHttp();
 
+    if (urls) {
+        cachedUrls.value = urls;
+    }
+
     const fetchQrCode = async (): Promise<void> => {
+        if (!cachedUrls.value) {
+            return;
+        }
+
         try {
-            const { svg } = (await http.submit(qrCode())) as {
+            const { svg } = (await http.submit({
+                url: cachedUrls.value.qrCodeUrl,
+                method: 'get',
+            })) as {
                 svg: string;
                 url: string;
             };
@@ -45,8 +64,15 @@ export const useTwoFactorAuth = (): UseTwoFactorAuthReturn => {
     };
 
     const fetchSetupKey = async (): Promise<void> => {
+        if (!cachedUrls.value) {
+            return;
+        }
+
         try {
-            const { secretKey: key } = (await http.submit(secretKey())) as {
+            const { secretKey: key } = (await http.submit({
+                url: cachedUrls.value.secretKeyUrl,
+                method: 'get',
+            })) as {
                 secretKey: string;
             };
 
@@ -74,11 +100,16 @@ export const useTwoFactorAuth = (): UseTwoFactorAuthReturn => {
     };
 
     const fetchRecoveryCodes = async (): Promise<void> => {
+        if (!cachedUrls.value) {
+            return;
+        }
+
         try {
             clearErrors();
-            recoveryCodesList.value = (await http.submit(
-                recoveryCodes(),
-            )) as string[];
+            recoveryCodesList.value = (await http.submit({
+                url: cachedUrls.value.recoveryCodesUrl,
+                method: 'get',
+            })) as string[];
         } catch {
             errors.value.push('Failed to fetch recovery codes');
             recoveryCodesList.value = [];

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ForgotPassword.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ForgotPassword.vue
@@ -7,7 +7,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
 import { login } from '@/routes';
-import { email } from '@/routes/password';
 
 defineOptions({
     layout: {
@@ -18,6 +17,7 @@ defineOptions({
 
 defineProps<{
     status?: string;
+    forgotPasswordSubmitUrl: string;
 }>();
 </script>
 
@@ -32,7 +32,11 @@ defineProps<{
     </div>
 
     <div class="space-y-6">
-        <Form v-bind="email.form()" v-slot="{ errors, processing }">
+        <Form
+            :action="forgotPasswordSubmitUrl"
+            method="post"
+            v-slot="{ errors, processing }"
+        >
             <div class="grid gap-2">
                 <Label for="email">Email address</Label>
                 <Input

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Login.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Login.vue
@@ -8,9 +8,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
-import { register } from '@/routes';
 import { store } from '@/routes/login';
-import { request } from '@/routes/password';
 
 defineOptions({
     layout: {
@@ -23,6 +21,8 @@ defineProps<{
     status?: string;
     canResetPassword: boolean;
     canRegister: boolean;
+    registerUrl: string | null;
+    forgotPasswordUrl: string | null;
 }>();
 </script>
 
@@ -62,8 +62,8 @@ defineProps<{
                 <div class="flex items-center justify-between">
                     <Label for="password">Password</Label>
                     <TextLink
-                        v-if="canResetPassword"
-                        :href="request()"
+                        v-if="canResetPassword && forgotPasswordUrl"
+                        :href="forgotPasswordUrl"
                         class="text-sm"
                         :tabindex="5"
                     >
@@ -102,10 +102,10 @@ defineProps<{
 
         <div
             class="text-center text-sm text-muted-foreground"
-            v-if="canRegister"
+            v-if="canRegister && registerUrl"
         >
             Don't have an account?
-            <TextLink :href="register()" :tabindex="5">Sign up</TextLink>
+            <TextLink :href="registerUrl" :tabindex="5">Sign up</TextLink>
         </div>
     </Form>
 </template>

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Register.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Register.vue
@@ -8,7 +8,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
 import { login } from '@/routes';
-import { store } from '@/routes/register';
 
 defineOptions({
     layout: {
@@ -16,13 +15,18 @@ defineOptions({
         description: 'Enter your details below to create your account',
     },
 });
+
+defineProps<{
+    registerUrl: string;
+}>();
 </script>
 
 <template>
     <Head title="Register" />
 
     <Form
-        v-bind="store.form()"
+        :action="registerUrl"
+        method="post"
         :reset-on-success="['password', 'password_confirmation']"
         v-slot="{ errors, processing }"
         class="flex flex-col gap-6"

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ResetPassword.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ResetPassword.vue
@@ -7,7 +7,6 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
-import { update } from '@/routes/password';
 
 defineOptions({
     layout: {
@@ -19,6 +18,7 @@ defineOptions({
 const props = defineProps<{
     token: string;
     email: string;
+    resetPasswordSubmitUrl: string;
 }>();
 
 const inputEmail = ref(props.email);
@@ -28,7 +28,8 @@ const inputEmail = ref(props.email);
     <Head title="Reset password" />
 
     <Form
-        v-bind="update.form()"
+        :action="resetPasswordSubmitUrl"
+        method="post"
         :transform="(data) => ({ ...data, token, email })"
         :reset-on-success="['password', 'password_confirmation']"
         v-slot="{ errors, processing }"

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/TwoFactorChallenge.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/TwoFactorChallenge.vue
@@ -9,8 +9,11 @@ import {
     InputOTPGroup,
     InputOTPSlot,
 } from '@/components/ui/input-otp';
-import { store } from '@/routes/two-factor/login';
 import type { TwoFactorConfigContent } from '@/types';
+
+defineProps<{
+    twoFactorLoginUrl: string;
+}>();
 
 const authConfigContent = computed<TwoFactorConfigContent>(() => {
     if (showRecoveryInput.value) {
@@ -54,7 +57,8 @@ const code = ref<string>('');
     <div class="space-y-6">
         <template v-if="!showRecoveryInput">
             <Form
-                v-bind="store.form()"
+                :action="twoFactorLoginUrl"
+                method="post"
                 class="space-y-4"
                 reset-on-error
                 @error="code = ''"
@@ -101,7 +105,8 @@ const code = ref<string>('');
 
         <template v-else>
             <Form
-                v-bind="store.form()"
+                :action="twoFactorLoginUrl"
+                method="post"
                 class="space-y-4"
                 reset-on-error
                 #default="{ errors, processing, clearErrors }"

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/VerifyEmail.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/VerifyEmail.vue
@@ -4,7 +4,6 @@ import TextLink from '@/components/TextLink.vue';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 import { logout } from '@/routes';
-import { send } from '@/routes/verification';
 
 defineOptions({
     layout: {
@@ -16,6 +15,7 @@ defineOptions({
 
 defineProps<{
     status?: string;
+    verificationSendUrl: string;
 }>();
 </script>
 
@@ -31,7 +31,8 @@ defineProps<{
     </div>
 
     <Form
-        v-bind="send.form()"
+        :action="verificationSendUrl"
+        method="post"
         class="space-y-6 text-center"
         v-slot="{ processing }"
     >

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/settings/Security.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/settings/Security.vue
@@ -12,18 +12,29 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { useTwoFactorAuth } from '@/composables/useTwoFactorAuth';
 import { edit } from '@/routes/security';
-import { disable, enable } from '@/routes/two-factor';
+
+export type TwoFactorUrls = {
+    enableUrl: string;
+    disableUrl: string;
+    confirmUrl: string;
+    qrCodeUrl: string;
+    secretKeyUrl: string;
+    recoveryCodesUrl: string;
+    regenerateUrl: string;
+};
 
 type Props = {
     canManageTwoFactor?: boolean;
     requiresConfirmation?: boolean;
     twoFactorEnabled?: boolean;
+    twoFactorUrls?: TwoFactorUrls | null;
 };
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
     canManageTwoFactor: false,
     requiresConfirmation: false,
     twoFactorEnabled: false,
+    twoFactorUrls: null,
 });
 
 defineOptions({
@@ -37,7 +48,15 @@ defineOptions({
     },
 });
 
-const { hasSetupData, clearTwoFactorAuthData } = useTwoFactorAuth();
+const { hasSetupData, clearTwoFactorAuthData } = useTwoFactorAuth(
+    props.twoFactorUrls
+        ? {
+              qrCodeUrl: props.twoFactorUrls.qrCodeUrl,
+              secretKeyUrl: props.twoFactorUrls.secretKeyUrl,
+              recoveryCodesUrl: props.twoFactorUrls.recoveryCodesUrl,
+          }
+        : undefined,
+);
 const showSetupModal = ref<boolean>(false);
 
 onUnmounted(() => clearTwoFactorAuthData());
@@ -116,7 +135,7 @@ onUnmounted(() => clearTwoFactorAuthData());
         </Form>
     </div>
 
-    <div v-if="canManageTwoFactor" class="space-y-6">
+    <div v-if="canManageTwoFactor && twoFactorUrls" class="space-y-6">
         <Heading
             variant="small"
             title="Two-factor authentication"
@@ -139,7 +158,8 @@ onUnmounted(() => clearTwoFactorAuthData());
                 </Button>
                 <Form
                     v-else
-                    v-bind="enable.form()"
+                    :action="twoFactorUrls.enableUrl"
+                    method="post"
                     @success="showSetupModal = true"
                     #default="{ processing }"
                 >
@@ -158,7 +178,11 @@ onUnmounted(() => clearTwoFactorAuthData());
             </p>
 
             <div class="relative inline">
-                <Form v-bind="disable.form()" #default="{ processing }">
+                <Form
+                    :action="twoFactorUrls.disableUrl"
+                    method="delete"
+                    #default="{ processing }"
+                >
                     <Button
                         variant="destructive"
                         type="submit"
@@ -169,13 +193,16 @@ onUnmounted(() => clearTwoFactorAuthData());
                 </Form>
             </div>
 
-            <TwoFactorRecoveryCodes />
+            <TwoFactorRecoveryCodes
+                :regenerate-url="twoFactorUrls.regenerateUrl"
+            />
         </div>
 
         <TwoFactorSetupModal
             v-model:isOpen="showSetupModal"
             :requiresConfirmation="requiresConfirmation"
             :twoFactorEnabled="twoFactorEnabled"
+            :confirm-url="twoFactorUrls.confirmUrl"
         />
     </div>
 </template>

--- a/kits/Inertia/React/resources/js/pages/settings/profile.tsx
+++ b/kits/Inertia/React/resources/js/pages/settings/profile.tsx
@@ -7,13 +7,14 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { edit } from '@/routes/profile';
-import { send } from '@/routes/verification';
 
 export default function Profile({
     mustVerifyEmail,
+    verificationSendUrl = null,
     status,
 }: {
     mustVerifyEmail: boolean;
+    verificationSendUrl?: string | null;
     status?: string;
 }) {
     const { auth } = usePage().props;
@@ -80,12 +81,13 @@ export default function Profile({
                             </div>
 
                             {mustVerifyEmail &&
+                                verificationSendUrl &&
                                 auth.user.email_verified_at === null && (
                                     <div>
                                         <p className="-mt-4 text-sm text-muted-foreground">
                                             Your email address is unverified.{' '}
                                             <Link
-                                                href={send()}
+                                                href={verificationSendUrl}
                                                 as="button"
                                                 className="text-foreground underline decoration-neutral-300 underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-neutral-500"
                                             >

--- a/kits/Inertia/React/resources/js/pages/welcome.tsx
+++ b/kits/Inertia/React/resources/js/pages/welcome.tsx
@@ -1,10 +1,12 @@
 import { Head, Link, usePage } from '@inertiajs/react';
-import { dashboard, login, register } from '@/routes';
+import { dashboard, login } from '@/routes';
 
 export default function Welcome({
     canRegister = true,
+    registerUrl = null,
 }: {
     canRegister?: boolean;
+    registerUrl?: string | null;
 }) {
     const { auth } = usePage().props;
 
@@ -35,9 +37,9 @@ export default function Welcome({
                                 >
                                     Log in
                                 </Link>
-                                {canRegister && (
+                                {canRegister && registerUrl && (
                                     <Link
-                                        href={register()}
+                                        href={registerUrl}
                                         className="inline-block rounded-sm border border-[#19140035] px-5 py-1.5 text-sm leading-normal text-[#1b1b18] hover:border-[#1915014a] dark:border-[#3E3E3A] dark:text-[#EDEDEC] dark:hover:border-[#62605b]"
                                     >
                                         Register

--- a/kits/Inertia/Svelte/resources/js/lib/twoFactorAuth.svelte.ts
+++ b/kits/Inertia/Svelte/resources/js/lib/twoFactorAuth.svelte.ts
@@ -1,5 +1,10 @@
 import { useHttp } from '@inertiajs/svelte';
-import { qrCode, recoveryCodes, secretKey } from '@/routes/two-factor';
+
+export type TwoFactorAuthUrls = {
+    qrCodeUrl: string;
+    secretKeyUrl: string;
+    recoveryCodesUrl: string;
+};
 
 type TwoFactorAuthState = {
     qrCodeSvg: string | null;
@@ -27,15 +32,30 @@ const state = $state<TwoFactorAuthState>({
     errors: [],
 });
 
+let cachedUrls: TwoFactorAuthUrls | null = null;
+
 const hasSetupData = (): boolean =>
     state.qrCodeSvg !== null && state.manualSetupKey !== null;
 
-export function twoFactorAuthState(): TwoFactorAuthStateApi {
+export function twoFactorAuthState(
+    urls?: TwoFactorAuthUrls,
+): TwoFactorAuthStateApi {
     const http = useHttp();
 
+    if (urls) {
+        cachedUrls = urls;
+    }
+
     const fetchQrCode = async (): Promise<void> => {
+        if (!cachedUrls) {
+            return;
+        }
+
         try {
-            const { svg } = (await http.submit(qrCode())) as {
+            const { svg } = (await http.submit({
+                url: cachedUrls.qrCodeUrl,
+                method: 'get',
+            })) as {
                 svg: string;
                 url: string;
             };
@@ -48,8 +68,15 @@ export function twoFactorAuthState(): TwoFactorAuthStateApi {
     };
 
     const fetchSetupKey = async (): Promise<void> => {
+        if (!cachedUrls) {
+            return;
+        }
+
         try {
-            const { secretKey: key } = (await http.submit(secretKey())) as {
+            const { secretKey: key } = (await http.submit({
+                url: cachedUrls.secretKeyUrl,
+                method: 'get',
+            })) as {
                 secretKey: string;
             };
 
@@ -77,11 +104,16 @@ export function twoFactorAuthState(): TwoFactorAuthStateApi {
     };
 
     const fetchRecoveryCodes = async (): Promise<void> => {
+        if (!cachedUrls) {
+            return;
+        }
+
         try {
             clearErrors();
-            state.recoveryCodesList = (await http.submit(
-                recoveryCodes(),
-            )) as string[];
+            state.recoveryCodesList = (await http.submit({
+                url: cachedUrls.recoveryCodesUrl,
+                method: 'get',
+            })) as string[];
         } catch {
             state.errors = [...state.errors, 'Failed to fetch recovery codes'];
             state.recoveryCodesList = [];

--- a/kits/Inertia/Svelte/resources/js/pages/Welcome.svelte
+++ b/kits/Inertia/Svelte/resources/js/pages/Welcome.svelte
@@ -2,12 +2,14 @@
     import { Link, page } from '@inertiajs/svelte';
     import AppHead from '@/components/AppHead.svelte';
     import { toUrl } from '@/lib/utils';
-    import { dashboard, login, register } from '@/routes';
+    import { dashboard, login } from '@/routes';
 
     let {
         canRegister = true,
+        registerUrl = null,
     }: {
         canRegister: boolean;
+        registerUrl?: string | null;
     } = $props();
 
     const auth = $derived(page.props.auth);
@@ -39,9 +41,9 @@
                 >
                     Log in
                 </Link>
-                {#if canRegister}
+                {#if canRegister && registerUrl}
                     <Link
-                        href={toUrl(register())}
+                        href={registerUrl}
                         class="inline-block rounded-sm border border-[#19140035] px-5 py-1.5 text-sm leading-normal text-[#1b1b18] hover:border-[#1915014a] dark:border-[#3E3E3A] dark:text-[#EDEDEC] dark:hover:border-[#62605b]"
                     >
                         Register

--- a/kits/Inertia/Svelte/resources/js/pages/settings/Profile.svelte
+++ b/kits/Inertia/Svelte/resources/js/pages/settings/Profile.svelte
@@ -22,13 +22,14 @@
     import { Button } from '@/components/ui/button';
     import { Input } from '@/components/ui/input';
     import { Label } from '@/components/ui/label';
-    import { send } from '@/routes/verification';
 
     let {
         mustVerifyEmail,
+        verificationSendUrl = null,
         status = '',
     }: {
         mustVerifyEmail: boolean;
+        verificationSendUrl?: string | null;
         status?: string;
     } = $props();
 
@@ -81,11 +82,11 @@
                 <InputError class="mt-2" message={errors.email} />
             </div>
 
-            {#if mustVerifyEmail && !user.email_verified_at}
+            {#if mustVerifyEmail && verificationSendUrl && !user.email_verified_at}
                 <div>
                     <p class="-mt-4 text-sm text-muted-foreground">
                         Your email address is unverified.
-                        <TextLink href={send()} as="button">
+                        <TextLink href={verificationSendUrl} as="button">
                             Click here to resend the verification email.
                         </TextLink>
                     </p>

--- a/kits/Inertia/Teams/Fortify/Base/app/Providers/FortifyServiceProvider.php
+++ b/kits/Inertia/Teams/Fortify/Base/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Http\Responses\LoginResponse;
 use App\Http\Responses\RegisterResponse;
 use App\Http\Responses\TwoFactorLoginResponse;
+use App\Support\FortifyFeaturePayload;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
@@ -58,25 +59,34 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::loginView(fn (Request $request) => Inertia::render('{{auth_login}}', [
             'canResetPassword' => Features::enabled(Features::resetPasswords()),
             'canRegister' => Features::enabled(Features::registration()),
+            'registerUrl' => FortifyFeaturePayload::registerUrl(),
+            'forgotPasswordUrl' => FortifyFeaturePayload::forgotPasswordUrl(),
             'status' => $request->session()->get('status'),
         ]));
 
         Fortify::resetPasswordView(fn (Request $request) => Inertia::render('{{auth_reset_password}}', [
             'email' => $request->email,
             'token' => $request->route('token'),
+            'resetPasswordSubmitUrl' => FortifyFeaturePayload::resetPasswordSubmitUrl(),
         ]));
 
         Fortify::requestPasswordResetLinkView(fn (Request $request) => Inertia::render('{{auth_forgot_password}}', [
             'status' => $request->session()->get('status'),
+            'forgotPasswordSubmitUrl' => FortifyFeaturePayload::forgotPasswordSubmitUrl(),
         ]));
 
         Fortify::verifyEmailView(fn (Request $request) => Inertia::render('{{auth_verify_email}}', [
             'status' => $request->session()->get('status'),
+            'verificationSendUrl' => FortifyFeaturePayload::verificationSendUrl(),
         ]));
 
-        Fortify::registerView(fn () => Inertia::render('{{auth_register}}'));
+        Fortify::registerView(fn () => Inertia::render('{{auth_register}}', [
+            'registerUrl' => FortifyFeaturePayload::registerUrl(),
+        ]));
 
-        Fortify::twoFactorChallengeView(fn () => Inertia::render('{{auth_two_factor_challenge}}'));
+        Fortify::twoFactorChallengeView(fn () => Inertia::render('{{auth_two_factor_challenge}}', [
+            'twoFactorLoginUrl' => FortifyFeaturePayload::twoFactorLoginUrl(),
+        ]));
 
         Fortify::confirmPasswordView(fn () => Inertia::render('{{auth_confirm_password}}'));
     }

--- a/kits/Inertia/Teams/Fortify/Base/routes/web.php
+++ b/kits/Inertia/Teams/Fortify/Base/routes/web.php
@@ -2,11 +2,13 @@
 
 use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Middleware\EnsureTeamMembership;
+use App\Support\FortifyFeaturePayload;
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
 
 Route::inertia('/', '{{welcome}}', [
-    'canRegister' => Features::enabled(Features::registration()),
+    'canRegister' => fn () => Features::enabled(Features::registration()),
+    'registerUrl' => fn () => FortifyFeaturePayload::registerUrl(),
 ])->name('home');
 
 Route::prefix('{current_team}')

--- a/kits/Inertia/Teams/Fortify/Base/tests/Feature/WelcomeTest.php
+++ b/kits/Inertia/Teams/Fortify/Base/tests/Feature/WelcomeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Laravel\Fortify\Features;
+use Tests\TestCase;
+
+class WelcomeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_welcome_screen_can_be_rendered(): void
+    {
+        $response = $this->get(route('home'));
+
+        $response->assertOk();
+
+        $featureEnabled = Features::enabled(Features::registration());
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{welcome}}')
+            ->where('canRegister', $featureEnabled)
+            ->where('registerUrl', $featureEnabled ? route('register') : null),
+        );
+    }
+
+    public function test_welcome_screen_omits_register_url_when_registration_is_disabled(): void
+    {
+        config(['fortify.features' => []]);
+
+        $response = $this->get(route('home'));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{welcome}}')
+            ->where('canRegister', false)
+            ->where('registerUrl', null),
+        );
+    }
+}

--- a/kits/Inertia/Teams/Fortify/React/resources/js/pages/welcome.tsx
+++ b/kits/Inertia/Teams/Fortify/React/resources/js/pages/welcome.tsx
@@ -1,10 +1,12 @@
 import { Head, Link, usePage } from '@inertiajs/react';
-import { dashboard, login, register } from '@/routes';
+import { dashboard, login } from '@/routes';
 
 export default function Welcome({
     canRegister = true,
+    registerUrl = null,
 }: {
     canRegister?: boolean;
+    registerUrl?: string | null;
 }) {
     const { auth, currentTeam } = usePage().props;
     const dashboardUrl = currentTeam ? dashboard(currentTeam.slug) : '/';
@@ -36,9 +38,9 @@ export default function Welcome({
                                 >
                                     Log in
                                 </Link>
-                                {canRegister && (
+                                {canRegister && registerUrl && (
                                     <Link
-                                        href={register()}
+                                        href={registerUrl}
                                         className="inline-block rounded-sm border border-[#19140035] px-5 py-1.5 text-sm leading-normal text-[#1b1b18] hover:border-[#1915014a] dark:border-[#3E3E3A] dark:text-[#EDEDEC] dark:hover:border-[#62605b]"
                                     >
                                         Register

--- a/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/Welcome.svelte
+++ b/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/Welcome.svelte
@@ -2,13 +2,15 @@
     import { Link, page } from '@inertiajs/svelte';
     import AppHead from '@/components/AppHead.svelte';
     import { toUrl } from '@/lib/utils';
-    import { dashboard, login, register } from '@/routes';
+    import { dashboard, login } from '@/routes';
     import type { Team } from '@/types';
 
     let {
         canRegister = true,
+        registerUrl = null,
     }: {
         canRegister: boolean;
+        registerUrl?: string | null;
     } = $props();
 
     const auth = $derived(page.props.auth);
@@ -44,9 +46,9 @@
                 >
                     Log in
                 </Link>
-                {#if canRegister}
+                {#if canRegister && registerUrl}
                     <Link
-                        href={toUrl(register())}
+                        href={registerUrl}
                         class="inline-block rounded-sm border border-[#19140035] px-5 py-1.5 text-sm leading-normal text-[#1b1b18] hover:border-[#1915014a] dark:border-[#3E3E3A] dark:text-[#EDEDEC] dark:hover:border-[#62605b]"
                     >
                         Register

--- a/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/Welcome.vue
+++ b/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/Welcome.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
 import { Head, Link, usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
-import { dashboard, login, register } from '@/routes';
+import { dashboard, login } from '@/routes';
 
 withDefaults(
     defineProps<{
         canRegister: boolean;
+        registerUrl?: string | null;
     }>(),
     {
         canRegister: true,
+        registerUrl: null,
     },
 );
 
@@ -45,8 +47,8 @@ const dashboardUrl = computed(() =>
                         Log in
                     </Link>
                     <Link
-                        v-if="canRegister"
-                        :href="register()"
+                        v-if="canRegister && registerUrl"
+                        :href="registerUrl"
                         class="inline-block rounded-sm border border-[#19140035] px-5 py-1.5 text-sm leading-normal text-[#1b1b18] hover:border-[#1915014a] dark:border-[#3E3E3A] dark:text-[#EDEDEC] dark:hover:border-[#62605b]"
                     >
                         Register

--- a/kits/Inertia/Vue/resources/js/pages/Welcome.vue
+++ b/kits/Inertia/Vue/resources/js/pages/Welcome.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import { Head, Link } from '@inertiajs/vue3';
-import { dashboard, login, register } from '@/routes';
+import { dashboard, login } from '@/routes';
 
 withDefaults(
     defineProps<{
         canRegister: boolean;
+        registerUrl?: string | null;
     }>(),
     {
         canRegister: true,
+        registerUrl: null,
     },
 );
 </script>
@@ -39,8 +41,8 @@ withDefaults(
                         Log in
                     </Link>
                     <Link
-                        v-if="canRegister"
-                        :href="register()"
+                        v-if="canRegister && registerUrl"
+                        :href="registerUrl"
                         class="inline-block rounded-sm border border-[#19140035] px-5 py-1.5 text-sm leading-normal text-[#1b1b18] hover:border-[#1915014a] dark:border-[#3E3E3A] dark:text-[#EDEDEC] dark:hover:border-[#62605b]"
                     >
                         Register

--- a/kits/Inertia/Vue/resources/js/pages/settings/Profile.vue
+++ b/kits/Inertia/Vue/resources/js/pages/settings/Profile.vue
@@ -9,14 +9,16 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { edit } from '@/routes/profile';
-import { send } from '@/routes/verification';
 
 type Props = {
     mustVerifyEmail: boolean;
+    verificationSendUrl?: string | null;
     status?: string;
 };
 
-defineProps<Props>();
+withDefaults(defineProps<Props>(), {
+    verificationSendUrl: null,
+});
 
 defineOptions({
     layout: {
@@ -79,11 +81,17 @@ const user = computed(() => page.props.auth.user);
                 <InputError class="mt-2" :message="errors.email" />
             </div>
 
-            <div v-if="mustVerifyEmail && !user.email_verified_at">
+            <div
+                v-if="
+                    mustVerifyEmail &&
+                    verificationSendUrl &&
+                    !user.email_verified_at
+                "
+            >
                 <p class="-mt-4 text-sm text-muted-foreground">
                     Your email address is unverified.
                     <Link
-                        :href="send()"
+                        :href="verificationSendUrl"
                         as="button"
                         class="text-foreground underline decoration-neutral-300 underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-neutral-500"
                     >

--- a/orchestrator/composer.json
+++ b/orchestrator/composer.json
@@ -67,6 +67,7 @@
         ],
         "kits:check": [
             "Composer\\Config::disableProcessTimeout",
+            "node scripts/check-banned-imports.js",
             "node scripts/check-kits.js"
         ],
         "kits:browser-tests": [

--- a/orchestrator/scripts/check-banned-imports.js
+++ b/orchestrator/scripts/check-banned-imports.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const orchestratorDir = path.dirname(__dirname);
+const rootDir = path.dirname(orchestratorDir);
+const targetDir = path.join(rootDir, 'kits', 'Inertia', 'Fortify');
+
+const colors = {
+    reset: '\x1b[0m',
+    red: '\x1b[31m',
+    yellow: '\x1b[33m',
+    dim: '\x1b[2m',
+};
+
+/**
+ * Each rule fails the build if ANY of its `patterns` matches a file.
+ * Patterns are RegExps tested against the file's full source.
+ */
+const rules = [
+    {
+        label: "static import from '@/routes/register'",
+        patterns: [/from\s+['"]@\/routes\/register['"]/],
+    },
+    {
+        label: "named import { register } from '@/routes'",
+        patterns: [/import\s*{[^}]*\bregister\b[^}]*}\s*from\s+['"]@\/routes['"]/],
+    },
+    {
+        label: "static import from '@/routes/verification'",
+        patterns: [/from\s+['"]@\/routes\/verification['"]/],
+    },
+    {
+        label: "static import from '@/routes/two-factor' or '@/routes/two-factor/login'",
+        patterns: [/from\s+['"]@\/routes\/two-factor(\/login)?['"]/],
+    },
+    {
+        label: "named imports { request | email | update } from '@/routes/password'",
+        patterns: [
+            /import\s*{[^}]*\b(request|email|update)\b[^}]*}\s*from\s+['"]@\/routes\/password['"]/,
+        ],
+    },
+];
+
+const allowedExtensions = ['.ts', '.tsx', '.vue', '.svelte'];
+
+function walk(dir, files = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            if (entry.name === 'node_modules') {
+                continue;
+            }
+
+            walk(full, files);
+
+            continue;
+        }
+
+        if (allowedExtensions.includes(path.extname(entry.name))) {
+            files.push(full);
+        }
+    }
+
+    return files;
+}
+
+if (!fs.existsSync(targetDir)) {
+    console.error(`${colors.red}Target directory not found: ${targetDir}${colors.reset}`);
+    process.exit(1);
+}
+
+const files = walk(targetDir);
+const violations = [];
+
+for (const file of files) {
+    const source = fs.readFileSync(file, 'utf8');
+
+    for (const rule of rules) {
+        for (const pattern of rule.patterns) {
+            if (pattern.test(source)) {
+                violations.push({ file: path.relative(rootDir, file), rule: rule.label });
+            }
+        }
+    }
+}
+
+if (violations.length > 0) {
+    console.error(`${colors.red}Banned feature-gated imports found in kits/Inertia/Fortify:${colors.reset}`);
+    console.error(`${colors.dim}These imports break the build when their Fortify feature is disabled.${colors.reset}\n`);
+
+    for (const { file, rule } of violations) {
+        console.error(`  ${colors.yellow}${rule}${colors.reset}`);
+        console.error(`    ${colors.dim}${file}${colors.reset}`);
+    }
+
+    console.error(`\n${colors.red}${violations.length} violation(s).${colors.reset} Use the URL prop pattern instead — see App\\Support\\FortifyFeaturePayload.`);
+    process.exit(1);
+}
+
+console.log('No banned feature-gated imports found in kits/Inertia/Fortify.');


### PR DESCRIPTION
The Inertia/Fortify kits expose flags like `canRegister` and `canResetPassword`, which suggests removing a feature from `config/fortify.php` should Just Work. It doesn't: when a feature is disabled, Wayfinder drops the corresponding generated route module, and static imports like `@/routes/register`, `@/routes/verification`, `@/routes/two-factor`, and the password named imports break the frontend build (#82). The same surface exists for `resetPasswords`, `emailVerification`, and `twoFactorAuthentication`, so this PR fixes all four.

The kits now stop relying on feature-gated Wayfinder modules and consume URL props supplied by the backend instead. A new `App\Support\FortifyFeaturePayload` helper returns each URL or `null` based on the current feature state. Both `FortifyServiceProvider`s, the welcome routes, and `ProfileController` / `SecurityController` now ship those props, and the React, Vue, and Svelte auth pages, settings pages, welcome pages, and 2FA components/hook were updated to read them — `<Form {...store.form()}>` becomes `<Form action={url} method="post">`. A small Node guard wired into `composer kits:check` keeps the banned imports from coming back.

Verified with `composer kits:check` for all 9 affected Inertia variants (3 Fortify base + 6 Teams), `kits:browser-tests` for the 6 Inertia browser jobs, and a build smoke that ran `npm run build` four times per framework with one feature stripped each — all 12 builds passed.

Fixes #82