### PR TITLE
Fix Teams email verification redirect

### DIFF
--- a/kits/Inertia/Fortify/Base/chisel.php
+++ b/kits/Inertia/Fortify/Base/chisel.php
@@ -127,6 +127,7 @@ return Chisel::script(__DIR__)
             )->removeSection('email-verification');
 
             $c->files(
+                'app/Http/Responses/VerifyEmailResponse.php',
                 $paths['verify_email'],
                 'tests/Feature/Auth/EmailVerificationTest.php',
                 'tests/Feature/Auth/VerificationNotificationTest.php',

--- a/kits/Inertia/Teams/Fortify/Base/app/Providers/FortifyServiceProvider.php
+++ b/kits/Inertia/Teams/Fortify/Base/app/Providers/FortifyServiceProvider.php
@@ -16,6 +16,9 @@ use App\Http\Responses\RegisterResponse;
 /* @chisel-2fa */
 use App\Http\Responses\TwoFactorLoginResponse;
 /* @end-chisel-2fa */
+/* @chisel-email-verification */
+use App\Http\Responses\VerifyEmailResponse;
+/* @end-chisel-email-verification */
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
@@ -29,6 +32,9 @@ use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 /* @chisel-2fa */
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 /* @end-chisel-2fa */
+/* @chisel-email-verification */
+use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
+/* @end-chisel-email-verification */
 use Laravel\Fortify\Features;
 use Laravel\Fortify\Fortify;
 /* @chisel-passkeys */
@@ -53,6 +59,9 @@ class FortifyServiceProvider extends ServiceProvider
         /* @chisel-2fa */
         $this->app->singleton(TwoFactorLoginResponseContract::class, TwoFactorLoginResponse::class);
         /* @end-chisel-2fa */
+        /* @chisel-email-verification */
+        $this->app->singleton(VerifyEmailResponseContract::class, VerifyEmailResponse::class);
+        /* @end-chisel-email-verification */
     }
 
     /**

--- a/kits/Inertia/Teams/Fortify/Base/tests/Feature/Auth/EmailVerificationTest.php
+++ b/kits/Inertia/Teams/Fortify/Base/tests/Feature/Auth/EmailVerificationTest.php
@@ -25,6 +25,7 @@ class EmailVerificationTest extends TestCase
     public function test_email_can_be_verified()
     {
         $user = User::factory()->unverified()->create();
+        $team = $user->personalTeam();
 
         Event::fake();
 
@@ -38,7 +39,7 @@ class EmailVerificationTest extends TestCase
 
         Event::assertDispatched(Verified::class);
         $this->assertTrue($user->fresh()->hasVerifiedEmail());
-        $response->assertRedirect('/dashboard?verified=1');
+        $response->assertRedirect("/{$team->slug}/dashboard?verified=1");
     }
 
     public function test_email_is_not_verified_with_invalid_hash()
@@ -92,6 +93,7 @@ class EmailVerificationTest extends TestCase
     public function test_already_verified_user_visiting_verification_link_is_redirected_without_firing_event_again(): void
     {
         $user = User::factory()->create();
+        $team = $user->personalTeam();
 
         Event::fake();
 
@@ -102,7 +104,7 @@ class EmailVerificationTest extends TestCase
         );
 
         $this->actingAs($user)->get($verificationUrl)
-            ->assertRedirect('/dashboard?verified=1');
+            ->assertRedirect("/{$team->slug}/dashboard?verified=1");
 
         Event::assertNotDispatched(Verified::class);
         $this->assertTrue($user->fresh()->hasVerifiedEmail());

--- a/kits/Livewire/Fortify/chisel.php
+++ b/kits/Livewire/Fortify/chisel.php
@@ -124,6 +124,7 @@ return Chisel::script(__DIR__)
             )->removeSection('email-verification');
 
             $c->files(
+                'app/Http/Responses/VerifyEmailResponse.php',
                 $paths['verify_email'],
                 'tests/Feature/Auth/EmailVerificationTest.php',
             )->delete();

--- a/kits/Livewire/Teams/Fortify/app/Providers/FortifyServiceProvider.php
+++ b/kits/Livewire/Teams/Fortify/app/Providers/FortifyServiceProvider.php
@@ -28,12 +28,12 @@ use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 /* @chisel-registration */
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 /* @end-chisel-registration */
-/* @chisel-email-verification */
-use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
-/* @end-chisel-email-verification */
 /* @chisel-2fa */
-use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
+use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 /* @end-chisel-2fa */
+/* @chisel-email-verification */
+use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
+/* @end-chisel-email-verification */
 use Laravel\Fortify\Fortify;
 /* @chisel-passkeys */
 use Laravel\Passkeys\Contracts\PasskeyLoginResponse as PasskeyLoginResponseContract;

--- a/kits/Livewire/Teams/Fortify/app/Providers/FortifyServiceProvider.php
+++ b/kits/Livewire/Teams/Fortify/app/Providers/FortifyServiceProvider.php
@@ -13,7 +13,9 @@ use App\Http\Responses\PasskeyLoginResponse;
 /* @chisel-registration */
 use App\Http\Responses\RegisterResponse;
 /* @end-chisel-registration */
+/* @chisel-2fa */
 use App\Http\Responses\TwoFactorLoginResponse;
