### PR TITLE
Remove unnecessary null-safe operator from member role label

### DIFF
--- a/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamController.php
+++ b/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamController.php
@@ -62,7 +62,7 @@ class TeamController extends Controller
                 'email' => $member->email,
                 'avatar' => $member->avatar ?? null,
                 'role' => $member->pivot->role->value,
-                'role_label' => $member->pivot->role?->label(),
+                'role_label' => $member->pivot->role->label(),
             ]),
             'invitations' => $team->invitations()
                 ->whereNull('accepted_at')

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/edit.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/edit.blade.php
@@ -99,7 +99,7 @@ new class extends Component
             'email' => $member->email,
             'avatar' => $member->avatar ?? null,
             'role' => $member->pivot->role->value,
-            'role_label' => $member->pivot->role?->label(),
+            'role_label' => $member->pivot->role->label(),
         ])->toArray();
 
         $this->invitations = $team->invitations()


### PR DESCRIPTION
## What
Removes the unnecessary null-safe operator (`?->`) when accessing the role label on team memberships.

## Why
The `team_members.role` column is non-nullable in the database schema and is cast to a `TeamRole` enum in the `Membership` model. Therefore, the role can never be null, making the null-safe operator redundant.

This change also creates consistency with line 112 in the same file, where `$invitation->role->label()` is accessed without the null-safe operator (invitations also have a non-nullable role column).

## How
- Changed `$member->pivot->role?->label()` to `$member->pivot->role->label()` on line 102
