### PR TITLE
fix: revert accidental `laravel/framework` constraint bump from `^13.0` to `^13.7`

### DIFF
--- a/kits/Inertia/Base/composer.json
+++ b/kits/Inertia/Base/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.3",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/fortify": "^1.34",
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14"
     },

--- a/kits/Inertia/Blank/Base/composer.json
+++ b/kits/Inertia/Blank/Base/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.3",
         "inertiajs/inertia-laravel": "^3.0",
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14"
     },

--- a/kits/Inertia/WorkOS/Base/composer.json
+++ b/kits/Inertia/WorkOS/Base/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.3",
         "inertiajs/inertia-laravel": "^3.0",
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",
         "laravel/workos": "^0.6.0",
         "laravel/wayfinder": "^0.1.14"

--- a/kits/Livewire/Base/composer.json
+++ b/kits/Livewire/Base/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.3",
         "laravel/fortify": "^1.34",
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",
         "livewire/flux": "^2.13.1",
         "livewire/livewire": "^4.1"

--- a/kits/Livewire/Blank/composer.json
+++ b/kits/Livewire/Blank/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",
         "livewire/livewire": "^4.1"
     },

--- a/kits/Livewire/WorkOS/composer.json
+++ b/kits/Livewire/WorkOS/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",
         "laravel/workos": "^0.6.0",
         "livewire/flux": "^2.12.0",


### PR DESCRIPTION
# Revert accidental `laravel/framework` constraint bump from `^13.0` to `^13.7`

Refs #87.

## Bug

Fresh `laravel new` (any starter kit flavor) fails during dependency resolution. The kit is extracted but the post-install resolution rejects every available `laravel/framework` version, leaving a half-installed project.

```
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - Root composer.json requires laravel/framework ^13.7,
      found laravel/framework[13.x-dev] but it does not match your minimum-stability.
```

## Root cause and missing piece from #87

Issue #87 correctly identified PR #85 as the source of the `^13.7` constraint and that v13.7.0 has been published. The discussion stalled on "but v13.7.0 IS on Packagist, why does it still fail even after `composer clear-cache`?" — that's the gap this PR closes.

It is a **CDN edge cache inconsistency at Packagist's metadata mirror (Bunny CDN)**, reproducible right now:

- After `composer clear-cache`, Composer fetched `/p2/laravel/framework.json` and stored **887,866 bytes / 1234 versions / latest v13.6.0**.
- Within seconds, a parallel `curl` to the same URL returned **889,694 bytes / 1235 versions / latest v13.7.0**.
- Same URL. Different Bunny edge node. Different cached content.
- `Cache-Control: max-age=2592000` (30 days) on the metadata response means stale edges can persist for a long time after a release.

So @DevvDiego's report is genuine — Composer running on their machine literally cannot see `v13.7.0` because the regional edge is serving the pre-release snapshot, and `minimum-stability: stable` prevents `13.x-dev` from being an acceptable fallback.

This makes the `^13.7` + `minimum-stability: stable` combination fragile by design: any future minor framework release will reproduce the same failure window for users on stale edges. `laravel/laravel` uses `^13.0` + `minimum-stability: dev` + `prefer-stable: true` and is unaffected by this pattern.

## Why this PR is a revert, not a redesign

`git log` on `kits/` shows every prior intentional bump pins to `^MAJOR.0`:

| Commit | Date | `laravel/framework` |
|---|---|---|
| Initial kits added | 2026-01-16/20/22 | `^12.0` |
| `2a28fdb` Laravel 13 (#44) | 2026-03-17 | `^13.0` |
| `0235e34` Use the Vite font plugin in starter kits (#85) | 2026-04-29 | **`^13.7`** |

PR #85's stated purpose is the Vite font plugin. The framework constraint bump in that change looks like an unintentional side effect — it isn't mentioned in the PR title or description, no other dependency was tightened, and every other change in the PR is Vite/font related.

## What this PR changes

```diff
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.0",
```

…applied to all six source `composer.json` files:

- `kits/Inertia/Base/composer.json`
- `kits/Inertia/Blank/Base/composer.json`
- `kits/Inertia/WorkOS/Base/composer.json`
- `kits/Livewire/Base/composer.json`
- `kits/Livewire/Blank/composer.json`
- `kits/Livewire/WorkOS/composer.json`

6 files changed, 6 insertions, 6 deletions. No change to `minimum-stability` or `prefer-stable` — those are separate concerns and out of scope.

## Test plan

- `php artisan build --kit=react` then `composer install` in `build/` resolves successfully against any 13.x stable, including `v13.6.0` (the version a stale CDN edge has) and `v13.7.0`.
- Repeat with `--kit=vue`, `--kit=livewire`, `--kit=svelte`, and the `--workos` / `--blank` variants.
- No runtime code changes; existing tests are unaffected.

## After-merge

Eight starter-kit repos (`react`, `vue`, `livewire`, `svelte`, plus their `blank-*` variants) carry the bumped constraint via the previous bot drift from #85. Re-running the build/drift after this merges should restore them to `^13.0`.
