### PR TITLE
Update Vue 2fa challenge page

### DIFF
--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/TwoFactorChallenge.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/TwoFactorChallenge.vue
@@ -12,6 +12,9 @@ import {
 import { store } from '@/routes/two-factor/login';
 import type { TwoFactorConfigContent } from '@/types';
 
+const showRecoveryInput = ref<boolean>(false);
+const code = ref<string>('');
+
 const authConfigContent = computed<TwoFactorConfigContent>(() => {
     if (showRecoveryInput.value) {
         return {
@@ -37,15 +40,11 @@ watchEffect(() => {
     });
 });
 
-const showRecoveryInput = ref<boolean>(false);
-
 const toggleRecoveryMode = (clearErrors: () => void): void => {
     showRecoveryInput.value = !showRecoveryInput.value;
     clearErrors();
     code.value = '';
 };
-
-const code = ref<string>('');
 </script>
 
 <template>


### PR DESCRIPTION
Closes #116

Seems to be an issue with the Vue 2fa challenge page evaluating `authConfigContent` before `showRecoveryInput` has been initialized. 