### PR TITLE
Add passwordrules attribute to new-password inputs

### DIFF
--- a/kits/Inertia/Blank/React/resources/js/types/global.d.ts
+++ b/kits/Inertia/Blank/React/resources/js/types/global.d.ts
@@ -1,5 +1,11 @@
 import type { Auth } from '@/types/auth';
 
+declare module 'react' {
+    interface InputHTMLAttributes<T> {
+        passwordrules?: string;
+    }
+}
+
 declare module '@inertiajs/core' {
     export interface InertiaConfig {
         sharedPageProps: {

--- a/kits/Inertia/Blank/React/resources/js/types/global.d.ts
+++ b/kits/Inertia/Blank/React/resources/js/types/global.d.ts
@@ -1,6 +1,7 @@
 import type { Auth } from '@/types/auth';
 
 declare module 'react' {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface InputHTMLAttributes<T> {
         passwordrules?: string;
     }

--- a/kits/Inertia/Fortify/Base/app/Http/Controllers/Settings/SecurityController.php
+++ b/kits/Inertia/Fortify/Base/app/Http/Controllers/Settings/SecurityController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\Settings\TwoFactorAuthenticationRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Controllers\Middleware;
+use Illuminate\Validation\Rules\Password;
 use Inertia\Inertia;
 use Inertia\Response;
 use Laravel\Fortify\Features;
@@ -32,6 +33,7 @@ class SecurityController extends Controller implements HasMiddleware
     {
         $props = [
             'canManageTwoFactor' => Features::canManageTwoFactorAuthentication(),
+            'passwordRules' => Password::defaults()->toPasswordRulesString(),
         ];
 
         if (Features::canManageTwoFactorAuthentication()) {

--- a/kits/Inertia/Fortify/Base/app/Providers/FortifyServiceProvider.php
+++ b/kits/Inertia/Fortify/Base/app/Providers/FortifyServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Password;
 use Inertia\Inertia;
 use Laravel\Fortify\Features;
 use Laravel\Fortify\Fortify;
@@ -56,6 +57,7 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::resetPasswordView(fn (Request $request) => Inertia::render('{{auth_reset_password}}', [
             'email' => $request->email,
             'token' => $request->route('token'),
+            'passwordRules' => Password::defaults()->toPasswordRulesString(),
         ]));
 
         Fortify::requestPasswordResetLinkView(fn (Request $request) => Inertia::render('{{auth_forgot_password}}', [
@@ -66,7 +68,9 @@ class FortifyServiceProvider extends ServiceProvider
             'status' => $request->session()->get('status'),
         ]));
 
-        Fortify::registerView(fn () => Inertia::render('{{auth_register}}'));
+        Fortify::registerView(fn () => Inertia::render('{{auth_register}}', [
+            'passwordRules' => Password::defaults()->toPasswordRulesString(),
+        ]));
 
         Fortify::twoFactorChallengeView(fn () => Inertia::render('{{auth_two_factor_challenge}}'));
 

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/register.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/register.tsx
@@ -9,7 +9,11 @@ import { Spinner } from '@/components/ui/spinner';
 import { login } from '@/routes';
 import { store } from '@/routes/register';
 
-export default function Register() {
+type Props = {
+    passwordRules: string;
+};
+
+export default function Register({ passwordRules }: Props) {
     return (
         <>
             <Head title="Register" />
@@ -63,6 +67,7 @@ export default function Register() {
                                     autoComplete="new-password"
                                     name="password"
                                     placeholder="Password"
+                                    passwordrules={passwordRules}
                                 />
                                 <InputError message={errors.password} />
                             </div>
@@ -78,6 +83,7 @@ export default function Register() {
                                     autoComplete="new-password"
                                     name="password_confirmation"
                                     placeholder="Confirm password"
+                                    passwordrules={passwordRules}
                                 />
                                 <InputError
                                     message={errors.password_confirmation}

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/reset-password.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/reset-password.tsx
@@ -10,9 +10,10 @@ import { update } from '@/routes/password';
 type Props = {
     token: string;
     email: string;
+    passwordRules: string;
 };
 
-export default function ResetPassword({ token, email }: Props) {
+export default function ResetPassword({ token, email, passwordRules }: Props) {
     return (
         <>
             <Head title="Reset password" />
@@ -50,6 +51,7 @@ export default function ResetPassword({ token, email }: Props) {
                                 className="mt-1 block w-full"
                                 autoFocus
                                 placeholder="Password"
+                                passwordrules={passwordRules}
                             />
                             <InputError message={errors.password} />
                         </div>
@@ -64,6 +66,7 @@ export default function ResetPassword({ token, email }: Props) {
                                 autoComplete="new-password"
                                 className="mt-1 block w-full"
                                 placeholder="Confirm password"
+                                passwordrules={passwordRules}
                             />
                             <InputError
                                 message={errors.password_confirmation}

--- a/kits/Inertia/Fortify/React/resources/js/pages/settings/security.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/settings/security.tsx
@@ -17,12 +17,14 @@ type Props = {
     canManageTwoFactor?: boolean;
     requiresConfirmation?: boolean;
     twoFactorEnabled?: boolean;
+    passwordRules: string;
 };
 
 export default function Security({
     canManageTwoFactor = false,
     requiresConfirmation = false,
     twoFactorEnabled = false,
+    passwordRules,
 }: Props) {
     const passwordInput = useRef<HTMLInputElement>(null);
     const currentPasswordInput = useRef<HTMLInputElement>(null);
@@ -113,6 +115,7 @@ export default function Security({
                                     className="mt-1 block w-full"
                                     autoComplete="new-password"
                                     placeholder="New password"
+                                    passwordrules={passwordRules}
                                 />
 
                                 <InputError message={errors.password} />
@@ -129,6 +132,7 @@ export default function Security({
                                     className="mt-1 block w-full"
                                     autoComplete="new-password"
                                     placeholder="Confirm password"
+                                    passwordrules={passwordRules}
                                 />
 
                                 <InputError

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Register.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Register.svelte
@@ -17,6 +17,8 @@
     import { Spinner } from '@/components/ui/spinner';
     import { login } from '@/routes';
     import { store } from '@/routes/register';
+
+    let { passwordRules }: { passwordRules: string } = $props();
 </script>
 
 <AppHead title="Register" />
@@ -62,6 +64,7 @@
                     autocomplete="new-password"
                     name="password"
                     placeholder="Password"
+                    passwordrules={passwordRules}
                 />
                 <InputError message={errors.password} />
             </div>
@@ -74,6 +77,7 @@
                     autocomplete="new-password"
                     name="password_confirmation"
                     placeholder="Confirm password"
+                    passwordrules={passwordRules}
                 />
                 <InputError message={errors.password_confirmation} />
             </div>

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/ResetPassword.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/ResetPassword.svelte
@@ -19,9 +19,11 @@
     let {
         token,
         email,
+        passwordRules,
     }: {
         token: string;
         email: string;
+        passwordRules: string;
     } = $props();
 </script>
 
@@ -56,6 +58,7 @@
                     autocomplete="new-password"
                     class="mt-1 block w-full"
                     placeholder="Password"
+                    passwordrules={passwordRules}
                 />
                 <InputError message={errors.password} />
             </div>
@@ -68,6 +71,7 @@
                     autocomplete="new-password"
                     class="mt-1 block w-full"
                     placeholder="Confirm password"
+                    passwordrules={passwordRules}
                 />
                 <InputError message={errors.password_confirmation} />
             </div>

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/settings/Security.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/settings/Security.svelte
@@ -31,10 +31,12 @@
         canManageTwoFactor = false,
         requiresConfirmation = false,
         twoFactorEnabled = false,
+        passwordRules,
     }: {
         canManageTwoFactor?: boolean;
         requiresConfirmation?: boolean;
         twoFactorEnabled?: boolean;
+        passwordRules: string;
     } = $props();
 
     const twoFactorAuth = twoFactorAuthState();
@@ -82,6 +84,7 @@
                     class="mt-1 block w-full"
                     autocomplete="new-password"
                     placeholder="New password"
+                    passwordrules={passwordRules}
                 />
                 <InputError message={errors.password} />
             </div>
@@ -94,6 +97,7 @@
                     class="mt-1 block w-full"
                     autocomplete="new-password"
                     placeholder="Confirm password"
+                    passwordrules={passwordRules}
                 />
                 <InputError message={errors.password_confirmation} />
             </div>

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Register.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Register.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { Form, Head } from '@inertiajs/vue3';
 import InputError from '@/components/InputError.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import TextLink from '@/components/TextLink.vue';
@@ -8,7 +9,6 @@ import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
 import { login } from '@/routes';
 import { store } from '@/routes/register';
-import { Form, Head } from '@inertiajs/vue3';
 
 defineProps<{
     passwordRules: string;

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Register.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Register.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Form, Head } from '@inertiajs/vue3';
 import InputError from '@/components/InputError.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import TextLink from '@/components/TextLink.vue';
@@ -9,6 +8,11 @@ import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
 import { login } from '@/routes';
 import { store } from '@/routes/register';
+import { Form, Head } from '@inertiajs/vue3';
+
+defineProps<{
+    passwordRules: string;
+}>();
 
 defineOptions({
     layout: {
@@ -66,6 +70,7 @@ defineOptions({
                     autocomplete="new-password"
                     name="password"
                     placeholder="Password"
+                    :passwordrules="passwordRules"
                 />
                 <InputError :message="errors.password" />
             </div>
@@ -79,6 +84,7 @@ defineOptions({
                     autocomplete="new-password"
                     name="password_confirmation"
                     placeholder="Confirm password"
+                    :passwordrules="passwordRules"
                 />
                 <InputError :message="errors.password_confirmation" />
             </div>

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ResetPassword.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ResetPassword.vue
@@ -19,6 +19,7 @@ defineOptions({
 const props = defineProps<{
     token: string;
     email: string;
+    passwordRules: string;
 }>();
 
 const inputEmail = ref(props.email);
@@ -57,6 +58,7 @@ const inputEmail = ref(props.email);
                     class="mt-1 block w-full"
                     autofocus
                     placeholder="Password"
+                    :passwordrules="passwordRules"
                 />
                 <InputError :message="errors.password" />
             </div>
@@ -69,6 +71,7 @@ const inputEmail = ref(props.email);
                     autocomplete="new-password"
                     class="mt-1 block w-full"
                     placeholder="Confirm password"
+                    :passwordrules="passwordRules"
                 />
                 <InputError :message="errors.password_confirmation" />
             </div>

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/settings/Security.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/settings/Security.vue
@@ -18,9 +18,10 @@ type Props = {
     canManageTwoFactor?: boolean;
     requiresConfirmation?: boolean;
     twoFactorEnabled?: boolean;
+    passwordRules: string;
 };
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
     canManageTwoFactor: false,
     requiresConfirmation: false,
     twoFactorEnabled: false,
@@ -89,6 +90,7 @@ onUnmounted(() => clearTwoFactorAuthData());
                     class="mt-1 block w-full"
                     autocomplete="new-password"
                     placeholder="New password"
+                    :passwordrules="props.passwordRules"
                 />
                 <InputError :message="errors.password" />
             </div>
@@ -101,6 +103,7 @@ onUnmounted(() => clearTwoFactorAuthData());
                     class="mt-1 block w-full"
                     autocomplete="new-password"
                     placeholder="Confirm password"
+                    :passwordrules="props.passwordRules"
                 />
                 <InputError :message="errors.password_confirmation" />
             </div>

--- a/kits/Inertia/Teams/React/resources/js/types/global.d.ts
+++ b/kits/Inertia/Teams/React/resources/js/types/global.d.ts
@@ -1,6 +1,13 @@
 import type { Auth } from '@/types/auth';
 import type { Team } from '@/types/teams';
 
+declare module 'react' {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    interface InputHTMLAttributes<T> {
+        passwordrules?: string;
+    }
+}
+
 declare module '@inertiajs/core' {
     export interface InertiaConfig {
         sharedPageProps: {

--- a/kits/Livewire/Components/resources/views/livewire/settings/security.blade.php
+++ b/kits/Livewire/Components/resources/views/livewire/settings/security.blade.php
@@ -19,6 +19,7 @@
                 type="password"
                 required
                 autocomplete="new-password"
+                passwordrules="{{ \Illuminate\Validation\Rules\Password::defaults()->toPasswordRulesString() }}"
                 viewable
             />
             <flux:input
@@ -27,6 +28,7 @@
                 type="password"
                 required
                 autocomplete="new-password"
+                passwordrules="{{ \Illuminate\Validation\Rules\Password::defaults()->toPasswordRulesString() }}"
                 viewable
             />
 

--- a/kits/Livewire/Fortify/resources/views/pages/auth/register.blade.php
+++ b/kits/Livewire/Fortify/resources/views/pages/auth/register.blade.php
@@ -38,6 +38,7 @@
                 required
                 autocomplete="new-password"
                 :placeholder="__('Password')"
+                passwordrules="{{ \Illuminate\Validation\Rules\Password::defaults()->toPasswordRulesString() }}"
                 viewable
             />
 
@@ -49,6 +50,7 @@
                 required
                 autocomplete="new-password"
                 :placeholder="__('Confirm password')"
+                passwordrules="{{ \Illuminate\Validation\Rules\Password::defaults()->toPasswordRulesString() }}"
                 viewable
             />
 

--- a/kits/Livewire/Fortify/resources/views/pages/auth/reset-password.blade.php
+++ b/kits/Livewire/Fortify/resources/views/pages/auth/reset-password.blade.php
@@ -28,6 +28,7 @@
                 required
                 autocomplete="new-password"
                 :placeholder="__('Password')"
+                passwordrules="{{ \Illuminate\Validation\Rules\Password::defaults()->toPasswordRulesString() }}"
                 viewable
             />
 
@@ -39,6 +40,7 @@
                 required
                 autocomplete="new-password"
                 :placeholder="__('Confirm password')"
+                passwordrules="{{ \Illuminate\Validation\Rules\Password::defaults()->toPasswordRulesString() }}"
                 viewable
             />
 

--- a/kits/Livewire/Fortify/resources/views/pages/settings/security.blade.php
+++ b/kits/Livewire/Fortify/resources/views/pages/settings/security.blade.php
@@ -107,6 +107,7 @@ new #[Title('Security settings')] class extends Component {
                 type="password"
                 required
                 autocomplete="new-password"
+                passwordrules="{{ \Illuminate\Validation\Rules\Password::defaults()->toPasswordRulesString() }}"
                 viewable
             />
             <flux:input
@@ -115,6 +116,7 @@ new #[Title('Security settings')] class extends Component {
                 type="password"
                 required
                 autocomplete="new-password"
+                passwordrules="{{ \Illuminate\Validation\Rules\Password::defaults()->toPasswordRulesString() }}"
                 viewable
             />
 


### PR DESCRIPTION
Uses the new `Password::defaults()->toPasswordRulesString()` method from laravel/framework#60070 to add the `passwordrules` HTML attribute to all new-password inputs across every kit variant (register, reset password, and update password pages). This helps password managers like Safari and 1Password generate compliant passwords automatically.

The value is passed as a page prop from `FortifyServiceProvider` (for register and reset password) and `SecurityController` (for the security settings page).