+/* @end-chisel-2fa */
 /* @chisel-email-verification */
 use App\Http\Responses\VerifyEmailResponse;
 /* @end-chisel-email-verification */
@@ -26,18 +28,17 @@ use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 /* @chisel-registration */
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 /* @end-chisel-registration */
-/* @chisel-2fa */
-use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
-use Laravel\Fortify\Fortify;
 /* @chisel-email-verification */
-use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
+use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 /* @end-chisel-email-verification */
+/* @chisel-2fa */
+use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
+/* @end-chisel-2fa */
+use Laravel\Fortify\Fortify;
 /* @chisel-passkeys */
 use Laravel\Passkeys\Contracts\PasskeyLoginResponse as PasskeyLoginResponseContract;
 
 /* @end-chisel-passkeys */
-
-/* @end-chisel-2fa */
 
 class FortifyServiceProvider extends ServiceProvider
 {

--- a/kits/Livewire/Teams/Fortify/app/Providers/FortifyServiceProvider.php
+++ b/kits/Livewire/Teams/Fortify/app/Providers/FortifyServiceProvider.php
@@ -14,6 +14,9 @@ use App\Http\Responses\PasskeyLoginResponse;
 use App\Http\Responses\RegisterResponse;
 /* @end-chisel-registration */
 use App\Http\Responses\TwoFactorLoginResponse;
+/* @chisel-email-verification */
+use App\Http\Responses\VerifyEmailResponse;
+/* @end-chisel-email-verification */
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
@@ -26,6 +29,9 @@ use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 /* @chisel-2fa */
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 use Laravel\Fortify\Fortify;
+/* @chisel-email-verification */
+use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
+/* @end-chisel-email-verification */
 /* @chisel-passkeys */
 use Laravel\Passkeys\Contracts\PasskeyLoginResponse as PasskeyLoginResponseContract;
 
@@ -50,6 +56,9 @@ class FortifyServiceProvider extends ServiceProvider
         /* @chisel-2fa */
         $this->app->singleton(TwoFactorLoginResponseContract::class, TwoFactorLoginResponse::class);
         /* @end-chisel-2fa */
+        /* @chisel-email-verification */
+        $this->app->singleton(VerifyEmailResponseContract::class, VerifyEmailResponse::class);
+        /* @end-chisel-email-verification */
     }
 
     /**

--- a/kits/Livewire/Teams/Fortify/tests/Feature/Auth/EmailVerificationTest.php
+++ b/kits/Livewire/Teams/Fortify/tests/Feature/Auth/EmailVerificationTest.php
@@ -25,6 +25,7 @@ class EmailVerificationTest extends TestCase
     public function test_email_can_be_verified(): void
     {
         $user = User::factory()->unverified()->create();
+        $team = $user->personalTeam();
 
         Event::fake();
 
@@ -39,7 +40,7 @@ class EmailVerificationTest extends TestCase
         Event::assertDispatched(Verified::class);
         $this->assertTrue($user->fresh()->hasVerifiedEmail());
 
-        $response->assertRedirect('/dashboard?verified=1');
+        $response->assertRedirect("/{$team->slug}/dashboard?verified=1");
     }
 
     public function test_email_is_not_verified_with_invalid_hash(): void
@@ -62,6 +63,7 @@ class EmailVerificationTest extends TestCase
         $user = User::factory()->create([
             'email_verified_at' => now(),
         ]);
+        $team = $user->personalTeam();
 
         Event::fake();
 
@@ -72,7 +74,7 @@ class EmailVerificationTest extends TestCase
         );
 
         $this->actingAs($user)->get($verificationUrl)
-            ->assertRedirect('/dashboard?verified=1');
+            ->assertRedirect("/{$team->slug}/dashboard?verified=1");
 
         $this->assertTrue($user->fresh()->hasVerifiedEmail());
         Event::assertNotDispatched(Verified::class);

--- a/kits/Shared/Teams/Fortify/app/Http/Responses/VerifyEmailResponse.php
+++ b/kits/Shared/Teams/Fortify/app/Http/Responses/VerifyEmailResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Responses;
+
+use App\Http\Responses\Concerns\RedirectsToCurrentTeam;
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
+use Laravel\Fortify\Fortify;
+use Symfony\Component\HttpFoundation\Response;
+
+class VerifyEmailResponse implements VerifyEmailResponseContract
+{
+    use RedirectsToCurrentTeam;
+
+    public function toResponse($request): Response
+    {
+        return $request->wantsJson()
+            ? new JsonResponse('', 204)
+            : redirect()->intended($this->redirectPathForCurrentTeam($request, Fortify::redirects('email-verification')).'?verified=1');
+    }
+}


### PR DESCRIPTION
## Summary
- add a Teams Fortify `VerifyEmailResponse` that redirects to the current team's dashboard
- bind the custom response in both the Livewire and Inertia Teams Fortify service providers
- fix the 404 after email verification when Teams is enabled

## Problem
Fortify's default email verification response redirects to `/dashboard?verified=1`.
In Teams variants, the dashboard route is team-prefixed, so the correct destination is `/{team_slug}/dashboard?verified=1`.

## Scope
- Livewire Teams + Fortify
- Inertia Teams + Fortify
