### PR TITLE
Clean up starter kit CI configuration

### DIFF
--- a/kits/Inertia/WorkOS/Base/composer.json
+++ b/kits/Inertia/WorkOS/Base/composer.json
@@ -13,8 +13,8 @@
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
-        "laravel/workos": "^0.6.0",
-        "laravel/wayfinder": "^0.1.14"
+        "laravel/wayfinder": "^0.1.14",
+        "laravel/workos": "^0.6.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",

--- a/kits/Livewire/Blank/.github/workflows/lint.yml
+++ b/kits/Livewire/Blank/.github/workflows/lint.yml
@@ -20,7 +20,6 @@ permissions:
 jobs:
   quality:
     runs-on: ubuntu-latest
-    environment: Testing
     steps:
       - uses: actions/checkout@v6
 

--- a/kits/Livewire/Blank/.github/workflows/tests.yml
+++ b/kits/Livewire/Blank/.github/workflows/tests.yml
@@ -17,7 +17,6 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    environment: Testing
     strategy:
       matrix:
         php-version: ['8.3', '8.4', '8.5']


### PR DESCRIPTION
The Livewire blank starter kit workflows do not need to target the Testing environment, so this removes that extra environment requirement from the lint and test jobs. It also keeps the Inertia WorkOS dependency list consistently ordered.