### PR TITLE
Fix Duplicate `create-team-switcher` modal bug in header layout on livewire/teams

### DIFF
--- a/kits/Livewire/Teams/Base/resources/views/components/create-team-modal.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/components/create-team-modal.blade.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Rules\TeamName;
+use Flux\Flux;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+new class extends Component {
+    public string $teamName = '';
+
+    public function createTeam(CreateTeam $createTeam): void
+    {
+        $validated = $this->validate([
+            'teamName' => ['required', 'string', 'max:255', new TeamName],
+        ]);
+
+        $team = $createTeam->handle(Auth::user(), $validated['teamName']);
+
+        $this->dispatch('close-modal', name: 'create-team-switcher');
+
+        $this->reset('teamName');
+
+        Flux::toast(variant: 'success', text: __('Team created.'));
+
+        $this->redirectRoute('teams.edit', ['team' => $team->slug], navigate: true);
+    }
+}; ?>
+
+<flux:modal name="create-team-switcher" :show="$errors->isNotEmpty()" focusable class="max-w-lg">
+    <form wire:submit="createTeam" class="space-y-6">
+        <div>
+            <flux:heading size="lg">{{ __('Create a new team') }}</flux:heading>
+            <flux:subheading>{{ __('Give your team a name to get started.') }}</flux:subheading>
+        </div>
+
+        <flux:input wire:model="teamName" :label="__('Team name')" type="text" required autofocus data-test="switcher-create-team-name" />
+
+        <div class="flex justify-end space-x-2 rtl:space-x-reverse">
+            <flux:modal.close>
+                <flux:button variant="filled">{{ __('Cancel') }}</flux:button>
+            </flux:modal.close>
+
+            <flux:button variant="primary" type="submit" data-test="switcher-create-team-submit">
+                {{ __('Create team') }}
+            </flux:button>
+        </div>
+    </form>
+</flux:modal>

--- a/kits/Livewire/Teams/Base/resources/views/components/team-switcher.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/components/team-switcher.blade.php
@@ -31,23 +31,6 @@ new class extends Component {
         return Auth::user()->toUserTeams(includeCurrent: true);
     }
 
-    public function createTeam(CreateTeam $createTeam): void
-    {
-        $validated = $this->validate([
-            'teamName' => ['required', 'string', 'max:255', new TeamName],
-        ]);
-
-        $team = $createTeam->handle(Auth::user(), $validated['teamName']);
-
-        $this->dispatch('close-modal', name: 'create-team-switcher');
-
-        $this->reset('teamName');
-
-        Flux::toast(variant: 'success', text: __('Team created.'));
-
-        $this->redirectRoute('teams.edit', ['team' => $team->slug], navigate: true);
-    }
-
     public function switchTeam(string $slug): void
     {
         $user = Auth::user();
@@ -139,25 +122,4 @@ new class extends Component {
             </flux:modal.trigger>
         </flux:menu>
     </flux:dropdown>
-
-    <flux:modal name="create-team-switcher" :show="$errors->isNotEmpty()" focusable class="max-w-lg">
-        <form wire:submit="createTeam" class="space-y-6">
-            <div>
-                <flux:heading size="lg">{{ __('Create a new team') }}</flux:heading>
-                <flux:subheading>{{ __('Give your team a name to get started.') }}</flux:subheading>
-            </div>
-
-            <flux:input wire:model="teamName" :label="__('Team name')" type="text" required autofocus data-test="switcher-create-team-name" />
-
-            <div class="flex justify-end space-x-2 rtl:space-x-reverse">
-                <flux:modal.close>
-                    <flux:button variant="filled">{{ __('Cancel') }}</flux:button>
-                </flux:modal.close>
-
-                <flux:button variant="primary" type="submit" data-test="switcher-create-team-submit">
-                    {{ __('Create team') }}
-                </flux:button>
-            </div>
-        </form>
-    </flux:modal>
 </div>

--- a/kits/Livewire/Teams/Base/resources/views/components/team-switcher.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/components/team-switcher.blade.php
@@ -1,17 +1,12 @@
 <?php
 
-use App\Actions\Teams\CreateTeam;
 use App\Models\Team;
-use App\Rules\TeamName;
 use App\Support\UserTeam;
-use Flux\Flux;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 
 new class extends Component {
-    public string $teamName = '';
-
     public function currentTeam(): ?array
     {
         $team = Auth::user()->currentTeam;

--- a/kits/Livewire/Teams/Base/resources/views/layouts/app/header.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/layouts/app/header.blade.php
@@ -79,6 +79,8 @@
 
         {{ $slot }}
 
+        <livewire:create-team-modal />
+
         @persist('toast')
             <flux:toast.group>
                 <flux:toast />

--- a/kits/Livewire/Teams/Base/resources/views/layouts/app/sidebar.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/layouts/app/sidebar.blade.php
@@ -92,6 +92,8 @@
 
         {{ $slot }}
 
+        <livewire:create-team-modal />
+
         @persist('toast')
             <flux:toast.group>
                 <flux:toast />


### PR DESCRIPTION
When using the header layout the `team-switcher.blade` component is mounted twice: once in the header and once in the mobile sidebar. Since the modal for creating a team was defined inside the `team-switcher.blade` component, this led to duplicate modals with the same name, which does not work and leads to a full page "freeze". The user can't do anything after the modal comes up, until they refresh the page.

Rather than trying name the modal dynamically or duplicate the whole switcher component just to rename the modal in one of them, I've opted to extract the modal into its own separate component, along with the `createTeam` action method.