### PR TITLE
Remove unused variable in TeamInvitationController

### DIFF
--- a/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamInvitationController.php
+++ b/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamInvitationController.php
@@ -65,12 +65,10 @@ class TeamInvitationController extends Controller
         DB::transaction(function () use ($user, $invitation) {
             $team = $invitation->team;
 
-            $membership = $team->memberships()->firstOrCreate(
+            $team->memberships()->firstOrCreate(
                 ['user_id' => $user->id],
                 ['role' => $invitation->role],
             );
-
-            $wasRecentlyCreated = $membership->wasRecentlyCreated;
 
             $invitation->update(['accepted_at' => now()]);
 


### PR DESCRIPTION
## Description
Removes an unused `$wasRecentlyCreated` variable from the `TeamInvitationController::accept()` method.

The variable was assigned but never used, likely leftover from a previous refactoring.

## Changes
- Removed `$membership` variable assignment
- Removed unused `$wasRecentlyCreated` variable

## Impact
- No functional changes
- Slightly cleaner code
- Reduces memory allocation (one less variable)