### PR TITLE
Add missing autofocus to 2FA input field

### DIFF
--- a/kits/Inertia/Fortify/React/resources/js/components/two-factor-setup-modal.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/components/two-factor-setup-modal.tsx
@@ -181,6 +181,7 @@ function TwoFactorVerificationStep({
                                 onChange={setCode}
                                 disabled={processing}
                                 pattern={REGEXP_ONLY_DIGITS}
+                                autoFocus
                             >
                                 <InputOTPGroup>
                                     {Array.from(

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/two-factor-challenge.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/two-factor-challenge.tsx
@@ -85,6 +85,7 @@ export default function TwoFactorChallenge() {
                                             onChange={(value) => setCode(value)}
                                             disabled={processing}
                                             pattern={REGEXP_ONLY_DIGITS}
+                                            autoFocus
                                         >
                                             <InputOTPGroup>
                                                 {Array.from(

--- a/kits/Inertia/Fortify/Svelte/resources/js/components/TwoFactorSetupModal.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/components/TwoFactorSetupModal.svelte
@@ -269,6 +269,7 @@
                                     bind:value={code}
                                     maxlength={6}
                                     disabled={processing}
+                                    autofocus
                                 >
                                     <InputOTPGroup>
                                         {#each { length: 6 } as _, i (i)}

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/TwoFactorChallenge.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/TwoFactorChallenge.svelte
@@ -68,6 +68,7 @@
                             bind:value={code}
                             maxlength={6}
                             disabled={processing}
+                            autofocus
                         >
                             <InputOTPGroup>
                                 {#each { length: 6 } as _, i (i)}

--- a/kits/Inertia/Fortify/Vue/resources/js/components/TwoFactorSetupModal.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/components/TwoFactorSetupModal.vue
@@ -258,6 +258,7 @@ watch(
                                     v-model="code"
                                     :maxlength="6"
                                     :disabled="processing"
+                                    autofocus
                                 >
                                     <InputOTPGroup>
                                         <InputOTPSlot

--- a/kits/Livewire/Components/resources/views/livewire/settings/security.blade.php
+++ b/kits/Livewire/Components/resources/views/livewire/settings/security.blade.php
@@ -109,7 +109,11 @@
 
                     @if ($showVerificationStep)
                         <div class="space-y-6">
-                            <div class="flex flex-col items-center space-y-3 justify-center">
+                            <div
+                                class="flex flex-col items-center space-y-3 justify-center"
+                                x-data
+                                x-init="$nextTick(() => $el.querySelector('input')?.focus())"
+                            >
                                 <flux:otp
                                     name="code"
                                     wire:model="code"

--- a/kits/Livewire/Fortify/resources/views/pages/auth/two-factor-challenge.blade.php
+++ b/kits/Livewire/Fortify/resources/views/pages/auth/two-factor-challenge.blade.php
@@ -7,18 +7,24 @@
                 showRecoveryInput: @js($errors->has('recovery_code')),
                 code: '',
                 recovery_code: '',
+                focusOtp() {
+                    this.$nextTick(() => this.$refs.otp?.querySelector('input')?.focus());
+                },
+                init() {
+                    if (! this.showRecoveryInput) {
+                        this.focusOtp();
+                    }
+                },
                 toggleInput() {
                     this.showRecoveryInput = !this.showRecoveryInput;
 
                     this.code = '';
                     this.recovery_code = '';
 
-                    $dispatch('clear-2fa-auth-code');
-
                     $nextTick(() => {
                         this.showRecoveryInput
                             ? this.$refs.recovery_code?.focus()
-                            : $dispatch('focus-2fa-auth-code');
+                            : this.focusOtp();
                     });
                 },
             }"
@@ -42,7 +48,7 @@
 
                 <div class="space-y-5 text-center">
                     <div x-show="!showRecoveryInput">
-                        <div class="flex items-center justify-center my-5">
+                        <div class="flex items-center justify-center my-5" x-ref="otp">
                             <flux:otp
                                 x-model="code"
                                 length="6"

--- a/kits/Livewire/Fortify/resources/views/pages/settings/two-factor-setup-modal.blade.php
+++ b/kits/Livewire/Fortify/resources/views/pages/settings/two-factor-setup-modal.blade.php
@@ -185,7 +185,11 @@ new class extends Component {
 
             @if ($showVerificationStep)
                 <div class="space-y-6">
-                    <div class="flex flex-col items-center space-y-3 justify-center">
+                    <div
+                        class="flex flex-col items-center space-y-3 justify-center"
+                        x-data
+                        x-init="$nextTick(() => $el.querySelector('input')?.focus())"
+                    >
                         <flux:otp
                             name="code"
                             wire:model="code"


### PR DESCRIPTION
- Adds autofocus to the InputOTP component on the two-factor challenge page and the two-factor setup confirmation step across the Inertia Fortify React, Svelte, and Vue kits.
- Saves users an extra click when they reach a screen whose only purpose is to enter a 6-digit code.

The `kits/Inertia/Fortify/Vue/resources/js/pages/auth/TwoFactorChallenge.vue` already had this autofocus