### PR TITLE
Define explicit package root for older versions of pnpm

### DIFF
--- a/kits/Inertia/Blank/Base/pnpm-workspace.yaml
+++ b/kits/Inertia/Blank/Base/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - '.'
+
 publicHoistPattern:
   - '@inertiajs/core'


### PR DESCRIPTION
Older versions of pnpm (< v10.5)  require a `packages:` field to be defined in `pnpm-workspace.yaml`, otherwise frontend dependency installation with `pnpm install` fails (see https://github.com/laravel/installer/issues/518).

I added an explicit single `'.'` package root to the `pnpm-workspace.yaml`. This is fully compatible with current versions of pnpm (>=10.5, >=11).

Fixes: https://github.com/laravel/installer/issues/518