### PR TITLE
Use the Vite font plugin in starter kits

### DIFF
--- a/kits/Inertia/Base/.gitignore
+++ b/kits/Inertia/Base/.gitignore
@@ -2,6 +2,7 @@
 /bootstrap/ssr
 /node_modules
 /public/build
+/public/fonts-manifest.dev.json
 /public/hot
 /public/storage
 /storage/*.key

--- a/kits/Inertia/Base/composer.json
+++ b/kits/Inertia/Base/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.3",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/fortify": "^1.34",
-        "laravel/framework": "^13.0",
+        "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14"
     },

--- a/kits/Inertia/Blank/Base/.gitignore
+++ b/kits/Inertia/Blank/Base/.gitignore
@@ -2,6 +2,7 @@
 /bootstrap/ssr
 /node_modules
 /public/build
+/public/fonts-manifest.dev.json
 /public/hot
 /public/storage
 /resources/js/actions

--- a/kits/Inertia/Blank/Base/composer.json
+++ b/kits/Inertia/Blank/Base/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.3",
         "inertiajs/inertia-laravel": "^3.0",
-        "laravel/framework": "^13.0",
+        "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14"
     },

--- a/kits/Inertia/Blank/React/package.json
+++ b/kits/Inertia/Blank/React/package.json
@@ -39,7 +39,7 @@
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
         "globals": "^15.14.0",
-        "laravel-vite-plugin": "^3.0.0",
+        "laravel-vite-plugin": "^3.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tailwind-merge": "^3.0.1",

--- a/kits/Inertia/Blank/React/resources/js/pages/welcome.tsx
+++ b/kits/Inertia/Blank/React/resources/js/pages/welcome.tsx
@@ -3,13 +3,7 @@ import { Head } from '@inertiajs/react';
 export default function Welcome() {
     return (
         <>
-            <Head title="Welcome">
-                <link rel="preconnect" href="https://fonts.bunny.net" />
-                <link
-                    href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600"
-                    rel="stylesheet"
-                />
-            </Head>
+            <Head title="Welcome" />
             <div className="flex min-h-screen flex-col items-center bg-[#FDFDFC] p-6 text-[#1b1b18] lg:justify-center lg:p-8 dark:bg-[#0a0a0a]">
                 <div className="flex w-full items-center justify-center opacity-100 transition-opacity duration-750 lg:grow starting:opacity-0">
                     <main className="flex w-full max-w-[335px] flex-col-reverse lg:max-w-4xl lg:flex-row">

--- a/kits/Inertia/Blank/React/resources/views/app.blade.php
+++ b/kits/Inertia/Blank/React/resources/views/app.blade.php
@@ -8,8 +8,7 @@
         <link rel="icon" href="/favicon.svg" type="image/svg+xml">
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+        @fonts
 
         @viteReactRefresh
         @vite(['resources/css/app.css', 'resources/js/app.tsx', "resources/js/pages/{$page['component']}.tsx"])

--- a/kits/Inertia/Blank/React/vite.config.ts
+++ b/kits/Inertia/Blank/React/vite.config.ts
@@ -3,6 +3,7 @@ import { wayfinder } from '@laravel/vite-plugin-wayfinder';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import laravel from 'laravel-vite-plugin';
+import { bunny } from 'laravel-vite-plugin/fonts';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
@@ -10,6 +11,11 @@ export default defineConfig({
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.tsx'],
             refresh: true,
+            fonts: [
+                bunny('Instrument Sans', {
+                    weights: [400, 500, 600],
+                }),
+            ],
         }),
         inertia(),
         react({

--- a/kits/Inertia/Blank/Svelte/package.json
+++ b/kits/Inertia/Blank/Svelte/package.json
@@ -36,7 +36,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
-        "laravel-vite-plugin": "^3.0.0",
+        "laravel-vite-plugin": "^3.1",
         "svelte": "^5.16.0",
         "tailwind-merge": "^3.2.0",
         "tailwindcss": "^4.1.1",

--- a/kits/Inertia/Blank/Svelte/resources/views/app.blade.php
+++ b/kits/Inertia/Blank/Svelte/resources/views/app.blade.php
@@ -8,8 +8,7 @@
         <link rel="icon" href="/favicon.svg" type="image/svg+xml">
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+        @fonts
 
         @vite(['resources/css/app.css', 'resources/js/app.ts'])
         <x-inertia::head>

--- a/kits/Inertia/Blank/Svelte/vite.config.ts
+++ b/kits/Inertia/Blank/Svelte/vite.config.ts
@@ -3,6 +3,7 @@ import { wayfinder } from '@laravel/vite-plugin-wayfinder';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import tailwindcss from '@tailwindcss/vite';
 import laravel from 'laravel-vite-plugin';
+import { bunny } from 'laravel-vite-plugin/fonts';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
@@ -10,6 +11,11 @@ export default defineConfig({
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.ts'],
             refresh: true,
+            fonts: [
+                bunny('Instrument Sans', {
+                    weights: [400, 500, 600],
+                }),
+            ],
         }),
         inertia(),
         tailwindcss(),

--- a/kits/Inertia/Blank/Vue/package.json
+++ b/kits/Inertia/Blank/Vue/package.json
@@ -37,7 +37,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
-        "laravel-vite-plugin": "^3.0.0",
+        "laravel-vite-plugin": "^3.1",
         "tailwind-merge": "^3.2.0",
         "tailwindcss": "^4.1.1",
         "typescript": "^5.2.2",

--- a/kits/Inertia/Blank/Vue/resources/views/app.blade.php
+++ b/kits/Inertia/Blank/Vue/resources/views/app.blade.php
@@ -8,8 +8,7 @@
         <link rel="icon" href="/favicon.svg" type="image/svg+xml">
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+        @fonts
 
         @vite(['resources/css/app.css', 'resources/js/app.ts', "resources/js/pages/{$page['component']}.vue"])
         <x-inertia::head>

--- a/kits/Inertia/Blank/Vue/vite.config.ts
+++ b/kits/Inertia/Blank/Vue/vite.config.ts
@@ -3,6 +3,7 @@ import { wayfinder } from '@laravel/vite-plugin-wayfinder';
 import tailwindcss from '@tailwindcss/vite';
 import vue from '@vitejs/plugin-vue';
 import laravel from 'laravel-vite-plugin';
+import { bunny } from 'laravel-vite-plugin/fonts';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
@@ -10,6 +11,11 @@ export default defineConfig({
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.ts'],
             refresh: true,
+            fonts: [
+                bunny('Instrument Sans', {
+                    weights: [400, 500, 600],
+                }),
+            ],
         }),
         inertia(),
         tailwindcss(),

--- a/kits/Inertia/React/package.json
+++ b/kits/Inertia/React/package.json
@@ -54,7 +54,7 @@
         "concurrently": "^9.0.1",
         "globals": "^15.14.0",
         "input-otp": "^1.4.2",
-        "laravel-vite-plugin": "^3.0.0",
+        "laravel-vite-plugin": "^3.1",
         "lucide-react": "^0.475.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",

--- a/kits/Inertia/React/resources/js/pages/welcome.tsx
+++ b/kits/Inertia/React/resources/js/pages/welcome.tsx
@@ -10,13 +10,7 @@ export default function Welcome({
 
     return (
         <>
-            <Head title="Welcome">
-                <link rel="preconnect" href="https://fonts.bunny.net" />
-                <link
-                    href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600"
-                    rel="stylesheet"
-                />
-            </Head>
+            <Head title="Welcome" />
             <div className="flex min-h-screen flex-col items-center bg-[#FDFDFC] p-6 text-[#1b1b18] lg:justify-center lg:p-8 dark:bg-[#0a0a0a]">
                 <header className="mb-6 w-full max-w-[335px] text-sm not-has-[nav]:hidden lg:max-w-4xl">
                     <nav className="flex items-center justify-end gap-4">

--- a/kits/Inertia/React/resources/views/app.blade.php
+++ b/kits/Inertia/React/resources/views/app.blade.php
@@ -34,8 +34,7 @@
         <link rel="icon" href="/favicon.svg" type="image/svg+xml">
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+        @fonts
 
         @viteReactRefresh
         @vite(['resources/css/app.css', 'resources/js/app.tsx', "resources/js/pages/{$page['component']}.tsx"])

--- a/kits/Inertia/Svelte/package.json
+++ b/kits/Inertia/Svelte/package.json
@@ -39,7 +39,7 @@
         "bits-ui": "^2.15.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "laravel-vite-plugin": "^3.0.0",
+        "laravel-vite-plugin": "^3.1",
         "lucide-svelte": "^0.468.0",
         "svelte": "^5.16.0",
         "svelte-sonner": "^0.3.28",

--- a/kits/Inertia/Teams/Fortify/React/resources/js/pages/welcome.tsx
+++ b/kits/Inertia/Teams/Fortify/React/resources/js/pages/welcome.tsx
@@ -11,13 +11,7 @@ export default function Welcome({
 
     return (
         <>
-            <Head title="Welcome">
-                <link rel="preconnect" href="https://fonts.bunny.net" />
-                <link
-                    href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600"
-                    rel="stylesheet"
-                />
-            </Head>
+            <Head title="Welcome" />
             <div className="flex min-h-screen flex-col items-center bg-[#FDFDFC] p-6 text-[#1b1b18] lg:justify-center lg:p-8 dark:bg-[#0a0a0a]">
                 <header className="mb-6 w-full max-w-[335px] text-sm not-has-[nav]:hidden lg:max-w-4xl">
                     <nav className="flex items-center justify-end gap-4">

--- a/kits/Inertia/Teams/WorkOS/React/resources/js/pages/welcome.tsx
+++ b/kits/Inertia/Teams/WorkOS/React/resources/js/pages/welcome.tsx
@@ -7,13 +7,7 @@ export default function Welcome() {
 
     return (
         <>
-            <Head title="Welcome">
-                <link rel="preconnect" href="https://fonts.bunny.net" />
-                <link
-                    href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600"
-                    rel="stylesheet"
-                />
-            </Head>
+            <Head title="Welcome" />
             <div className="flex min-h-screen flex-col items-center bg-[#FDFDFC] p-6 text-[#1b1b18] lg:justify-center lg:p-8 dark:bg-[#0a0a0a]">
                 <header className="mb-6 w-full max-w-[335px] text-sm not-has-[nav]:hidden lg:max-w-4xl">
                     <nav className="flex items-center justify-end gap-4">

--- a/kits/Inertia/Vue/package.json
+++ b/kits/Inertia/Vue/package.json
@@ -39,7 +39,7 @@
         "@vueuse/core": "^12.8.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "laravel-vite-plugin": "^3.0.0",
+        "laravel-vite-plugin": "^3.1",
         "lucide-vue-next": "^0.468.0",
         "reka-ui": "^2.6.1",
         "tailwind-merge": "^3.2.0",

--- a/kits/Inertia/Vue/resources/views/app.blade.php
+++ b/kits/Inertia/Vue/resources/views/app.blade.php
@@ -34,8 +34,7 @@
         <link rel="icon" href="/favicon.svg" type="image/svg+xml">
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+        @fonts
 
         @vite(['resources/css/app.css', 'resources/js/app.ts', "resources/js/pages/{$page['component']}.vue"])
         <x-inertia::head>

--- a/kits/Inertia/WorkOS/Base/composer.json
+++ b/kits/Inertia/WorkOS/Base/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.3",
         "inertiajs/inertia-laravel": "^3.0",
-        "laravel/framework": "^13.0",
+        "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
         "laravel/workos": "^0.6.0",
         "laravel/wayfinder": "^0.1.14"

--- a/kits/Inertia/WorkOS/React/resources/js/pages/welcome.tsx
+++ b/kits/Inertia/WorkOS/React/resources/js/pages/welcome.tsx
@@ -6,13 +6,7 @@ export default function Welcome() {
 
     return (
         <>
-            <Head title="Welcome">
-                <link rel="preconnect" href="https://fonts.bunny.net" />
-                <link
-                    href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600"
-                    rel="stylesheet"
-                />
-            </Head>
+            <Head title="Welcome" />
             <div className="flex min-h-screen flex-col items-center bg-[#FDFDFC] p-6 text-[#1b1b18] lg:justify-center lg:p-8 dark:bg-[#0a0a0a]">
                 <header className="mb-6 w-full max-w-[335px] text-sm not-has-[nav]:hidden lg:max-w-4xl">
                     <nav className="flex items-center justify-end gap-4">

--- a/kits/Inertia/WorkOS/Vue/package.json
+++ b/kits/Inertia/WorkOS/Vue/package.json
@@ -39,7 +39,7 @@
         "@vueuse/core": "^12.8.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "laravel-vite-plugin": "^3.0.0",
+        "laravel-vite-plugin": "^3.1",
         "lucide-vue-next": "^0.468.0",
         "reka-ui": "^2.6.1",
         "tailwind-merge": "^3.2.0",

--- a/kits/Livewire/Base/composer.json
+++ b/kits/Livewire/Base/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.3",
         "laravel/fortify": "^1.34",
-        "laravel/framework": "^13.0",
+        "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
         "livewire/flux": "^2.13.1",
         "livewire/livewire": "^4.1"

--- a/kits/Livewire/Base/resources/views/partials/head.blade.php
+++ b/kits/Livewire/Base/resources/views/partials/head.blade.php
@@ -9,8 +9,7 @@
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
-<link rel="preconnect" href="https://fonts.bunny.net">
-<link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+@fonts
 
 @vite(['resources/css/app.css', 'resources/js/app.js'])
 @fluxAppearance

--- a/kits/Livewire/Base/resources/views/welcome.blade.php
+++ b/kits/Livewire/Base/resources/views/welcome.blade.php
@@ -10,9 +10,7 @@
         <link rel="icon" href="/favicon.svg" type="image/svg+xml">
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
-        <!-- Fonts -->
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+        @fonts
 
         <!-- Styles -->
         <style>

--- a/kits/Livewire/Blank/.gitignore
+++ b/kits/Livewire/Blank/.gitignore
@@ -1,6 +1,7 @@
 /.phpunit.cache
 /node_modules
 /public/build
+/public/fonts-manifest.dev.json
 /public/hot
 /public/storage
 /storage/*.key

--- a/kits/Livewire/Blank/composer.json
+++ b/kits/Livewire/Blank/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "laravel/framework": "^13.0",
+        "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
         "livewire/livewire": "^4.1"
     },

--- a/kits/Livewire/Blank/package.json
+++ b/kits/Livewire/Blank/package.json
@@ -10,7 +10,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "autoprefixer": "^10.4.20",
         "concurrently": "^9.0.1",
-        "laravel-vite-plugin": "^3.0.0",
+        "laravel-vite-plugin": "^3.1",
         "tailwindcss": "^4.0.7",
         "vite": "^8.0.0"
     },

--- a/kits/Livewire/Blank/resources/views/welcome.blade.php
+++ b/kits/Livewire/Blank/resources/views/welcome.blade.php
@@ -10,9 +10,7 @@
         <link rel="icon" href="/favicon.svg" type="image/svg+xml">
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
-        <!-- Fonts -->
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+        @fonts
 
         <!-- Styles / Scripts -->
         @if (file_exists(public_path('build/manifest.json')) || file_exists(public_path('hot')))

--- a/kits/Livewire/Blank/vite.config.js
+++ b/kits/Livewire/Blank/vite.config.js
@@ -2,6 +2,7 @@ import {
     defineConfig
 } from 'vite';
 import laravel from 'laravel-vite-plugin';
+import { bunny } from 'laravel-vite-plugin/fonts';
 import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
@@ -9,6 +10,11 @@ export default defineConfig({
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.js'],
             refresh: true,
+            fonts: [
+                bunny('Instrument Sans', {
+                    weights: [400, 500, 600],
+                }),
+            ],
         }),
         tailwindcss(),
     ],

--- a/kits/Livewire/WorkOS/composer.json
+++ b/kits/Livewire/WorkOS/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "laravel/framework": "^13.0",
+        "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
         "laravel/workos": "^0.6.0",
         "livewire/flux": "^2.12.0",


### PR DESCRIPTION
Starter kits now load Instrument Sans through the Laravel Vite font plugin instead of direct Bunny font links, so font preloads and styles are handled by the framework runtime. This updates the required framework and Vite plugin constraints, configures the Bunny provider in each shared Vite source layer, replaces layout font links with \`@fonts\`, and ignores the generated development font manifest so it does not sync back into kit sources.