### PR TITLE
fix: Update tailwindcss v4 syntax for custom property

### DIFF
--- a/kits/Inertia/Teams/Svelte/resources/js/components/TeamSwitcher.svelte
+++ b/kits/Inertia/Teams/Svelte/resources/js/components/TeamSwitcher.svelte
@@ -112,7 +112,7 @@
     <DropdownMenuContent
         class={inHeader
             ? 'w-56'
-            : 'w-[--reka-dropdown-menu-trigger-width] min-w-56 rounded-lg'}
+            : 'w-(--reka-dropdown-menu-trigger-width) min-w-56 rounded-lg'}
         side={inHeader ? undefined : isMobile ? 'bottom' : 'right'}
         align={inHeader ? 'end' : 'start'}
         sideOffset={inHeader ? undefined : 4}

--- a/kits/Inertia/Teams/Vue/resources/js/components/TeamSwitcher.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/components/TeamSwitcher.vue
@@ -38,7 +38,7 @@ const teams = computed(() => page.props.teams ?? []);
 const menuContentClass = computed(() =>
     props.inHeader
         ? 'w-56'
-        : 'w-[--reka-dropdown-menu-trigger-width] min-w-56 rounded-lg',
+        : 'w-(--reka-dropdown-menu-trigger-width) min-w-56 rounded-lg',
 );
 const teamItemClass = computed(() =>
     props.inHeader ? 'cursor-pointer gap-2' : 'cursor-pointer gap-2 p-2',


### PR DESCRIPTION
This syntax is not valid in tailwindcss v4 `w-[--reka-dropdown-menu-trigger-width]`. 
It was probably forgotten during the migraiton.
It should be `w-(--reka-dropdown-menu-trigger-width)` or `w-[var(--reka-dropdown-menu-trigger-width)]`

https://tailwindcss.com/docs/adding-custom-styles#using-arbitrary-values:~:text=If%20you%27re%20referencing%20a%20CSS%20variable%20as%20an%20arbitrary%20value%2C%20you%20can%20use%20the%20custom%20property%20syntax%3A