### PR TITLE
Teams Invitation Flow Improvements

### DIFF
--- a/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
+++ b/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
@@ -103,7 +103,7 @@ test('invitation can be accepted by the invited user', function () {
 });
 
 test('login page shows team invitation alert', function () {
-    if (! file_exists(resource_path('js/pages/auth/login.tsx')) && ! file_exists(resource_path('js/pages/auth/Login.svelte'))) {
+    if (! file_exists(resource_path('js/pages/auth/login.tsx')) && ! file_exists(resource_path('js/pages/auth/Login.svelte')) && ! file_exists(resource_path('js/pages/auth/Login.vue'))) {
         $this->markTestSkipped('Auth invitation alert is not implemented for this stack yet.');
     }
 
@@ -125,7 +125,7 @@ test('login page shows team invitation alert', function () {
 });
 
 test('register page preserves team invitation alert from login', function () {
-    if (! file_exists(resource_path('js/pages/auth/register.tsx')) && ! file_exists(resource_path('js/pages/auth/Register.svelte'))) {
+    if (! file_exists(resource_path('js/pages/auth/register.tsx')) && ! file_exists(resource_path('js/pages/auth/Register.svelte')) && ! file_exists(resource_path('js/pages/auth/Register.vue'))) {
         $this->markTestSkipped('Auth invitation alert is not implemented for this stack yet.');
     }
 

--- a/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
+++ b/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
@@ -103,8 +103,8 @@ test('invitation can be accepted by the invited user', function () {
 });
 
 test('login page shows team invitation alert', function () {
-    if (! file_exists(resource_path('js/pages/auth/login.tsx'))) {
-        $this->markTestSkipped('React auth invitation alert is not implemented for this stack yet.');
+    if (! file_exists(resource_path('js/pages/auth/login.tsx')) && ! file_exists(resource_path('js/pages/auth/Login.svelte'))) {
+        $this->markTestSkipped('Auth invitation alert is not implemented for this stack yet.');
     }
 
     $owner = User::factory()->create();
@@ -125,8 +125,8 @@ test('login page shows team invitation alert', function () {
 });
 
 test('register page preserves team invitation alert from login', function () {
-    if (! file_exists(resource_path('js/pages/auth/register.tsx'))) {
-        $this->markTestSkipped('React auth invitation alert is not implemented for this stack yet.');
+    if (! file_exists(resource_path('js/pages/auth/register.tsx')) && ! file_exists(resource_path('js/pages/auth/Register.svelte'))) {
+        $this->markTestSkipped('Auth invitation alert is not implemented for this stack yet.');
     }
 
     $owner = User::factory()->create();

--- a/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
+++ b/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
@@ -103,10 +103,6 @@ test('invitation can be accepted by the invited user', function () {
 });
 
 test('login page shows team invitation alert', function () {
-    if (! file_exists(resource_path('js/pages/auth/login.tsx')) && ! file_exists(resource_path('js/pages/auth/Login.svelte')) && ! file_exists(resource_path('js/pages/auth/Login.vue'))) {
-        $this->markTestSkipped('Auth invitation alert is not implemented for this stack yet.');
-    }
-
     $owner = User::factory()->create();
     $team = Team::factory()->create(['name' => 'Login Alert Team']);
     $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
@@ -125,10 +121,6 @@ test('login page shows team invitation alert', function () {
 });
 
 test('register page preserves team invitation alert from login', function () {
-    if (! file_exists(resource_path('js/pages/auth/register.tsx')) && ! file_exists(resource_path('js/pages/auth/Register.svelte')) && ! file_exists(resource_path('js/pages/auth/Register.vue'))) {
-        $this->markTestSkipped('Auth invitation alert is not implemented for this stack yet.');
-    }
-
     $owner = User::factory()->create();
     $team = Team::factory()->create(['name' => 'Register Alert Team']);
     $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);

--- a/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
+++ b/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
@@ -102,6 +102,51 @@ test('invitation can be accepted by the invited user', function () {
     expect($invitedUser->fresh()->currentTeam->id)->toBe($team->id);
 });
 
+test('login page shows team invitation alert', function () {
+    if (! file_exists(resource_path('js/pages/auth/login.tsx'))) {
+        $this->markTestSkipped('React auth invitation alert is not implemented for this stack yet.');
+    }
+
+    $owner = User::factory()->create();
+    $team = Team::factory()->create(['name' => 'Login Alert Team']);
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $invitation = TeamInvitation::factory()->create([
+        'team_id' => $team->id,
+        'email' => 'login-alert@example.com',
+        'invited_by' => $owner->id,
+    ]);
+
+    visit(route('login', ['invitation' => $invitation->code]))
+        ->assertVisible('@team-invitation-alert')
+        ->assertSee('Log in to join the "Login Alert Team" Team.')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});
+
+test('register page preserves team invitation alert from login', function () {
+    if (! file_exists(resource_path('js/pages/auth/register.tsx'))) {
+        $this->markTestSkipped('React auth invitation alert is not implemented for this stack yet.');
+    }
+
+    $owner = User::factory()->create();
+    $team = Team::factory()->create(['name' => 'Register Alert Team']);
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $invitation = TeamInvitation::factory()->create([
+        'team_id' => $team->id,
+        'email' => 'register-alert@example.com',
+        'invited_by' => $owner->id,
+    ]);
+
+    visit(route('login', ['invitation' => $invitation->code]))
+        ->click('@team-invitation-register-link')
+        ->assertVisible('@team-invitation-alert')
+        ->assertSee('Register to join the "Register Alert Team" Team.')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});
+
 test('pending invitations modal appears on the dashboard', function () {
     $owner = User::factory()->create(['name' => 'Taylor Otwell']);
     $team = Team::factory()->create(['name' => 'Browser Team']);

--- a/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
+++ b/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
@@ -101,3 +101,81 @@ test('invitation can be accepted by the invited user', function () {
 
     expect($invitedUser->fresh()->currentTeam->id)->toBe($team->id);
 });
+
+test('pending invitations modal appears on the dashboard', function () {
+    $owner = User::factory()->create(['name' => 'Taylor Otwell']);
+    $team = Team::factory()->create(['name' => 'Browser Team']);
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $invitedUser = User::factory()->create(['email' => 'browser@example.com']);
+
+    TeamInvitation::factory()->create([
+        'team_id' => $team->id,
+        'email' => 'browser@example.com',
+        'invited_by' => $owner->id,
+    ]);
+
+    actingAs($invitedUser);
+
+    visit(route('dashboard'))
+        ->waitForText('Pending team invitations')
+        ->assertVisible('@pending-invitations-modal')
+        ->assertVisible('@pending-invitation-row')
+        ->assertSee('Taylor Otwell')
+        ->assertSee('Browser Team')
+        ->assertVisible('@pending-invitation-accept')
+        ->assertVisible('@pending-invitation-decline')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});
+
+test('pending invitations can be declined from the dashboard modal', function () {
+    $owner = User::factory()->create();
+    $team = Team::factory()->create(['name' => 'Decline Browser Team']);
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $invitedUser = User::factory()->create(['email' => 'decline-browser@example.com']);
+
+    $invitation = TeamInvitation::factory()->create([
+        'team_id' => $team->id,
+        'email' => 'decline-browser@example.com',
+        'invited_by' => $owner->id,
+    ]);
+
+    actingAs($invitedUser);
+
+    visit(route('dashboard'))
+        ->waitForText('Pending team invitations')
+        ->pressAndWaitFor('@pending-invitation-decline')
+        ->assertDontSee('Decline Browser Team')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+
+    expect(TeamInvitation::whereKey($invitation->id)->exists())->toBeFalse();
+});
+
+test('pending invitations can be accepted from the dashboard modal', function () {
+    $owner = User::factory()->create();
+    $team = Team::factory()->create(['name' => 'Accept Browser Team']);
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $invitedUser = User::factory()->create(['email' => 'accept-browser@example.com']);
+
+    TeamInvitation::factory()->create([
+        'team_id' => $team->id,
+        'email' => 'accept-browser@example.com',
+        'invited_by' => $owner->id,
+    ]);
+
+    actingAs($invitedUser);
+
+    visit(route('dashboard'))
+        ->waitForText('Pending team invitations')
+        ->pressAndWaitFor('@pending-invitation-accept')
+        ->assertPathEndsWith('/dashboard')
+        ->assertPathContains($team->slug)
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+
+    expect($invitedUser->fresh()->currentTeam->id)->toBe($team->id);
+});

--- a/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
+++ b/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
@@ -132,7 +132,7 @@ test('register page preserves team invitation alert from login', function () {
     ]);
 
     visit(route('login', ['invitation' => $invitation->code]))
-        ->click('@team-invitation-register-link')
+        ->click('@register-link')
         ->assertVisible('@team-invitation-alert')
         ->assertSee('Register to join the "Register Alert Team" Team.')
         ->assertNoConsoleLogs()

--- a/kits/Inertia/Teams/Base/app/Http/Controllers/DashboardController.php
+++ b/kits/Inertia/Teams/Base/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TeamInvitation;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class DashboardController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        $email = strtolower($request->user()->email);
+
+        TeamInvitation::query()
+            ->whereRaw('LOWER(email) = ?', [$email])
+            ->whereNotNull('expires_at')
+            ->where('expires_at', '<', now())
+            ->delete();
+
+        $pendingInvitations = TeamInvitation::query()
+            ->with(['inviter', 'team'])
+            ->whereRaw('LOWER(email) = ?', [$email])
+            ->whereNull('accepted_at')
+            ->where(fn ($query) => $query
+                ->whereNull('expires_at')
+                ->orWhere('expires_at', '>=', now()))
+            ->latest()
+            ->get()
+            ->map(fn (TeamInvitation $invitation) => [
+                'code' => $invitation->code,
+                'inviterName' => $invitation->inviter->name,
+                'teamName' => $invitation->team->name,
+                'team' => [
+                    'name' => $invitation->team->name,
+                    'slug' => $invitation->team->slug,
+                ],
+            ]);
+
+        return Inertia::render('{{dashboard}}', [
+            'pendingInvitations' => $pendingInvitations,
+        ]);
+    }
+}

--- a/kits/Inertia/Teams/Base/app/Http/Controllers/DashboardController.php
+++ b/kits/Inertia/Teams/Base/app/Http/Controllers/DashboardController.php
@@ -13,12 +13,6 @@ class DashboardController extends Controller
     {
         $email = strtolower($request->user()->email);
 
-        TeamInvitation::query()
-            ->whereRaw('LOWER(email) = ?', [$email])
-            ->whereNotNull('expires_at')
-            ->where('expires_at', '<', now())
-            ->delete();
-
         $pendingInvitations = TeamInvitation::query()
             ->with(['inviter', 'team'])
             ->whereRaw('LOWER(email) = ?', [$email])
@@ -31,7 +25,6 @@ class DashboardController extends Controller
             ->map(fn (TeamInvitation $invitation) => [
                 'code' => $invitation->code,
                 'inviterName' => $invitation->inviter->name,
-                'teamName' => $invitation->team->name,
                 'team' => [
                     'name' => $invitation->team->name,
                     'slug' => $invitation->team->slug,

--- a/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamInvitationController.php
+++ b/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamInvitationController.php
@@ -75,6 +75,20 @@ class TeamInvitationController extends Controller
             $user->switchTeam($team);
         });
 
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation accepted.')]);
+
+        return to_route('dashboard');
+    }
+
+    /**
+     * Decline the invitation.
+     */
+    public function decline(AcceptTeamInvitationRequest $request, TeamInvitation $invitation): RedirectResponse
+    {
+        $invitation->delete();
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation declined.')]);
+
         return to_route('dashboard');
     }
 }

--- a/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamInvitationController.php
+++ b/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamInvitationController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers\Teams;
 
 use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Teams\AcceptTeamInvitationRequest;
 use App\Http\Requests\Teams\CreateTeamInvitationRequest;
+use App\Http\Requests\Teams\RespondToTeamInvitationRequest;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
@@ -58,7 +58,7 @@ class TeamInvitationController extends Controller
     /**
      * Accept the invitation.
      */
-    public function accept(AcceptTeamInvitationRequest $request, TeamInvitation $invitation): RedirectResponse
+    public function accept(RespondToTeamInvitationRequest $request, TeamInvitation $invitation): RedirectResponse
     {
         $user = $request->user();
 
@@ -83,7 +83,7 @@ class TeamInvitationController extends Controller
     /**
      * Decline the invitation.
      */
-    public function decline(AcceptTeamInvitationRequest $request, TeamInvitation $invitation): RedirectResponse
+    public function decline(RespondToTeamInvitationRequest $request, TeamInvitation $invitation): RedirectResponse
     {
         $invitation->delete();
 

--- a/kits/Inertia/Teams/Base/app/Http/Requests/Teams/RespondToTeamInvitationRequest.php
+++ b/kits/Inertia/Teams/Base/app/Http/Requests/Teams/RespondToTeamInvitationRequest.php
@@ -6,7 +6,7 @@ use App\Rules\ValidTeamInvitation;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
-class AcceptTeamInvitationRequest extends FormRequest
+class RespondToTeamInvitationRequest extends FormRequest
 {
     /**
      * Get the validation rules that apply to the request.

--- a/kits/Inertia/Teams/Base/tests/Feature/DashboardTest.php
+++ b/kits/Inertia/Teams/Base/tests/Feature/DashboardTest.php
@@ -2,8 +2,12 @@
 
 namespace Tests\Feature;
 
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
 
 class DashboardTest extends TestCase
@@ -29,5 +33,118 @@ class DashboardTest extends TestCase
             ->get(route('dashboard'));
 
         $response->assertOk();
+    }
+
+    public function test_dashboard_includes_pending_invitations_for_the_authenticated_user()
+    {
+        $owner = User::factory()->create(['name' => 'Taylor Otwell']);
+        $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
+        $team = Team::factory()->create(['name' => 'Laravel Team']);
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $invitation = TeamInvitation::factory()->create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $response = $this
+            ->actingAs($invitedUser)
+            ->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{dashboard}}')
+            ->has('pendingInvitations', 1)
+            ->where('pendingInvitations.0.code', $invitation->code)
+            ->where('pendingInvitations.0.inviterName', 'Taylor Otwell')
+            ->where('pendingInvitations.0.teamName', 'Laravel Team')
+            ->where('pendingInvitations.0.team.name', 'Laravel Team')
+            ->where('pendingInvitations.0.team.slug', $team->slug),
+        );
+    }
+
+    public function test_dashboard_does_not_include_accepted_invitations()
+    {
+        $owner = User::factory()->create();
+        $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        TeamInvitation::factory()->accepted()->create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $response = $this
+            ->actingAs($invitedUser)
+            ->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{dashboard}}')
+            ->has('pendingInvitations', 0),
+        );
+    }
+
+    public function test_dashboard_deletes_expired_invitations_for_the_authenticated_user()
+    {
+        $owner = User::factory()->create();
+        $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $invitation = TeamInvitation::factory()->expired()->create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $response = $this
+            ->actingAs($invitedUser)
+            ->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{dashboard}}')
+            ->has('pendingInvitations', 0),
+        );
+
+        $this->assertDatabaseMissing('team_invitations', [
+            'id' => $invitation->id,
+        ]);
+    }
+
+    public function test_dashboard_does_not_include_or_delete_other_users_invitations()
+    {
+        $owner = User::factory()->create();
+        $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $invitation = TeamInvitation::factory()->expired()->create([
+            'team_id' => $team->id,
+            'email' => 'someone@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $response = $this
+            ->actingAs($invitedUser)
+            ->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{dashboard}}')
+            ->has('pendingInvitations', 0),
+        );
+
+        $this->assertDatabaseHas('team_invitations', [
+            'id' => $invitation->id,
+        ]);
     }
 }

--- a/kits/Inertia/Teams/Base/tests/Feature/DashboardTest.php
+++ b/kits/Inertia/Teams/Base/tests/Feature/DashboardTest.php
@@ -59,9 +59,9 @@ class DashboardTest extends TestCase
             ->has('pendingInvitations', 1)
             ->where('pendingInvitations.0.code', $invitation->code)
             ->where('pendingInvitations.0.inviterName', 'Taylor Otwell')
-            ->where('pendingInvitations.0.teamName', 'Laravel Team')
             ->where('pendingInvitations.0.team.name', 'Laravel Team')
-            ->where('pendingInvitations.0.team.slug', $team->slug),
+            ->where('pendingInvitations.0.team.slug', $team->slug)
+            ->missing('pendingInvitations.0.teamName'),
         );
     }
 
@@ -90,7 +90,7 @@ class DashboardTest extends TestCase
         );
     }
 
-    public function test_dashboard_deletes_expired_invitations_for_the_authenticated_user()
+    public function test_dashboard_excludes_expired_invitations_without_deleting_them()
     {
         $owner = User::factory()->create();
         $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
@@ -114,7 +114,7 @@ class DashboardTest extends TestCase
             ->has('pendingInvitations', 0),
         );
 
-        $this->assertDatabaseMissing('team_invitations', [
+        $this->assertDatabaseHas('team_invitations', [
             'id' => $invitation->id,
         ]);
     }

--- a/kits/Inertia/Teams/Base/tests/Feature/Teams/TeamInvitationTest.php
+++ b/kits/Inertia/Teams/Base/tests/Feature/Teams/TeamInvitationTest.php
@@ -6,8 +6,10 @@ use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
+use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Route;
 use Tests\TestCase;
 
 class TeamInvitationTest extends TestCase
@@ -37,6 +39,72 @@ class TeamInvitationTest extends TestCase
             'email' => 'invited@example.com',
             'role' => TeamRole::Member->value,
         ]);
+    }
+
+    public function test_invitation_email_for_existing_users_uses_login_route()
+    {
+        $owner = User::factory()->create();
+        $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $invitation = TeamInvitation::factory()->create([
+            'team_id' => $team->id,
+            'email' => $invitedUser->email,
+            'invited_by' => $owner->id,
+        ]);
+
+        $mail = (new TeamInvitationNotification($invitation))->toMail($invitedUser);
+
+        $this->assertSame(route('login'), $mail->actionUrl);
+        $this->assertStringContainsString('dashboard', implode(' ', $mail->introLines));
+    }
+
+    public function test_invitation_email_for_unknown_users_uses_register_route_when_available()
+    {
+        if (! Route::has('register')) {
+            $this->markTestSkipped('This kit does not provide local registration.');
+        }
+
+        $owner = User::factory()->create();
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $invitation = TeamInvitation::factory()->create([
+            'team_id' => $team->id,
+            'email' => 'unknown@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $mail = (new TeamInvitationNotification($invitation))->toMail((object) []);
+
+        $this->assertSame(route('register'), $mail->actionUrl);
+        $this->assertStringContainsString('register', strtolower(implode(' ', $mail->introLines)));
+    }
+
+    public function test_invitation_email_for_unknown_users_uses_login_route_when_registration_is_unavailable()
+    {
+        if (Route::has('register')) {
+            $this->markTestSkipped('This kit provides local registration.');
+        }
+
+        $owner = User::factory()->create();
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $invitation = TeamInvitation::factory()->create([
+            'team_id' => $team->id,
+            'email' => 'unknown@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $mail = (new TeamInvitationNotification($invitation))->toMail((object) []);
+
+        $this->assertSame(route('login'), $mail->actionUrl);
+        $this->assertStringContainsString('log in', strtolower(implode(' ', $mail->introLines)));
     }
 
     public function test_team_invitations_can_be_created_by_admins()
@@ -167,9 +235,85 @@ class TeamInvitationTest extends TestCase
             ->get(route('invitations.accept', $invitation));
 
         $response->assertRedirect(route('dashboard'));
+        $response->assertInertiaFlash('toast', ['type' => 'success', 'message' => 'Invitation accepted.']);
 
         $this->assertTrue($invitedUser->fresh()->belongsToTeam($team));
         $this->assertNotNull($invitation->fresh()->accepted_at);
+    }
+
+    public function test_team_invitations_can_be_declined_by_the_invited_user()
+    {
+        $owner = User::factory()->create();
+        $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $invitation = TeamInvitation::factory()->create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $response = $this
+            ->actingAs($invitedUser)
+            ->delete(route('invitations.decline', $invitation));
+
+        $response->assertRedirect(route('dashboard'));
+
+        $this->assertDatabaseMissing('team_invitations', [
+            'id' => $invitation->id,
+        ]);
+    }
+
+    public function test_team_invitations_cannot_be_declined_by_uninvited_user()
+    {
+        $owner = User::factory()->create();
+        $uninvitedUser = User::factory()->create(['email' => 'uninvited@example.com']);
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $invitation = TeamInvitation::factory()->create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $response = $this
+            ->actingAs($uninvitedUser)
+            ->delete(route('invitations.decline', $invitation));
+
+        $response->assertSessionHasErrors('invitation');
+
+        $this->assertDatabaseHas('team_invitations', [
+            'id' => $invitation->id,
+        ]);
+    }
+
+    public function test_accepted_team_invitations_cannot_be_declined()
+    {
+        $owner = User::factory()->create();
+        $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $invitation = TeamInvitation::factory()->accepted()->create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $response = $this
+            ->actingAs($invitedUser)
+            ->delete(route('invitations.decline', $invitation));
+
+        $response->assertSessionHasErrors('invitation');
+
+        $this->assertDatabaseHas('team_invitations', [
+            'id' => $invitation->id,
+        ]);
     }
 
     public function test_team_invitations_cannot_be_accepted_by_uninvited_user()

--- a/kits/Inertia/Teams/Base/tests/Feature/Teams/TeamInvitationTest.php
+++ b/kits/Inertia/Teams/Base/tests/Feature/Teams/TeamInvitationTest.php
@@ -9,7 +9,6 @@ use App\Models\User;
 use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
-use Illuminate\Support\Facades\Route;
 use Tests\TestCase;
 
 class TeamInvitationTest extends TestCase
@@ -57,16 +56,12 @@ class TeamInvitationTest extends TestCase
 
         $mail = (new TeamInvitationNotification($invitation))->toMail($invitedUser);
 
-        $this->assertSame(route('login'), $mail->actionUrl);
+        $this->assertSame(route('login', ['invitation' => $invitation->code]), $mail->actionUrl);
         $this->assertStringContainsString('dashboard', implode(' ', $mail->introLines));
     }
 
-    public function test_invitation_email_for_unknown_users_uses_register_route_when_available()
+    public function test_invitation_email_for_unknown_users_uses_login_route()
     {
-        if (! Route::has('register')) {
-            $this->markTestSkipped('This kit does not provide local registration.');
-        }
-
         $owner = User::factory()->create();
         $team = Team::factory()->create();
 
@@ -80,30 +75,7 @@ class TeamInvitationTest extends TestCase
 
         $mail = (new TeamInvitationNotification($invitation))->toMail((object) []);
 
-        $this->assertSame(route('register'), $mail->actionUrl);
-        $this->assertStringContainsString('register', strtolower(implode(' ', $mail->introLines)));
-    }
-
-    public function test_invitation_email_for_unknown_users_uses_login_route_when_registration_is_unavailable()
-    {
-        if (Route::has('register')) {
-            $this->markTestSkipped('This kit provides local registration.');
-        }
-
-        $owner = User::factory()->create();
-        $team = Team::factory()->create();
-
-        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
-
-        $invitation = TeamInvitation::factory()->create([
-            'team_id' => $team->id,
-            'email' => 'unknown@example.com',
-            'invited_by' => $owner->id,
-        ]);
-
-        $mail = (new TeamInvitationNotification($invitation))->toMail((object) []);
-
-        $this->assertSame(route('login'), $mail->actionUrl);
+        $this->assertSame(route('login', ['invitation' => $invitation->code]), $mail->actionUrl);
         $this->assertStringContainsString('log in', strtolower(implode(' ', $mail->introLines)));
     }
 

--- a/kits/Inertia/Teams/Fortify/Base/app/Providers/FortifyServiceProvider.php
+++ b/kits/Inertia/Teams/Fortify/Base/app/Providers/FortifyServiceProvider.php
@@ -19,6 +19,7 @@ use App\Http\Responses\TwoFactorLoginResponse;
 /* @chisel-email-verification */
 use App\Http\Responses\VerifyEmailResponse;
 /* @end-chisel-email-verification */
+use App\Models\TeamInvitation;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
@@ -93,6 +94,7 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::loginView(fn (Request $request) => Inertia::render('{{auth_login}}', [
             'canResetPassword' => Features::enabled(Features::resetPasswords()),
             'status' => $request->session()->get('status'),
+            'teamInvitation' => $this->teamInvitation($request),
         ]));
 
         Fortify::resetPasswordView(fn (Request $request) => Inertia::render('{{auth_reset_password}}', [
@@ -111,7 +113,9 @@ class FortifyServiceProvider extends ServiceProvider
         /* @end-chisel-email-verification */
 
         /* @chisel-registration */
-        Fortify::registerView(fn () => Inertia::render('{{auth_register}}'));
+        Fortify::registerView(fn (Request $request) => Inertia::render('{{auth_register}}', [
+            'teamInvitation' => $this->teamInvitation($request),
+        ]));
         /* @end-chisel-registration */
 
         /* @chisel-2fa */
@@ -149,5 +153,37 @@ class FortifyServiceProvider extends ServiceProvider
             );
         });
         /* @end-chisel-passkeys */
+    }
+
+    /**
+     * Get the pending team invitation context for auth pages.
+     *
+     * @return array{code: string, teamName: string}|null
+     */
+    private function teamInvitation(Request $request): ?array
+    {
+        $invitationCode = $request->query('invitation');
+
+        if (! is_string($invitationCode)) {
+            return null;
+        }
+
+        $invitation = TeamInvitation::query()
+            ->with('team')
+            ->where('code', $invitationCode)
+            ->whereNull('accepted_at')
+            ->where(fn ($query) => $query
+                ->whereNull('expires_at')
+                ->orWhere('expires_at', '>=', now()))
+            ->first();
+
+        if (! $invitation) {
+            return null;
+        }
+
+        return [
+            'code' => $invitation->code,
+            'teamName' => $invitation->team->name,
+        ];
     }
 }

--- a/kits/Inertia/Teams/Fortify/Base/routes/web.php
+++ b/kits/Inertia/Teams/Fortify/Base/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Middleware\EnsureTeamMembership;
 use Illuminate\Support\Facades\Route;
@@ -9,11 +10,12 @@ Route::inertia('/', '{{welcome}}')->name('home');
 Route::prefix('{current_team}')
     ->middleware(['auth', 'verified', EnsureTeamMembership::class])
     ->group(function () {
-        Route::inertia('dashboard', '{{dashboard}}')->name('dashboard');
+        Route::get('dashboard', DashboardController::class)->name('dashboard');
     });
 
 Route::middleware(['auth'])->group(function () {
     Route::get('invitations/{invitation}/accept', [TeamInvitationController::class, 'accept'])->name('invitations.accept');
+    Route::delete('invitations/{invitation}', [TeamInvitationController::class, 'decline'])->name('invitations.decline');
 });
 
 require __DIR__.'/settings.php';

--- a/kits/Inertia/Teams/Fortify/Base/tests/Feature/Auth/AuthenticationTest.php
+++ b/kits/Inertia/Teams/Fortify/Base/tests/Feature/Auth/AuthenticationTest.php
@@ -2,10 +2,14 @@
 
 namespace Tests\Feature\Auth;
 
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
+use Inertia\Testing\AssertableInertia as Assert;
 use Laravel\Fortify\Features;
 /* @chisel-passkeys */
 use Laravel\Passkeys\Contracts\PasskeyLoginResponse;
@@ -21,6 +25,28 @@ class AuthenticationTest extends TestCase
         $response = $this->get(route('login'));
 
         $response->assertOk();
+    }
+
+    public function test_login_screen_includes_team_invitation_context()
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['name' => 'Laravel Team']);
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $invitation = TeamInvitation::factory()->create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $response = $this->get(route('login', ['invitation' => $invitation->code]));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{auth_login}}')
+            ->where('teamInvitation.code', $invitation->code)
+            ->where('teamInvitation.teamName', 'Laravel Team'),
+        );
     }
 
     public function test_users_can_authenticate_using_the_login_screen()

--- a/kits/Inertia/Teams/Fortify/Base/tests/Feature/Auth/RegistrationTest.php
+++ b/kits/Inertia/Teams/Fortify/Base/tests/Feature/Auth/RegistrationTest.php
@@ -2,8 +2,12 @@
 
 namespace Tests\Feature\Auth;
 
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
 
 class RegistrationTest extends TestCase
@@ -15,6 +19,28 @@ class RegistrationTest extends TestCase
         $response = $this->get(route('register'));
 
         $response->assertOk();
+    }
+
+    public function test_registration_screen_includes_team_invitation_context()
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['name' => 'Laravel Team']);
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $invitation = TeamInvitation::factory()->create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $response = $this->get(route('register', ['invitation' => $invitation->code]));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('{{auth_register}}')
+            ->where('teamInvitation.code', $invitation->code)
+            ->where('teamInvitation.teamName', 'Laravel Team'),
+        );
     }
 
     public function test_new_users_can_register()

--- a/kits/Inertia/Teams/Fortify/React/resources/js/components/team-invitation-alert.tsx
+++ b/kits/Inertia/Teams/Fortify/React/resources/js/components/team-invitation-alert.tsx
@@ -1,0 +1,22 @@
+import { InfoIcon } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import type { TeamInvitationContext } from '@/types';
+
+type Props = {
+    invitation: TeamInvitationContext;
+    action: 'Log in' | 'Register';
+};
+
+export default function TeamInvitationAlert({ invitation, action }: Props) {
+    return (
+        <Alert
+            data-test="team-invitation-alert"
+            className="border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-900/50 dark:bg-blue-950/50 dark:text-blue-100 [&>svg]:text-blue-600 dark:[&>svg]:text-blue-400"
+        >
+            <InfoIcon />
+            <AlertDescription className="text-blue-900 dark:text-blue-100">
+                {action} to join the "{invitation.teamName}" Team.
+            </AlertDescription>
+        </Alert>
+    );
+}

--- a/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/login.tsx
+++ b/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/login.tsx
@@ -126,7 +126,7 @@ export default function Login({
                                           })
                                         : register()
                                 }
-                                data-test="team-invitation-register-link"
+                                data-test="register-link"
                                 tabIndex={5}
                             >
                                 Sign up

--- a/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/login.tsx
+++ b/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/login.tsx
@@ -118,7 +118,12 @@ export default function Login({
                             <TextLink
                                 href={
                                     teamInvitation
-                                        ? `/register?invitation=${teamInvitation.code}`
+                                        ? register.url({
+                                              query: {
+                                                  invitation:
+                                                      teamInvitation.code,
+                                              },
+                                          })
                                         : register()
                                 }
                                 data-test="team-invitation-register-link"

--- a/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/login.tsx
+++ b/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/login.tsx
@@ -1,0 +1,147 @@
+import { Form, Head } from '@inertiajs/react';
+import InputError from '@/components/input-error';
+import PasswordInput from '@/components/password-input';
+import TeamInvitationAlert from '@/components/team-invitation-alert';
+import TextLink from '@/components/text-link';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+/* @chisel-registration */
+import { register } from '@/routes';
+/* @end-chisel-registration */
+import { store } from '@/routes/login';
+import { request } from '@/routes/password';
+/* @chisel-passkeys */
+import PasskeyVerify from '@/components/passkey-verify';
+/* @end-chisel-passkeys */
+import type { TeamInvitationContext } from '@/types';
+
+type Props = {
+    status?: string;
+    canResetPassword: boolean;
+    teamInvitation?: TeamInvitationContext | null;
+};
+
+export default function Login({
+    status,
+    canResetPassword,
+    teamInvitation,
+}: Props) {
+    return (
+        <>
+            <Head title="Log in" />
+
+            {teamInvitation && (
+                <TeamInvitationAlert
+                    invitation={teamInvitation}
+                    action="Log in"
+                />
+            )}
+
+            {/* @chisel-passkeys */}
+            <PasskeyVerify />
+            {/* @end-chisel-passkeys */}
+
+            <Form
+                {...store.form()}
+                resetOnSuccess={['password']}
+                className="flex flex-col gap-6"
+            >
+                {({ processing, errors }) => (
+                    <>
+                        <div className="grid gap-6">
+                            <div className="grid gap-2">
+                                <Label htmlFor="email">Email address</Label>
+                                <Input
+                                    id="email"
+                                    type="email"
+                                    name="email"
+                                    required
+                                    autoFocus
+                                    tabIndex={1}
+                                    autoComplete="email"
+                                    placeholder="email@example.com"
+                                />
+                                <InputError message={errors.email} />
+                            </div>
+
+                            <div className="grid gap-2">
+                                <div className="flex items-center">
+                                    <Label htmlFor="password">Password</Label>
+                                    {canResetPassword && (
+                                        <TextLink
+                                            href={request()}
+                                            className="ml-auto text-sm"
+                                            tabIndex={5}
+                                        >
+                                            Forgot password?
+                                        </TextLink>
+                                    )}
+                                </div>
+                                <PasswordInput
+                                    id="password"
+                                    name="password"
+                                    required
+                                    tabIndex={2}
+                                    autoComplete="current-password"
+                                    placeholder="Password"
+                                />
+                                <InputError message={errors.password} />
+                            </div>
+
+                            <div className="flex items-center space-x-3">
+                                <Checkbox
+                                    id="remember"
+                                    name="remember"
+                                    tabIndex={3}
+                                />
+                                <Label htmlFor="remember">Remember me</Label>
+                            </div>
+
+                            <Button
+                                type="submit"
+                                className="mt-4 w-full"
+                                tabIndex={4}
+                                disabled={processing}
+                                data-test="login-button"
+                            >
+                                {processing && <Spinner />}
+                                Log in
+                            </Button>
+                        </div>
+
+                        {/* @chisel-registration */}
+                        <div className="text-center text-sm text-muted-foreground">
+                            Don't have an account?{' '}
+                            <TextLink
+                                href={
+                                    teamInvitation
+                                        ? `/register?invitation=${teamInvitation.code}`
+                                        : register()
+                                }
+                                data-test="team-invitation-register-link"
+                                tabIndex={5}
+                            >
+                                Sign up
+                            </TextLink>
+                        </div>
+                        {/* @end-chisel-registration */}
+                    </>
+                )}
+            </Form>
+
+            {status && (
+                <div className="mb-4 text-center text-sm font-medium text-green-600">
+                    {status}
+                </div>
+            )}
+        </>
+    );
+}
+
+Login.layout = {
+    title: 'Log in to your account',
+    description: 'Enter your email and password below to log in',
+};

--- a/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/login.tsx
+++ b/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/login.tsx
@@ -116,16 +116,11 @@ export default function Login({
                         <div className="text-center text-sm text-muted-foreground">
                             Don't have an account?{' '}
                             <TextLink
-                                href={
-                                    teamInvitation
-                                        ? register.url({
-                                              query: {
-                                                  invitation:
-                                                      teamInvitation.code,
-                                              },
-                                          })
-                                        : register()
-                                }
+                                href={register({
+                                    query: {
+                                        invitation: teamInvitation?.code,
+                                    },
+                                })}
                                 data-test="register-link"
                                 tabIndex={5}
                             >

--- a/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/register.tsx
+++ b/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/register.tsx
@@ -1,0 +1,138 @@
+import { Form, Head } from '@inertiajs/react';
+import InputError from '@/components/input-error';
+import PasswordInput from '@/components/password-input';
+import TeamInvitationAlert from '@/components/team-invitation-alert';
+import TextLink from '@/components/text-link';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+import { login } from '@/routes';
+import { store } from '@/routes/register';
+import type { TeamInvitationContext } from '@/types';
+
+type Props = {
+    passwordRules: string;
+    teamInvitation?: TeamInvitationContext | null;
+};
+
+export default function Register({ passwordRules, teamInvitation }: Props) {
+    return (
+        <>
+            <Head title="Register" />
+            <Form
+                {...store.form()}
+                resetOnSuccess={['password', 'password_confirmation']}
+                disableWhileProcessing
+                className="flex flex-col gap-6"
+            >
+                {({ processing, errors }) => (
+                    <>
+                        {teamInvitation && (
+                            <TeamInvitationAlert
+                                invitation={teamInvitation}
+                                action="Register"
+                            />
+                        )}
+
+                        <div className="grid gap-6">
+                            <div className="grid gap-2">
+                                <Label htmlFor="name">Name</Label>
+                                <Input
+                                    id="name"
+                                    type="text"
+                                    required
+                                    autoFocus
+                                    tabIndex={1}
+                                    autoComplete="name"
+                                    name="name"
+                                    placeholder="Full name"
+                                />
+                                <InputError
+                                    message={errors.name}
+                                    className="mt-2"
+                                />
+                            </div>
+
+                            <div className="grid gap-2">
+                                <Label htmlFor="email">Email address</Label>
+                                <Input
+                                    id="email"
+                                    type="email"
+                                    required
+                                    tabIndex={2}
+                                    autoComplete="email"
+                                    name="email"
+                                    placeholder="email@example.com"
+                                />
+                                <InputError message={errors.email} />
+                            </div>
+
+                            <div className="grid gap-2">
+                                <Label htmlFor="password">Password</Label>
+                                <PasswordInput
+                                    id="password"
+                                    required
+                                    tabIndex={3}
+                                    autoComplete="new-password"
+                                    name="password"
+                                    placeholder="Password"
+                                    passwordrules={passwordRules}
+                                />
+                                <InputError message={errors.password} />
+                            </div>
+
+                            <div className="grid gap-2">
+                                <Label htmlFor="password_confirmation">
+                                    Confirm password
+                                </Label>
+                                <PasswordInput
+                                    id="password_confirmation"
+                                    required
+                                    tabIndex={4}
+                                    autoComplete="new-password"
+                                    name="password_confirmation"
+                                    placeholder="Confirm password"
+                                    passwordrules={passwordRules}
+                                />
+                                <InputError
+                                    message={errors.password_confirmation}
+                                />
+                            </div>
+
+                            <Button
+                                type="submit"
+                                className="mt-2 w-full"
+                                tabIndex={5}
+                                data-test="register-user-button"
+                            >
+                                {processing && <Spinner />}
+                                Create account
+                            </Button>
+                        </div>
+
+                        <div className="text-center text-sm text-muted-foreground">
+                            Already have an account?{' '}
+                            <TextLink
+                                href={
+                                    teamInvitation
+                                        ? `/login?invitation=${teamInvitation.code}`
+                                        : login()
+                                }
+                                data-test="team-invitation-login-link"
+                                tabIndex={6}
+                            >
+                                Log in
+                            </TextLink>
+                        </div>
+                    </>
+                )}
+            </Form>
+        </>
+    );
+}
+
+Register.layout = {
+    title: 'Create an account',
+    description: 'Enter your details below to create your account',
+};

--- a/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/register.tsx
+++ b/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/register.tsx
@@ -116,7 +116,12 @@ export default function Register({ passwordRules, teamInvitation }: Props) {
                             <TextLink
                                 href={
                                     teamInvitation
-                                        ? `/login?invitation=${teamInvitation.code}`
+                                        ? login.url({
+                                              query: {
+                                                  invitation:
+                                                      teamInvitation.code,
+                                              },
+                                          })
                                         : login()
                                 }
                                 data-test="team-invitation-login-link"

--- a/kits/Inertia/Teams/Fortify/Svelte/resources/js/components/TeamInvitationAlert.svelte
+++ b/kits/Inertia/Teams/Fortify/Svelte/resources/js/components/TeamInvitationAlert.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+    import Info from 'lucide-svelte/icons/info';
+    import { Alert, AlertDescription } from '@/components/ui/alert';
+    import type { TeamInvitationContext } from '@/types';
+
+    let {
+        invitation,
+        action,
+    }: {
+        invitation: TeamInvitationContext;
+        action: 'Log in' | 'Register';
+    } = $props();
+</script>
+
+<div data-test="team-invitation-alert">
+    <Alert
+        class="border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-900/50 dark:bg-blue-950/50 dark:text-blue-100 [&>svg]:text-blue-600 dark:[&>svg]:text-blue-400"
+    >
+        <Info class="size-4" />
+        <AlertDescription class="text-blue-900 dark:text-blue-100">
+            {action} to join the "{invitation.teamName}" Team.
+        </AlertDescription>
+    </Alert>
+</div>

--- a/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Login.svelte
+++ b/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Login.svelte
@@ -116,7 +116,11 @@
             Don't have an account?
             <TextLink
                 href={teamInvitation
-                    ? `/register?invitation=${teamInvitation.code}`
+                    ? register.url({
+                          query: {
+                              invitation: teamInvitation.code,
+                          },
+                      })
                     : register()}
                 data-test="team-invitation-register-link"
             >

--- a/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Login.svelte
+++ b/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Login.svelte
@@ -10,7 +10,9 @@
     import AppHead from '@/components/AppHead.svelte';
     import InputError from '@/components/InputError.svelte';
     import PasswordInput from '@/components/PasswordInput.svelte';
+    /* @chisel-passkeys */
     import PasskeyVerify from '@/components/PasskeyVerify.svelte';
+    /* @end-chisel-passkeys */
     import TeamInvitationAlert from '@/components/TeamInvitationAlert.svelte';
     import TextLink from '@/components/TextLink.svelte';
     import { Button } from '@/components/ui/button';

--- a/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Login.svelte
+++ b/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Login.svelte
@@ -1,0 +1,126 @@
+<script module lang="ts">
+    export const layout = {
+        title: 'Log in to your account',
+        description: 'Enter your email and password below to log in',
+    };
+</script>
+
+<script lang="ts">
+    import { Form } from '@inertiajs/svelte';
+    import AppHead from '@/components/AppHead.svelte';
+    import InputError from '@/components/InputError.svelte';
+    import PasswordInput from '@/components/PasswordInput.svelte';
+    import PasskeyVerify from '@/components/PasskeyVerify.svelte';
+    import TeamInvitationAlert from '@/components/TeamInvitationAlert.svelte';
+    import TextLink from '@/components/TextLink.svelte';
+    import { Button } from '@/components/ui/button';
+    import { Checkbox } from '@/components/ui/checkbox';
+    import { Input } from '@/components/ui/input';
+    import { Label } from '@/components/ui/label';
+    import { Spinner } from '@/components/ui/spinner';
+    /* @chisel-registration */
+    import { register } from '@/routes';
+    /* @end-chisel-registration */
+    import { store } from '@/routes/login';
+    import { request } from '@/routes/password';
+    import type { TeamInvitationContext } from '@/types';
+
+    let {
+        status = '',
+        canResetPassword,
+        teamInvitation = null,
+    }: {
+        status?: string;
+        canResetPassword: boolean;
+        teamInvitation?: TeamInvitationContext | null;
+    } = $props();
+</script>
+
+<AppHead title="Log in" />
+
+{#if status}
+    <div class="mb-4 text-center text-sm font-medium text-green-600">
+        {status}
+    </div>
+{/if}
+
+{#if teamInvitation}
+    <TeamInvitationAlert invitation={teamInvitation} action="Log in" />
+{/if}
+
+<!-- @chisel-passkeys -->
+<PasskeyVerify />
+<!-- @end-chisel-passkeys -->
+
+<Form
+    {...store.form()}
+    resetOnSuccess={['password']}
+    class="flex flex-col gap-6"
+>
+    {#snippet children({ errors, processing })}
+        <div class="grid gap-6">
+            <div class="grid gap-2">
+                <Label for="email">Email address</Label>
+                <Input
+                    id="email"
+                    type="email"
+                    name="email"
+                    required
+                    autocomplete="email"
+                    placeholder="email@example.com"
+                />
+                <InputError message={errors.email} />
+            </div>
+
+            <div class="grid gap-2">
+                <div class="flex items-center justify-between">
+                    <Label for="password">Password</Label>
+                    {#if canResetPassword}
+                        <TextLink href={request()} class="text-sm">
+                            Forgot password?
+                        </TextLink>
+                    {/if}
+                </div>
+                <PasswordInput
+                    id="password"
+                    name="password"
+                    required
+                    autocomplete="current-password"
+                    placeholder="Password"
+                />
+                <InputError message={errors.password} />
+            </div>
+
+            <div class="flex items-center justify-between">
+                <Label for="remember" class="flex items-center space-x-3">
+                    <Checkbox id="remember" name="remember" />
+                    <span>Remember me</span>
+                </Label>
+            </div>
+
+            <Button
+                type="submit"
+                class="mt-4 w-full"
+                disabled={processing}
+                data-test="login-button"
+            >
+                {#if processing}<Spinner />{/if}
+                Log in
+            </Button>
+        </div>
+
+        <!-- @chisel-registration -->
+        <div class="text-center text-sm text-muted-foreground">
+            Don't have an account?
+            <TextLink
+                href={teamInvitation
+                    ? `/register?invitation=${teamInvitation.code}`
+                    : register()}
+                data-test="team-invitation-register-link"
+            >
+                Sign up
+            </TextLink>
+        </div>
+        <!-- @end-chisel-registration -->
+    {/snippet}
+</Form>

--- a/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Login.svelte
+++ b/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Login.svelte
@@ -122,7 +122,7 @@
                           },
                       })
                     : register()}
-                data-test="team-invitation-register-link"
+                data-test="register-link"
             >
                 Sign up
             </TextLink>

--- a/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Login.svelte
+++ b/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Login.svelte
@@ -115,13 +115,11 @@
         <div class="text-center text-sm text-muted-foreground">
             Don't have an account?
             <TextLink
-                href={teamInvitation
-                    ? register.url({
-                          query: {
-                              invitation: teamInvitation.code,
-                          },
-                      })
-                    : register()}
+                href={register({
+                    query: {
+                        invitation: teamInvitation?.code,
+                    },
+                })}
                 data-test="register-link"
             >
                 Sign up

--- a/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Register.svelte
+++ b/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Register.svelte
@@ -1,0 +1,121 @@
+<script module lang="ts">
+    export const layout = {
+        title: 'Create an account',
+        description: 'Enter your details below to create your account',
+    };
+</script>
+
+<script lang="ts">
+    import { Form } from '@inertiajs/svelte';
+    import AppHead from '@/components/AppHead.svelte';
+    import InputError from '@/components/InputError.svelte';
+    import PasswordInput from '@/components/PasswordInput.svelte';
+    import TeamInvitationAlert from '@/components/TeamInvitationAlert.svelte';
+    import TextLink from '@/components/TextLink.svelte';
+    import { Button } from '@/components/ui/button';
+    import { Input } from '@/components/ui/input';
+    import { Label } from '@/components/ui/label';
+    import { Spinner } from '@/components/ui/spinner';
+    import { login } from '@/routes';
+    import { store } from '@/routes/register';
+    import type { TeamInvitationContext } from '@/types';
+
+    let {
+        passwordRules,
+        teamInvitation = null,
+    }: {
+        passwordRules: string;
+        teamInvitation?: TeamInvitationContext | null;
+    } = $props();
+</script>
+
+<AppHead title="Register" />
+
+{#if teamInvitation}
+    <TeamInvitationAlert invitation={teamInvitation} action="Register" />
+{/if}
+
+<Form
+    {...store.form()}
+    resetOnSuccess={['password', 'password_confirmation']}
+    class="flex flex-col gap-6"
+>
+    {#snippet children({ errors, processing })}
+        <div class="grid gap-6">
+            <div class="grid gap-2">
+                <Label for="name">Name</Label>
+                <Input
+                    id="name"
+                    type="text"
+                    required
+                    autocomplete="name"
+                    name="name"
+                    placeholder="Full name"
+                />
+                <InputError message={errors.name} />
+            </div>
+
+            <div class="grid gap-2">
+                <Label for="email">Email address</Label>
+                <Input
+                    id="email"
+                    type="email"
+                    required
+                    autocomplete="email"
+                    name="email"
+                    placeholder="email@example.com"
+                />
+                <InputError message={errors.email} />
+            </div>
+
+            <div class="grid gap-2">
+                <Label for="password">Password</Label>
+                <PasswordInput
+                    id="password"
+                    required
+                    autocomplete="new-password"
+                    name="password"
+                    placeholder="Password"
+                    passwordrules={passwordRules}
+                />
+                <InputError message={errors.password} />
+            </div>
+
+            <div class="grid gap-2">
+                <Label for="password_confirmation">Confirm password</Label>
+                <PasswordInput
+                    id="password_confirmation"
+                    required
+                    autocomplete="new-password"
+                    name="password_confirmation"
+                    placeholder="Confirm password"
+                    passwordrules={passwordRules}
+                />
+                <InputError message={errors.password_confirmation} />
+            </div>
+
+            <Button
+                type="submit"
+                class="mt-2 w-full"
+                disabled={processing}
+                data-test="register-user-button"
+            >
+                {#if processing}<Spinner />{/if}
+                Create account
+            </Button>
+        </div>
+
+        <div class="text-center text-sm text-muted-foreground">
+            Already have an account?
+            <TextLink
+                href={teamInvitation
+                    ? `/login?invitation=${teamInvitation.code}`
+                    : login()}
+                class="underline underline-offset-4"
+                data-test="team-invitation-login-link"
+            >
+                Log in
+            </TextLink>
+        </div>
+    {/snippet}
+</Form>

--- a/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Register.svelte
+++ b/kits/Inertia/Teams/Fortify/Svelte/resources/js/pages/auth/Register.svelte
@@ -109,7 +109,11 @@
             Already have an account?
             <TextLink
                 href={teamInvitation
-                    ? `/login?invitation=${teamInvitation.code}`
+                    ? login.url({
+                          query: {
+                              invitation: teamInvitation.code,
+                          },
+                      })
                     : login()}
                 class="underline underline-offset-4"
                 data-test="team-invitation-login-link"

--- a/kits/Inertia/Teams/Fortify/Vue/resources/js/components/TeamInvitationAlert.vue
+++ b/kits/Inertia/Teams/Fortify/Vue/resources/js/components/TeamInvitationAlert.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Info } from 'lucide-vue-next';
+import { Info } from '@lucide/vue';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import type { TeamInvitationContext } from '@/types';
 

--- a/kits/Inertia/Teams/Fortify/Vue/resources/js/components/TeamInvitationAlert.vue
+++ b/kits/Inertia/Teams/Fortify/Vue/resources/js/components/TeamInvitationAlert.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { Info } from 'lucide-vue-next';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import type { TeamInvitationContext } from '@/types';
+
+type Props = {
+    invitation: TeamInvitationContext;
+    action: 'Log in' | 'Register';
+};
+
+defineProps<Props>();
+</script>
+
+<template>
+    <div data-test="team-invitation-alert">
+        <Alert
+            class="border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-900/50 dark:bg-blue-950/50 dark:text-blue-100 [&>svg]:text-blue-600 dark:[&>svg]:text-blue-400"
+        >
+            <Info class="size-4" />
+            <AlertDescription class="text-blue-900 dark:text-blue-100">
+                {{ action }} to join the "{{ invitation.teamName }}" Team.
+            </AlertDescription>
+        </Alert>
+    </div>
+</template>

--- a/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Login.vue
+++ b/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Login.vue
@@ -123,7 +123,11 @@ defineProps<{
             <TextLink
                 :href="
                     teamInvitation
-                        ? `/register?invitation=${teamInvitation.code}`
+                        ? register.url({
+                              query: {
+                                  invitation: teamInvitation.code,
+                              },
+                          })
                         : register()
                 "
                 :tabindex="5"

--- a/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Login.vue
+++ b/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Login.vue
@@ -122,13 +122,11 @@ defineProps<{
             Don't have an account?
             <TextLink
                 :href="
-                    teamInvitation
-                        ? register.url({
-                              query: {
-                                  invitation: teamInvitation.code,
-                              },
-                          })
-                        : register()
+                    register({
+                        query: {
+                            invitation: teamInvitation?.code,
+                        },
+                    })
                 "
                 :tabindex="5"
                 data-test="register-link"

--- a/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Login.vue
+++ b/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Login.vue
@@ -131,7 +131,7 @@ defineProps<{
                         : register()
                 "
                 :tabindex="5"
-                data-test="team-invitation-register-link"
+                data-test="register-link"
             >
                 Sign up
             </TextLink>

--- a/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Login.vue
+++ b/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Login.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import { Form, Head } from '@inertiajs/vue3';
+import InputError from '@/components/InputError.vue';
+import PasswordInput from '@/components/PasswordInput.vue';
+/* @chisel-passkeys */
+import PasskeyVerify from '@/components/PasskeyVerify.vue';
+/* @end-chisel-passkeys */
+import TeamInvitationAlert from '@/components/TeamInvitationAlert.vue';
+import TextLink from '@/components/TextLink.vue';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+/* @chisel-registration */
+import { register } from '@/routes';
+/* @end-chisel-registration */
+import { store } from '@/routes/login';
+import { request } from '@/routes/password';
+import type { TeamInvitationContext } from '@/types';
+
+defineOptions({
+    layout: {
+        title: 'Log in to your account',
+        description: 'Enter your email and password below to log in',
+    },
+});
+
+defineProps<{
+    status?: string;
+    canResetPassword: boolean;
+    teamInvitation?: TeamInvitationContext | null;
+}>();
+</script>
+
+<template>
+    <Head title="Log in" />
+
+    <div
+        v-if="status"
+        class="mb-4 text-center text-sm font-medium text-green-600"
+    >
+        {{ status }}
+    </div>
+
+    <TeamInvitationAlert
+        v-if="teamInvitation"
+        :invitation="teamInvitation"
+        action="Log in"
+    />
+
+    <!-- @chisel-passkeys -->
+    <PasskeyVerify />
+    <!-- @end-chisel-passkeys -->
+
+    <Form
+        v-bind="store.form()"
+        :reset-on-success="['password']"
+        v-slot="{ errors, processing }"
+        class="flex flex-col gap-6"
+    >
+        <div class="grid gap-6">
+            <div class="grid gap-2">
+                <Label for="email">Email address</Label>
+                <Input
+                    id="email"
+                    type="email"
+                    name="email"
+                    required
+                    autofocus
+                    :tabindex="1"
+                    autocomplete="email"
+                    placeholder="email@example.com"
+                />
+                <InputError :message="errors.email" />
+            </div>
+
+            <div class="grid gap-2">
+                <div class="flex items-center justify-between">
+                    <Label for="password">Password</Label>
+                    <TextLink
+                        v-if="canResetPassword"
+                        :href="request()"
+                        class="text-sm"
+                        :tabindex="5"
+                    >
+                        Forgot password?
+                    </TextLink>
+                </div>
+                <PasswordInput
+                    id="password"
+                    name="password"
+                    required
+                    :tabindex="2"
+                    autocomplete="current-password"
+                    placeholder="Password"
+                />
+                <InputError :message="errors.password" />
+            </div>
+
+            <div class="flex items-center justify-between">
+                <Label for="remember" class="flex items-center space-x-3">
+                    <Checkbox id="remember" name="remember" :tabindex="3" />
+                    <span>Remember me</span>
+                </Label>
+            </div>
+
+            <Button
+                type="submit"
+                class="mt-4 w-full"
+                :tabindex="4"
+                :disabled="processing"
+                data-test="login-button"
+            >
+                <Spinner v-if="processing" />
+                Log in
+            </Button>
+        </div>
+
+        <!-- @chisel-registration -->
+        <div class="text-center text-sm text-muted-foreground">
+            Don't have an account?
+            <TextLink
+                :href="
+                    teamInvitation
+                        ? `/register?invitation=${teamInvitation.code}`
+                        : register()
+                "
+                :tabindex="5"
+                data-test="team-invitation-register-link"
+            >
+                Sign up
+            </TextLink>
+        </div>
+        <!-- @end-chisel-registration -->
+    </Form>
+</template>

--- a/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Register.vue
+++ b/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Register.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { Form, Head } from '@inertiajs/vue3';
+import InputError from '@/components/InputError.vue';
+import PasswordInput from '@/components/PasswordInput.vue';
+import TeamInvitationAlert from '@/components/TeamInvitationAlert.vue';
+import TextLink from '@/components/TextLink.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+import { login } from '@/routes';
+import { store } from '@/routes/register';
+import type { TeamInvitationContext } from '@/types';
+
+defineProps<{
+    passwordRules: string;
+    teamInvitation?: TeamInvitationContext | null;
+}>();
+
+defineOptions({
+    layout: {
+        title: 'Create an account',
+        description: 'Enter your details below to create your account',
+    },
+});
+</script>
+
+<template>
+    <Head title="Register" />
+
+    <TeamInvitationAlert
+        v-if="teamInvitation"
+        :invitation="teamInvitation"
+        action="Register"
+    />
+
+    <Form
+        v-bind="store.form()"
+        :reset-on-success="['password', 'password_confirmation']"
+        v-slot="{ errors, processing }"
+        class="flex flex-col gap-6"
+    >
+        <div class="grid gap-6">
+            <div class="grid gap-2">
+                <Label for="name">Name</Label>
+                <Input
+                    id="name"
+                    type="text"
+                    required
+                    autofocus
+                    :tabindex="1"
+                    autocomplete="name"
+                    name="name"
+                    placeholder="Full name"
+                />
+                <InputError :message="errors.name" />
+            </div>
+
+            <div class="grid gap-2">
+                <Label for="email">Email address</Label>
+                <Input
+                    id="email"
+                    type="email"
+                    required
+                    :tabindex="2"
+                    autocomplete="email"
+                    name="email"
+                    placeholder="email@example.com"
+                />
+                <InputError :message="errors.email" />
+            </div>
+
+            <div class="grid gap-2">
+                <Label for="password">Password</Label>
+                <PasswordInput
+                    id="password"
+                    required
+                    :tabindex="3"
+                    autocomplete="new-password"
+                    name="password"
+                    placeholder="Password"
+                    :passwordrules="passwordRules"
+                />
+                <InputError :message="errors.password" />
+            </div>
+
+            <div class="grid gap-2">
+                <Label for="password_confirmation">Confirm password</Label>
+                <PasswordInput
+                    id="password_confirmation"
+                    required
+                    :tabindex="4"
+                    autocomplete="new-password"
+                    name="password_confirmation"
+                    placeholder="Confirm password"
+                    :passwordrules="passwordRules"
+                />
+                <InputError :message="errors.password_confirmation" />
+            </div>
+
+            <Button
+                type="submit"
+                class="mt-2 w-full"
+                tabindex="5"
+                :disabled="processing"
+                data-test="register-user-button"
+            >
+                <Spinner v-if="processing" />
+                Create account
+            </Button>
+        </div>
+
+        <div class="text-center text-sm text-muted-foreground">
+            Already have an account?
+            <TextLink
+                :href="
+                    teamInvitation
+                        ? `/login?invitation=${teamInvitation.code}`
+                        : login()
+                "
+                class="underline underline-offset-4"
+                :tabindex="6"
+                data-test="team-invitation-login-link"
+            >
+                Log in
+            </TextLink>
+        </div>
+    </Form>
+</template>

--- a/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Register.vue
+++ b/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Register.vue
@@ -115,7 +115,11 @@ defineOptions({
             <TextLink
                 :href="
                     teamInvitation
-                        ? `/login?invitation=${teamInvitation.code}`
+                        ? login.url({
+                              query: {
+                                  invitation: teamInvitation.code,
+                              },
+                          })
                         : login()
                 "
                 class="underline underline-offset-4"

--- a/kits/Inertia/Teams/React/resources/js/components/pending-invitations-modal.tsx
+++ b/kits/Inertia/Teams/React/resources/js/components/pending-invitations-modal.tsx
@@ -1,15 +1,15 @@
-import { router } from "@inertiajs/react";
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import TeamInvitationController from "@/actions/App/Http/Controllers/Teams/TeamInvitationController";
+import { router } from '@inertiajs/react';
+import { useState } from 'react';
+import TeamInvitationController from '@/actions/App/Http/Controllers/Teams/TeamInvitationController';
+import { Button } from '@/components/ui/button';
 import {
     Dialog,
     DialogContent,
     DialogDescription,
     DialogHeader,
     DialogTitle,
-} from "@/components/ui/dialog";
-import type { DashboardInvitation } from "@/types";
+} from '@/components/ui/dialog';
+import type { DashboardInvitation } from '@/types';
 
 type Props = {
     invitations: DashboardInvitation[];

--- a/kits/Inertia/Teams/React/resources/js/components/pending-invitations-modal.tsx
+++ b/kits/Inertia/Teams/React/resources/js/components/pending-invitations-modal.tsx
@@ -62,7 +62,7 @@ export default function PendingInvitationsModal({
                         >
                             <div className="space-y-1">
                                 <p className="font-medium">
-                                    {invitation.teamName}
+                                    {invitation.team.name}
                                 </p>
                                 <p className="text-sm text-muted-foreground">
                                     {invitation.inviterName} invited you to join

--- a/kits/Inertia/Teams/React/resources/js/components/pending-invitations-modal.tsx
+++ b/kits/Inertia/Teams/React/resources/js/components/pending-invitations-modal.tsx
@@ -1,14 +1,15 @@
-import { router } from '@inertiajs/react';
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
+import { router } from "@inertiajs/react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import TeamInvitationController from "@/actions/App/Http/Controllers/Teams/TeamInvitationController";
 import {
     Dialog,
     DialogContent,
     DialogDescription,
     DialogHeader,
     DialogTitle,
-} from '@/components/ui/dialog';
-import type { DashboardInvitation } from '@/types';
+} from "@/components/ui/dialog";
+import type { DashboardInvitation } from "@/types";
 
 type Props = {
     invitations: DashboardInvitation[];
@@ -24,14 +25,14 @@ export default function PendingInvitationsModal({
     const [processingCode, setProcessingCode] = useState<string | null>(null);
 
     const acceptInvitation = (invitation: DashboardInvitation) => {
-        router.visit(`/invitations/${invitation.code}/accept`, {
+        router.visit(TeamInvitationController.accept(invitation), {
             onStart: () => setProcessingCode(invitation.code),
             onFinish: () => setProcessingCode(null),
         });
     };
 
     const declineInvitation = (invitation: DashboardInvitation) => {
-        router.delete(`/invitations/${invitation.code}`, {
+        router.visit(TeamInvitationController.decline(invitation), {
             onStart: () => setProcessingCode(invitation.code),
             onFinish: () => setProcessingCode(null),
             onSuccess: () => {

--- a/kits/Inertia/Teams/React/resources/js/components/pending-invitations-modal.tsx
+++ b/kits/Inertia/Teams/React/resources/js/components/pending-invitations-modal.tsx
@@ -1,0 +1,103 @@
+import { router } from '@inertiajs/react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import type { DashboardInvitation } from '@/types';
+
+type Props = {
+    invitations: DashboardInvitation[];
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+};
+
+export default function PendingInvitationsModal({
+    invitations,
+    open,
+    onOpenChange,
+}: Props) {
+    const [processingCode, setProcessingCode] = useState<string | null>(null);
+
+    const acceptInvitation = (invitation: DashboardInvitation) => {
+        router.visit(`/invitations/${invitation.code}/accept`, {
+            onStart: () => setProcessingCode(invitation.code),
+            onFinish: () => setProcessingCode(null),
+        });
+    };
+
+    const declineInvitation = (invitation: DashboardInvitation) => {
+        router.delete(`/invitations/${invitation.code}`, {
+            onStart: () => setProcessingCode(invitation.code),
+            onFinish: () => setProcessingCode(null),
+            onSuccess: () => {
+                if (invitations.length === 1) {
+                    onOpenChange(false);
+                }
+            },
+        });
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent data-test="pending-invitations-modal">
+                <DialogHeader>
+                    <DialogTitle>Pending team invitations</DialogTitle>
+                    <DialogDescription>
+                        Accept or decline the teams you have been invited to
+                        join.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="grid gap-4">
+                    {invitations.map((invitation) => (
+                        <div
+                            key={invitation.code}
+                            data-test="pending-invitation-row"
+                            className="rounded-lg border p-4"
+                        >
+                            <div className="space-y-1">
+                                <p className="font-medium">
+                                    {invitation.teamName}
+                                </p>
+                                <p className="text-sm text-muted-foreground">
+                                    {invitation.inviterName} invited you to join
+                                    this team.
+                                </p>
+                            </div>
+
+                            <div className="mt-4 flex justify-end gap-2">
+                                <Button
+                                    variant="secondary"
+                                    data-test="pending-invitation-decline"
+                                    disabled={
+                                        processingCode === invitation.code
+                                    }
+                                    onClick={() =>
+                                        declineInvitation(invitation)
+                                    }
+                                >
+                                    Decline
+                                </Button>
+
+                                <Button
+                                    data-test="pending-invitation-accept"
+                                    disabled={
+                                        processingCode === invitation.code
+                                    }
+                                    onClick={() => acceptInvitation(invitation)}
+                                >
+                                    Accept
+                                </Button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/kits/Inertia/Teams/React/resources/js/pages/dashboard.tsx
+++ b/kits/Inertia/Teams/React/resources/js/pages/dashboard.tsx
@@ -1,11 +1,27 @@
 import { Head } from '@inertiajs/react';
+import { useState } from 'react';
+import PendingInvitationsModal from '@/components/pending-invitations-modal';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import { dashboard } from '@/routes';
+import type { DashboardInvitation } from '@/types';
 
-export default function Dashboard() {
+type Props = {
+    pendingInvitations?: DashboardInvitation[];
+};
+
+export default function Dashboard({ pendingInvitations = [] }: Props) {
+    const [showInvitations, setShowInvitations] = useState(
+        pendingInvitations.length > 0,
+    );
+
     return (
         <>
             <Head title="Dashboard" />
+            <PendingInvitationsModal
+                invitations={pendingInvitations}
+                open={pendingInvitations.length > 0 && showInvitations}
+                onOpenChange={setShowInvitations}
+            />
             <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
                 <div className="grid auto-rows-min gap-4 md:grid-cols-3">
                     <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">

--- a/kits/Inertia/Teams/React/resources/js/types/teams.ts
+++ b/kits/Inertia/Teams/React/resources/js/types/teams.ts
@@ -27,6 +27,11 @@ export type TeamInvitation = {
     created_at: string;
 };
 
+export type TeamInvitationContext = {
+    code: string;
+    teamName: string;
+};
+
 export type DashboardInvitation = {
     code: string;
     inviterName: string;

--- a/kits/Inertia/Teams/React/resources/js/types/teams.ts
+++ b/kits/Inertia/Teams/React/resources/js/types/teams.ts
@@ -27,6 +27,16 @@ export type TeamInvitation = {
     created_at: string;
 };
 
+export type DashboardInvitation = {
+    code: string;
+    inviterName: string;
+    teamName: string;
+    team: {
+        name: string;
+        slug: string;
+    };
+};
+
 export type TeamPermissions = {
     canUpdateTeam: boolean;
     canDeleteTeam: boolean;

--- a/kits/Inertia/Teams/React/resources/js/types/teams.ts
+++ b/kits/Inertia/Teams/React/resources/js/types/teams.ts
@@ -35,7 +35,6 @@ export type TeamInvitationContext = {
 export type DashboardInvitation = {
     code: string;
     inviterName: string;
-    teamName: string;
     team: {
         name: string;
         slug: string;

--- a/kits/Inertia/Teams/Svelte/resources/js/components/PendingInvitationsModal.svelte
+++ b/kits/Inertia/Teams/Svelte/resources/js/components/PendingInvitationsModal.svelte
@@ -55,7 +55,7 @@
                         class="rounded-lg border p-4"
                     >
                         <div class="space-y-1">
-                            <p class="font-medium">{invitation.teamName}</p>
+                            <p class="font-medium">{invitation.team.name}</p>
                             <p class="text-sm text-muted-foreground">
                                 {invitation.inviterName} invited you to join this
                                 team.

--- a/kits/Inertia/Teams/Svelte/resources/js/components/PendingInvitationsModal.svelte
+++ b/kits/Inertia/Teams/Svelte/resources/js/components/PendingInvitationsModal.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+    import { router } from '@inertiajs/svelte';
+    import { Button } from '@/components/ui/button';
+    import {
+        Dialog,
+        DialogContent,
+        DialogDescription,
+        DialogTitle,
+    } from '@/components/ui/dialog';
+    import type { DashboardInvitation } from '@/types';
+
+    let {
+        invitations,
+    }: {
+        invitations: DashboardInvitation[];
+    } = $props();
+
+    let open = $state(true);
+    let processingCode = $state<string | null>(null);
+
+    const acceptInvitation = (invitation: DashboardInvitation) => {
+        router.visit(`/invitations/${invitation.code}/accept`, {
+            onStart: () => (processingCode = invitation.code),
+            onFinish: () => (processingCode = null),
+        });
+    };
+
+    const declineInvitation = (invitation: DashboardInvitation) => {
+        router.delete(`/invitations/${invitation.code}`, {
+            onStart: () => (processingCode = invitation.code),
+            onFinish: () => (processingCode = null),
+            onSuccess: () => {
+                if (invitations.length === 1) {
+                    open = false;
+                }
+            },
+        });
+    };
+</script>
+
+<Dialog bind:open>
+    <DialogContent>
+        <div data-test="pending-invitations-modal" class="space-y-6">
+            <div class="space-y-3">
+                <DialogTitle>Pending team invitations</DialogTitle>
+                <DialogDescription>
+                    Accept or decline the teams you have been invited to join.
+                </DialogDescription>
+            </div>
+
+            <div class="grid gap-4">
+                {#each invitations as invitation (invitation.code)}
+                    <div
+                        data-test="pending-invitation-row"
+                        class="rounded-lg border p-4"
+                    >
+                        <div class="space-y-1">
+                            <p class="font-medium">{invitation.teamName}</p>
+                            <p class="text-sm text-muted-foreground">
+                                {invitation.inviterName} invited you to join this
+                                team.
+                            </p>
+                        </div>
+
+                        <div class="mt-4 flex justify-end gap-2">
+                            <Button
+                                variant="secondary"
+                                data-test="pending-invitation-decline"
+                                disabled={processingCode === invitation.code}
+                                onclick={() => declineInvitation(invitation)}
+                            >
+                                Decline
+                            </Button>
+
+                            <Button
+                                data-test="pending-invitation-accept"
+                                disabled={processingCode === invitation.code}
+                                onclick={() => acceptInvitation(invitation)}
+                            >
+                                Accept
+                            </Button>
+                        </div>
+                    </div>
+                {/each}
+            </div>
+        </div>
+    </DialogContent>
+</Dialog>

--- a/kits/Inertia/Teams/Svelte/resources/js/components/PendingInvitationsModal.svelte
+++ b/kits/Inertia/Teams/Svelte/resources/js/components/PendingInvitationsModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { router } from '@inertiajs/svelte';
+    import TeamInvitationController from '@/actions/App/Http/Controllers/Teams/TeamInvitationController';
     import { Button } from '@/components/ui/button';
     import {
         Dialog,
@@ -19,14 +20,14 @@
     let processingCode = $state<string | null>(null);
 
     const acceptInvitation = (invitation: DashboardInvitation) => {
-        router.visit(`/invitations/${invitation.code}/accept`, {
+        router.visit(TeamInvitationController.accept(invitation), {
             onStart: () => (processingCode = invitation.code),
             onFinish: () => (processingCode = null),
         });
     };
 
     const declineInvitation = (invitation: DashboardInvitation) => {
-        router.delete(`/invitations/${invitation.code}`, {
+        router.visit(TeamInvitationController.decline(invitation), {
             onStart: () => (processingCode = invitation.code),
             onFinish: () => (processingCode = null),
             onSuccess: () => {

--- a/kits/Inertia/Teams/Svelte/resources/js/pages/Dashboard.svelte
+++ b/kits/Inertia/Teams/Svelte/resources/js/pages/Dashboard.svelte
@@ -16,10 +16,22 @@
 
 <script lang="ts">
     import AppHead from '@/components/AppHead.svelte';
+    import PendingInvitationsModal from '@/components/PendingInvitationsModal.svelte';
     import PlaceholderPattern from '@/components/PlaceholderPattern.svelte';
+    import type { DashboardInvitation } from '@/types';
+
+    let {
+        pendingInvitations = [],
+    }: {
+        pendingInvitations?: DashboardInvitation[];
+    } = $props();
 </script>
 
 <AppHead title="Dashboard" />
+
+{#if pendingInvitations.length > 0}
+    <PendingInvitationsModal invitations={pendingInvitations} />
+{/if}
 
 <div class="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
     <div class="grid auto-rows-min gap-4 md:grid-cols-3">

--- a/kits/Inertia/Teams/Svelte/resources/js/types/teams.ts
+++ b/kits/Inertia/Teams/Svelte/resources/js/types/teams.ts
@@ -27,6 +27,21 @@ export type TeamInvitation = {
     created_at: string;
 };
 
+export type TeamInvitationContext = {
+    code: string;
+    teamName: string;
+};
+
+export type DashboardInvitation = {
+    code: string;
+    inviterName: string;
+    teamName: string;
+    team: {
+        name: string;
+        slug: string;
+    };
+};
+
 export type TeamPermissions = {
     canUpdateTeam: boolean;
     canDeleteTeam: boolean;

--- a/kits/Inertia/Teams/Svelte/resources/js/types/teams.ts
+++ b/kits/Inertia/Teams/Svelte/resources/js/types/teams.ts
@@ -35,7 +35,6 @@ export type TeamInvitationContext = {
 export type DashboardInvitation = {
     code: string;
     inviterName: string;
-    teamName: string;
     team: {
         name: string;
         slug: string;

--- a/kits/Inertia/Teams/Vue/resources/js/components/PendingInvitationsModal.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/components/PendingInvitationsModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { router } from '@inertiajs/vue3';
 import { ref } from 'vue';
+import TeamInvitationController from '@/actions/App/Http/Controllers/Teams/TeamInvitationController';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -21,14 +22,14 @@ const open = ref(true);
 const processingCode = ref<string | null>(null);
 
 const acceptInvitation = (invitation: DashboardInvitation) => {
-    router.visit(`/invitations/${invitation.code}/accept`, {
+    router.visit(TeamInvitationController.accept(invitation), {
         onStart: () => (processingCode.value = invitation.code),
         onFinish: () => (processingCode.value = null),
     });
 };
 
 const declineInvitation = (invitation: DashboardInvitation) => {
-    router.delete(`/invitations/${invitation.code}`, {
+    router.visit(TeamInvitationController.decline(invitation), {
         onStart: () => (processingCode.value = invitation.code),
         onFinish: () => (processingCode.value = null),
         onSuccess: () => {

--- a/kits/Inertia/Teams/Vue/resources/js/components/PendingInvitationsModal.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/components/PendingInvitationsModal.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3';
+import { ref } from 'vue';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import type { DashboardInvitation } from '@/types';
+
+type Props = {
+    invitations: DashboardInvitation[];
+};
+
+const props = defineProps<Props>();
+
+const open = ref(true);
+const processingCode = ref<string | null>(null);
+
+const acceptInvitation = (invitation: DashboardInvitation) => {
+    router.visit(`/invitations/${invitation.code}/accept`, {
+        onStart: () => (processingCode.value = invitation.code),
+        onFinish: () => (processingCode.value = null),
+    });
+};
+
+const declineInvitation = (invitation: DashboardInvitation) => {
+    router.delete(`/invitations/${invitation.code}`, {
+        onStart: () => (processingCode.value = invitation.code),
+        onFinish: () => (processingCode.value = null),
+        onSuccess: () => {
+            if (props.invitations.length === 1) {
+                open.value = false;
+            }
+        },
+    });
+};
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogContent data-test="pending-invitations-modal">
+            <DialogHeader>
+                <DialogTitle>Pending team invitations</DialogTitle>
+                <DialogDescription>
+                    Accept or decline the teams you have been invited to join.
+                </DialogDescription>
+            </DialogHeader>
+
+            <div class="grid gap-4">
+                <div
+                    v-for="invitation in props.invitations"
+                    :key="invitation.code"
+                    data-test="pending-invitation-row"
+                    class="rounded-lg border p-4"
+                >
+                    <div class="space-y-1">
+                        <p class="font-medium">{{ invitation.teamName }}</p>
+                        <p class="text-sm text-muted-foreground">
+                            {{ invitation.inviterName }} invited you to join
+                            this team.
+                        </p>
+                    </div>
+
+                    <div class="mt-4 flex justify-end gap-2">
+                        <Button
+                            variant="secondary"
+                            data-test="pending-invitation-decline"
+                            :disabled="processingCode === invitation.code"
+                            @click="declineInvitation(invitation)"
+                        >
+                            Decline
+                        </Button>
+
+                        <Button
+                            data-test="pending-invitation-accept"
+                            :disabled="processingCode === invitation.code"
+                            @click="acceptInvitation(invitation)"
+                        >
+                            Accept
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/kits/Inertia/Teams/Vue/resources/js/components/PendingInvitationsModal.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/components/PendingInvitationsModal.vue
@@ -58,7 +58,7 @@ const declineInvitation = (invitation: DashboardInvitation) => {
                     class="rounded-lg border p-4"
                 >
                     <div class="space-y-1">
-                        <p class="font-medium">{{ invitation.teamName }}</p>
+                        <p class="font-medium">{{ invitation.team.name }}</p>
                         <p class="text-sm text-muted-foreground">
                             {{ invitation.inviterName }} invited you to join
                             this team.

--- a/kits/Inertia/Teams/Vue/resources/js/pages/Dashboard.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/pages/Dashboard.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
 import { Head } from '@inertiajs/vue3';
+import PendingInvitationsModal from '@/components/PendingInvitationsModal.vue';
 import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
 import { dashboard } from '@/routes';
-import type { Team } from '@/types';
+import type { DashboardInvitation, Team } from '@/types';
+
+defineProps<{
+    pendingInvitations?: DashboardInvitation[];
+}>();
 
 defineOptions({
     layout: (props: { currentTeam?: Team | null }) => ({
@@ -20,6 +25,11 @@ defineOptions({
 
 <template>
     <Head title="Dashboard" />
+
+    <PendingInvitationsModal
+        v-if="pendingInvitations && pendingInvitations.length > 0"
+        :invitations="pendingInvitations"
+    />
 
     <div
         class="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4"

--- a/kits/Inertia/Teams/Vue/resources/js/types/teams.ts
+++ b/kits/Inertia/Teams/Vue/resources/js/types/teams.ts
@@ -27,6 +27,21 @@ export type TeamInvitation = {
     created_at: string;
 };
 
+export type TeamInvitationContext = {
+    code: string;
+    teamName: string;
+};
+
+export type DashboardInvitation = {
+    code: string;
+    inviterName: string;
+    teamName: string;
+    team: {
+        name: string;
+        slug: string;
+    };
+};
+
 export type TeamPermissions = {
     canUpdateTeam: boolean;
     canDeleteTeam: boolean;

--- a/kits/Inertia/Teams/Vue/resources/js/types/teams.ts
+++ b/kits/Inertia/Teams/Vue/resources/js/types/teams.ts
@@ -35,7 +35,6 @@ export type TeamInvitationContext = {
 export type DashboardInvitation = {
     code: string;
     inviterName: string;
-    teamName: string;
     team: {
         name: string;
         slug: string;

--- a/kits/Inertia/Teams/WorkOS/Base/routes/web.php
+++ b/kits/Inertia/Teams/WorkOS/Base/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Middleware\EnsureTeamMembership;
 use Illuminate\Support\Facades\Route;
@@ -10,11 +11,12 @@ Route::inertia('/', '{{welcome}}')->name('home');
 Route::prefix('{current_team}')
     ->middleware(['auth', ValidateSessionWithWorkOS::class, EnsureTeamMembership::class])
     ->group(function () {
-        Route::inertia('dashboard', '{{dashboard}}')->name('dashboard');
+        Route::get('dashboard', DashboardController::class)->name('dashboard');
     });
 
 Route::middleware(['auth'])->group(function () {
     Route::get('invitations/{invitation}/accept', [TeamInvitationController::class, 'accept'])->name('invitations.accept');
+    Route::delete('invitations/{invitation}', [TeamInvitationController::class, 'decline'])->name('invitations.decline');
 });
 
 require __DIR__.'/settings.php';

--- a/kits/Livewire/Teams/Base/resources/views/dashboard.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/dashboard.blade.php
@@ -1,0 +1,20 @@
+<x-layouts::app :title="__('Dashboard')">
+    <livewire:pages::teams.pending-invitations-modal />
+
+    <div class="flex h-full w-full flex-1 flex-col gap-4 rounded-xl">
+        <div class="grid auto-rows-min gap-4 md:grid-cols-3">
+            <div class="relative aspect-video overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
+                <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
+            </div>
+            <div class="relative aspect-video overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
+                <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
+            </div>
+            <div class="relative aspect-video overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
+                <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
+            </div>
+        </div>
+        <div class="relative h-full flex-1 overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
+            <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
+        </div>
+    </div>
+</x-layouts::app>

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/accept-invitation.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/accept-invitation.blade.php
@@ -38,7 +38,9 @@ new #[Title('Teams')] class extends Component {
             $user->switchTeam($team);
         });
 
-        $this->redirectRoute('dashboard');
+        session()->flash('team-invitation-accepted', true);
+
+        $this->redirectRoute('dashboard', navigate: true);
     }
 
     private function validateInvitation(User $user, TeamInvitation $invitation): void

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/pending-invitations-modal.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/pending-invitations-modal.blade.php
@@ -26,12 +26,6 @@ new class extends Component {
     {
         $email = Str::lower(Auth::user()->email);
 
-        TeamInvitation::query()
-            ->whereRaw('LOWER(email) = ?', [$email])
-            ->whereNotNull('expires_at')
-            ->where('expires_at', '<', now())
-            ->delete();
-
         return TeamInvitation::query()
             ->with(['inviter', 'team'])
             ->whereRaw('LOWER(email) = ?', [$email])

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/pending-invitations-modal.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/pending-invitations-modal.blade.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Models\TeamInvitation;
+use Flux\Flux;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+new class extends Component {
+    public bool $showPendingInvitationsModal = true;
+
+    public function mount(): void
+    {
+        if (session()->pull('team-invitation-accepted')) {
+            Flux::toast(variant: 'success', text: __('Invitation accepted.'));
+        }
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection<int, array{code: string, inviter_name: string, team_name: string}>
+     */
+    #[Computed]
+    public function pendingInvitations(): \Illuminate\Support\Collection
+    {
+        $email = Str::lower(Auth::user()->email);
+
+        TeamInvitation::query()
+            ->whereRaw('LOWER(email) = ?', [$email])
+            ->whereNotNull('expires_at')
+            ->where('expires_at', '<', now())
+            ->delete();
+
+        return TeamInvitation::query()
+            ->with(['inviter', 'team'])
+            ->whereRaw('LOWER(email) = ?', [$email])
+            ->whereNull('accepted_at')
+            ->where(fn ($query) => $query
+                ->whereNull('expires_at')
+                ->orWhere('expires_at', '>=', now()))
+            ->latest()
+            ->get()
+            ->map(fn (TeamInvitation $invitation) => [
+                'code' => $invitation->code,
+                'inviter_name' => $invitation->inviter->name,
+                'team_name' => $invitation->team->name,
+            ]);
+    }
+
+    public function acceptInvitation(string $code): void
+    {
+        $invitation = $this->findPendingInvitation($code);
+
+        $this->redirectRoute('invitations.accept', ['invitation' => $invitation->code], navigate: true);
+    }
+
+    public function declineInvitation(string $code): void
+    {
+        $invitation = $this->findPendingInvitation($code);
+
+        $invitation->delete();
+
+        Flux::toast(variant: 'success', text: __('Invitation declined.'));
+    }
+
+    private function findPendingInvitation(string $code): TeamInvitation
+    {
+        $invitation = TeamInvitation::query()
+            ->where('code', $code)
+            ->whereNull('accepted_at')
+            ->firstOrFail();
+
+        if ($invitation->isExpired()) {
+            throw ValidationException::withMessages([
+                'invitation' => [__('This invitation has expired.')],
+            ]);
+        }
+
+        if (Str::lower($invitation->email) !== Str::lower(Auth::user()->email)) {
+            throw ValidationException::withMessages([
+                'invitation' => [__('This invitation was sent to a different email address.')],
+            ]);
+        }
+
+        return $invitation;
+    }
+}; ?>
+
+<div>
+    @if ($this->pendingInvitations->isNotEmpty())
+        <flux:modal name="pending-invitations" wire:model="showPendingInvitationsModal" focusable class="max-w-lg">
+            <div data-test="pending-invitations-modal" class="space-y-6">
+                <div>
+                    <flux:heading size="lg">{{ __('Pending team invitations') }}</flux:heading>
+                    <flux:subheading>{{ __('Accept or decline the teams you have been invited to join.') }}</flux:subheading>
+                </div>
+
+                <div class="grid gap-4">
+                    @foreach ($this->pendingInvitations as $invitation)
+                        <div data-test="pending-invitation-row" class="rounded-lg border border-zinc-200 p-4 dark:border-zinc-700">
+                            <div class="space-y-1">
+                                <p class="font-medium">{{ $invitation['team_name'] }}</p>
+                                <flux:text class="text-sm text-zinc-500 dark:text-zinc-400">
+                                    {{ __(':inviter invited you to join this team.', ['inviter' => $invitation['inviter_name']]) }}
+                                </flux:text>
+                            </div>
+
+                            <div class="mt-4 flex justify-end gap-2">
+                                <flux:button
+                                    variant="filled"
+                                    wire:click="declineInvitation('{{ $invitation['code'] }}')"
+                                    wire:loading.attr="disabled"
+                                    data-test="pending-invitation-decline"
+                                >
+                                    {{ __('Decline') }}
+                                </flux:button>
+
+                                <flux:button
+                                    variant="primary"
+                                    wire:click="acceptInvitation('{{ $invitation['code'] }}')"
+                                    wire:loading.attr="disabled"
+                                    data-test="pending-invitation-accept"
+                                >
+                                    {{ __('Accept') }}
+                                </flux:button>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </flux:modal>
+    @endif
+</div>

--- a/kits/Livewire/Teams/Base/tests/Feature/Teams/TeamInvitationTest.php
+++ b/kits/Livewire/Teams/Base/tests/Feature/Teams/TeamInvitationTest.php
@@ -104,8 +104,22 @@ class TeamInvitationTest extends TestCase
 
         $response->assertRedirect(route('dashboard'));
 
+        $this->assertTrue(session('team-invitation-accepted'));
+
         $this->assertNotNull($invitation->fresh()->accepted_at);
         $this->assertTrue($invitedUser->fresh()->belongsToTeam($team));
+    }
+
+    public function test_accepted_invitation_toast_is_shown_on_the_dashboard(): void
+    {
+        $user = User::factory()->create();
+
+        session()->flash('team-invitation-accepted', true);
+
+        $this->actingAs($user);
+
+        Livewire::test('pages::teams.pending-invitations-modal')
+            ->assertDispatched('toast-show');
     }
 
     public function test_team_invitations_cannot_be_accepted_by_user_that_wasnt_invited(): void

--- a/kits/Livewire/Teams/Base/tests/Feature/Teams/TeamInvitationTest.php
+++ b/kits/Livewire/Teams/Base/tests/Feature/Teams/TeamInvitationTest.php
@@ -122,6 +122,30 @@ class TeamInvitationTest extends TestCase
             ->assertDispatched('toast-show');
     }
 
+    public function test_pending_invitations_excludes_expired_invitations_without_deleting_them(): void
+    {
+        $owner = User::factory()->create();
+        $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
+        $team = Team::factory()->create(['name' => 'Expired Team']);
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $invitation = TeamInvitation::factory()->expired()->create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $this->actingAs($invitedUser);
+
+        Livewire::test('pages::teams.pending-invitations-modal')
+            ->assertDontSee('Expired Team');
+
+        $this->assertDatabaseHas('team_invitations', [
+            'id' => $invitation->id,
+        ]);
+    }
+
     public function test_team_invitations_cannot_be_accepted_by_user_that_wasnt_invited(): void
     {
         $owner = User::factory()->create();

--- a/kits/Livewire/Teams/Fortify/app/Providers/FortifyServiceProvider.php
+++ b/kits/Livewire/Teams/Fortify/app/Providers/FortifyServiceProvider.php
@@ -19,6 +19,7 @@ use App\Http\Responses\TwoFactorLoginResponse;
 /* @chisel-email-verification */
 use App\Http\Responses\VerifyEmailResponse;
 /* @end-chisel-email-verification */
+use App\Models\TeamInvitation;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
@@ -88,7 +89,9 @@ class FortifyServiceProvider extends ServiceProvider
      */
     private function configureViews(): void
     {
-        Fortify::loginView(fn () => view('pages::auth.login'));
+        Fortify::loginView(fn (Request $request) => view('pages::auth.login', [
+            'teamInvitation' => $this->teamInvitation($request),
+        ]));
         /* @chisel-email-verification */
         Fortify::verifyEmailView(fn () => view('pages::auth.verify-email'));
         /* @end-chisel-email-verification */
@@ -99,7 +102,9 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::confirmPasswordView(fn () => view('pages::auth.confirm-password'));
         /* @end-chisel-password-confirmation */
         /* @chisel-registration */
-        Fortify::registerView(fn () => view('pages::auth.register'));
+        Fortify::registerView(fn (Request $request) => view('pages::auth.register', [
+            'teamInvitation' => $this->teamInvitation($request),
+        ]));
         /* @end-chisel-registration */
         Fortify::resetPasswordView(fn () => view('pages::auth.reset-password'));
         Fortify::requestPasswordResetLinkView(fn () => view('pages::auth.forgot-password'));
@@ -131,5 +136,37 @@ class FortifyServiceProvider extends ServiceProvider
             );
         });
         /* @end-chisel-passkeys */
+    }
+
+    /**
+     * Get the pending team invitation context for auth pages.
+     *
+     * @return array{code: string, teamName: string}|null
+     */
+    private function teamInvitation(Request $request): ?array
+    {
+        $invitationCode = $request->query('invitation');
+
+        if (! is_string($invitationCode)) {
+            return null;
+        }
+
+        $invitation = TeamInvitation::query()
+            ->with('team')
+            ->where('code', $invitationCode)
+            ->whereNull('accepted_at')
+            ->where(fn ($query) => $query
+                ->whereNull('expires_at')
+                ->orWhere('expires_at', '>=', now()))
+            ->first();
+
+        if (! $invitation) {
+            return null;
+        }
+
+        return [
+            'code' => $invitation->code,
+            'teamName' => $invitation->team->name,
+        ];
     }
 }

--- a/kits/Livewire/Teams/Fortify/resources/views/components/team-invitation-alert.blade.php
+++ b/kits/Livewire/Teams/Fortify/resources/views/components/team-invitation-alert.blade.php
@@ -1,0 +1,14 @@
+@props([
+    'invitation',
+    'action',
+])
+
+<div data-test="team-invitation-alert">
+    <div class="flex gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-900/50 dark:bg-blue-950/50 dark:text-blue-100">
+        <flux:icon name="information-circle" class="mt-0.5 size-4 shrink-0 text-blue-600 dark:text-blue-400" />
+
+        <div>
+            {{ __(':action to join the ":team" Team.', ['action' => $action, 'team' => $invitation['teamName']]) }}
+        </div>
+    </div>
+</div>

--- a/kits/Livewire/Teams/Fortify/resources/views/pages/auth/login.blade.php
+++ b/kits/Livewire/Teams/Fortify/resources/views/pages/auth/login.blade.php
@@ -1,0 +1,73 @@
+<x-layouts::auth :title="__('Log in')">
+    <div class="flex flex-col gap-6">
+        <x-auth-header :title="__('Log in to your account')" :description="__('Enter your email and password below to log in')" />
+
+        <!-- Session Status -->
+        <x-auth-session-status class="text-center" :status="session('status')" />
+
+        @if ($teamInvitation)
+            <x-team-invitation-alert :invitation="$teamInvitation" :action="__('Log in')" />
+        @endif
+
+        {{-- @chisel-passkeys --}}
+        <x-passkey-verify />
+        {{-- @end-chisel-passkeys --}}
+
+        <form method="POST" action="{{ route('login.store') }}" class="flex flex-col gap-6">
+            @csrf
+
+            <!-- Email Address -->
+            <flux:input
+                name="email"
+                :label="__('Email address')"
+                :value="old('email')"
+                type="email"
+                required
+                autofocus
+                autocomplete="email"
+                placeholder="email@example.com"
+            />
+
+            <!-- Password -->
+            <div class="relative">
+                <flux:input
+                    name="password"
+                    :label="__('Password')"
+                    type="password"
+                    required
+                    autocomplete="current-password"
+                    :placeholder="__('Password')"
+                    viewable
+                />
+
+                @if (Route::has('password.request'))
+                    <flux:link class="absolute top-0 text-sm end-0" :href="route('password.request')" wire:navigate>
+                        {{ __('Forgot your password?') }}
+                    </flux:link>
+                @endif
+            </div>
+
+            <!-- Remember Me -->
+            <flux:checkbox name="remember" :label="__('Remember me')" :checked="old('remember')" />
+
+            <div class="flex items-center justify-end">
+                <flux:button variant="primary" type="submit" class="w-full" data-test="login-button">
+                    {{ __('Log in') }}
+                </flux:button>
+            </div>
+        </form>
+
+        {{-- @chisel-registration --}}
+        <div class="space-x-1 text-sm text-center rtl:space-x-reverse text-zinc-600 dark:text-zinc-400">
+            <span>{{ __('Don\'t have an account?') }}</span>
+            <flux:link
+                :href="$teamInvitation ? route('register', ['invitation' => $teamInvitation['code']]) : route('register')"
+                data-test="team-invitation-register-link"
+                wire:navigate
+            >
+                {{ __('Sign up') }}
+            </flux:link>
+        </div>
+        {{-- @end-chisel-registration --}}
+    </div>
+</x-layouts::auth>

--- a/kits/Livewire/Teams/Fortify/resources/views/pages/auth/login.blade.php
+++ b/kits/Livewire/Teams/Fortify/resources/views/pages/auth/login.blade.php
@@ -62,7 +62,7 @@
             <span>{{ __('Don\'t have an account?') }}</span>
             <flux:link
                 :href="$teamInvitation ? route('register', ['invitation' => $teamInvitation['code']]) : route('register')"
-                data-test="team-invitation-register-link"
+                data-test="register-link"
                 wire:navigate
             >
                 {{ __('Sign up') }}

--- a/kits/Livewire/Teams/Fortify/resources/views/pages/auth/register.blade.php
+++ b/kits/Livewire/Teams/Fortify/resources/views/pages/auth/register.blade.php
@@ -1,0 +1,79 @@
+<x-layouts::auth :title="__('Register')">
+    <div class="flex flex-col gap-6">
+        <x-auth-header :title="__('Create an account')" :description="__('Enter your details below to create your account')" />
+
+        <!-- Session Status -->
+        <x-auth-session-status class="text-center" :status="session('status')" />
+
+        @if ($teamInvitation)
+            <x-team-invitation-alert :invitation="$teamInvitation" :action="__('Register')" />
+        @endif
+
+        <form method="POST" action="{{ route('register.store') }}" class="flex flex-col gap-6">
+            @csrf
+            <!-- Name -->
+            <flux:input
+                name="name"
+                :label="__('Name')"
+                :value="old('name')"
+                type="text"
+                required
+                autofocus
+                autocomplete="name"
+                :placeholder="__('Full name')"
+            />
+
+            <!-- Email Address -->
+            <flux:input
+                name="email"
+                :label="__('Email address')"
+                :value="old('email')"
+                type="email"
+                required
+                autocomplete="email"
+                placeholder="email@example.com"
+            />
+
+            <!-- Password -->
+            <flux:input
+                name="password"
+                :label="__('Password')"
+                type="password"
+                required
+                autocomplete="new-password"
+                :placeholder="__('Password')"
+                passwordrules="{{ \Illuminate\Validation\Rules\Password::defaults()->toPasswordRulesString() }}"
+                viewable
+            />
+
+            <!-- Confirm Password -->
+            <flux:input
+                name="password_confirmation"
+                :label="__('Confirm password')"
+                type="password"
+                required
+                autocomplete="new-password"
+                :placeholder="__('Confirm password')"
+                passwordrules="{{ \Illuminate\Validation\Rules\Password::defaults()->toPasswordRulesString() }}"
+                viewable
+            />
+
+            <div class="flex items-center justify-end">
+                <flux:button type="submit" variant="primary" class="w-full" data-test="register-user-button">
+                    {{ __('Create account') }}
+                </flux:button>
+            </div>
+        </form>
+
+        <div class="space-x-1 rtl:space-x-reverse text-center text-sm text-zinc-600 dark:text-zinc-400">
+            <span>{{ __('Already have an account?') }}</span>
+            <flux:link
+                :href="$teamInvitation ? route('login', ['invitation' => $teamInvitation['code']]) : route('login')"
+                data-test="team-invitation-login-link"
+                wire:navigate
+            >
+                {{ __('Log in') }}
+            </flux:link>
+        </div>
+    </div>
+</x-layouts::auth>

--- a/kits/Shared/Teams/Base/app/Notifications/Teams/TeamInvitation.php
+++ b/kits/Shared/Teams/Base/app/Notifications/Teams/TeamInvitation.php
@@ -3,12 +3,10 @@
 namespace App\Notifications\Teams;
 
 use App\Models\TeamInvitation as TeamInvitationModel;
-use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
-use Illuminate\Support\Facades\Route;
 
 class TeamInvitation extends Notification implements ShouldQueue
 {
@@ -39,7 +37,6 @@ class TeamInvitation extends Notification implements ShouldQueue
     {
         $team = $this->invitation->team;
         $inviter = $this->invitation->inviter;
-        $actionLabel = $this->shouldUseLoginRoute() ? 'Log in' : 'Register';
 
         return (new MailMessage)
             ->subject(__("You've been invited to join :teamName", ['teamName' => $team->name]))
@@ -47,10 +44,10 @@ class TeamInvitation extends Notification implements ShouldQueue
                 'inviterName' => $inviter->name,
                 'teamName' => $team->name,
             ]))
-            ->line(__("{$actionLabel} and visit your dashboard to accept or decline this invitation."))
+            ->line(__('Log in and visit your dashboard to accept or decline this invitation.'))
             ->action(
-                __($actionLabel),
-                route($this->shouldUseLoginRoute() ? 'login' : 'register'),
+                __('Log in'),
+                route('login', ['invitation' => $this->invitation->code]),
             );
     }
 
@@ -67,10 +64,5 @@ class TeamInvitation extends Notification implements ShouldQueue
             'team_name' => $this->invitation->team->name,
             'role' => $this->invitation->role->value,
         ];
-    }
-
-    protected function shouldUseLoginRoute(): bool
-    {
-        return ! Route::has('register') || User::where('email', $this->invitation->email)->exists();
     }
 }

--- a/kits/Shared/Teams/Base/app/Notifications/Teams/TeamInvitation.php
+++ b/kits/Shared/Teams/Base/app/Notifications/Teams/TeamInvitation.php
@@ -3,10 +3,12 @@
 namespace App\Notifications\Teams;
 
 use App\Models\TeamInvitation as TeamInvitationModel;
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Route;
 
 class TeamInvitation extends Notification implements ShouldQueue
 {
@@ -37,6 +39,7 @@ class TeamInvitation extends Notification implements ShouldQueue
     {
         $team = $this->invitation->team;
         $inviter = $this->invitation->inviter;
+        $actionLabel = $this->shouldUseLoginRoute() ? 'Log in' : 'Register';
 
         return (new MailMessage)
             ->subject(__("You've been invited to join :teamName", ['teamName' => $team->name]))
@@ -44,7 +47,11 @@ class TeamInvitation extends Notification implements ShouldQueue
                 'inviterName' => $inviter->name,
                 'teamName' => $team->name,
             ]))
-            ->action(__('Accept invitation'), url("/invitations/{$this->invitation->code}/accept"));
+            ->line(__("{$actionLabel} and visit your dashboard to accept or decline this invitation."))
+            ->action(
+                __($actionLabel),
+                route($this->shouldUseLoginRoute() ? 'login' : 'register'),
+            );
     }
 
     /**
@@ -60,5 +67,10 @@ class TeamInvitation extends Notification implements ShouldQueue
             'team_name' => $this->invitation->team->name,
             'role' => $this->invitation->role->value,
         ];
+    }
+
+    protected function shouldUseLoginRoute(): bool
+    {
+        return ! Route::has('register') || User::where('email', $this->invitation->email)->exists();
     }
 }

--- a/kits/Shared/Teams/Base/routes/console.php
+++ b/kits/Shared/Teams/Base/routes/console.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Models\TeamInvitation;
+use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
+
+Artisan::command('inspire', function () {
+    $this->comment(Inspiring::quote());
+})->purpose('Display an inspiring quote');
+
+Schedule::call(function () {
+    TeamInvitation::query()
+        ->whereNotNull('expires_at')
+        ->where('expires_at', '<', now())
+        ->delete();
+})->daily()->description('Delete expired team invitations');

--- a/kits/Shared/Teams/Base/routes/console.php
+++ b/kits/Shared/Teams/Base/routes/console.php
@@ -1,13 +1,7 @@
 <?php
 
 use App\Models\TeamInvitation;
-use Illuminate\Foundation\Inspiring;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
-
-Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote');
 
 Schedule::call(function () {
     TeamInvitation::query()

--- a/kits/Shared/Teams/Base/tests/Feature/Teams/PruneExpiredTeamInvitationsTest.php
+++ b/kits/Shared/Teams/Base/tests/Feature/Teams/PruneExpiredTeamInvitationsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature\Teams;
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PruneExpiredTeamInvitationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_expired_invitations_are_deleted_by_the_scheduled_cleanup(): void
+    {
+        $this->travelTo(now()->startOfDay());
+
+        $owner = User::factory()->create();
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $expiredInvitation = TeamInvitation::factory()->expired()->create([
+            'team_id' => $team->id,
+            'invited_by' => $owner->id,
+        ]);
+
+        $unexpiredInvitation = TeamInvitation::factory()->expiresIn(1)->create([
+            'team_id' => $team->id,
+            'invited_by' => $owner->id,
+        ]);
+
+        $invitationWithoutExpiration = TeamInvitation::factory()->create([
+            'team_id' => $team->id,
+            'invited_by' => $owner->id,
+        ]);
+
+        $this->artisan('schedule:run')->assertSuccessful();
+
+        $this->assertDatabaseMissing('team_invitations', [
+            'id' => $expiredInvitation->id,
+        ]);
+
+        $this->assertDatabaseHas('team_invitations', [
+            'id' => $unexpiredInvitation->id,
+        ]);
+
+        $this->assertDatabaseHas('team_invitations', [
+            'id' => $invitationWithoutExpiration->id,
+        ]);
+    }
+}


### PR DESCRIPTION
This improves the UX for the team invitation flow by adding a banner on login/register page when clicking on the link from the invite email

<img width="466" height="766" alt="image" src="https://github.com/user-attachments/assets/9bc7be0e-31f8-4216-8d48-55b9ff44c0f9" />

<img width="578" height="759" alt="image" src="https://github.com/user-attachments/assets/e54d8aa0-a022-4304-9857-82638c39dd4b" />

The link in the email always sends the user to the login, but going to the register page from the login will still display the banner as shown above.

After logging in, if the user has any pending invitations, a modal will be rendered in the dashboard, where the user can accept or decline the invite.

<img width="543" height="440" alt="image" src="https://github.com/user-attachments/assets/0b5e2ada-6356-44bf-9df0-42057dbc9f09" />


Fixes #94