### PR TITLE
Catch migrations up to Skeleton

### DIFF
--- a/kits/Shared/Blank/database/migrations/0001_01_01_000001_create_cache_table.php
+++ b/kits/Shared/Blank/database/migrations/0001_01_01_000001_create_cache_table.php
@@ -14,13 +14,13 @@ return new class extends Migration
         Schema::create('cache', function (Blueprint $table) {
             $table->string('key')->primary();
             $table->mediumText('value');
-            $table->integer('expiration')->index();
+            $table->bigInteger('expiration')->index();
         });
 
         Schema::create('cache_locks', function (Blueprint $table) {
             $table->string('key')->primary();
             $table->string('owner');
-            $table->integer('expiration')->index();
+            $table->bigInteger('expiration')->index();
         });
     }
 

--- a/kits/Shared/Blank/database/migrations/0001_01_01_000002_create_jobs_table.php
+++ b/kits/Shared/Blank/database/migrations/0001_01_01_000002_create_jobs_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->string('queue')->index();
             $table->longText('payload');
-            $table->unsignedTinyInteger('attempts');
+            $table->unsignedSmallInteger('attempts');
             $table->unsignedInteger('reserved_at')->nullable();
             $table->unsignedInteger('available_at');
             $table->unsignedInteger('created_at');


### PR DESCRIPTION
Was just here poking around and noticed a few of the default migrations are different to the Skeleton

I guessed they should be the same so witness my PR!

 Below are the exact commits 🧑‍🍳:

cache table - https://github.com/laravel/laravel/commit/01f698ee4df24910dda0475092b698888b050b6d (in v13.0.0)
jobs table - https://github.com/laravel/laravel/commit/8ad7826f56d9e044cc3117d82d61c0e2282ce839 (in v13.3.0) 

Perhaps you'd prefer to wait a bit, but thought I'd give it ago :) 