### PR TITLE
fix: h-full breaks <Sidebar variant="sidebar" />

### DIFF
--- a/kits/Inertia/React/resources/js/components/ui/sidebar.tsx
+++ b/kits/Inertia/React/resources/js/components/ui/sidebar.tsx
@@ -166,7 +166,7 @@ function Sidebar({
       <div
         data-slot="sidebar"
         className={cn(
-          "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
+          "bg-sidebar text-sidebar-foreground flex w-(--sidebar-width) flex-col",
           className
         )}
         {...props}

--- a/kits/Inertia/Svelte/resources/js/components/ui/sidebar/Sidebar.svelte
+++ b/kits/Inertia/Svelte/resources/js/components/ui/sidebar/Sidebar.svelte
@@ -30,7 +30,7 @@
 {#if collapsible === 'none'}
     <div
         data-slot="sidebar"
-        class={cn('bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col', className)}
+        class={cn('bg-sidebar text-sidebar-foreground flex w-(--sidebar-width) flex-col', className)}
     >
         {@render children?.()}
     </div>

--- a/kits/Inertia/Teams/Svelte/resources/js/components/TeamSwitcher.svelte
+++ b/kits/Inertia/Teams/Svelte/resources/js/components/TeamSwitcher.svelte
@@ -112,7 +112,7 @@
     <DropdownMenuContent
         class={inHeader
             ? 'w-56'
-            : 'w-[--reka-dropdown-menu-trigger-width] min-w-56 rounded-lg'}
+            : 'w-(--reka-dropdown-menu-trigger-width) min-w-56 rounded-lg'}
         side={inHeader ? undefined : isMobile ? 'bottom' : 'right'}
         align={inHeader ? 'end' : 'start'}
         sideOffset={inHeader ? undefined : 4}

--- a/kits/Inertia/Teams/Vue/resources/js/components/TeamSwitcher.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/components/TeamSwitcher.vue
@@ -38,7 +38,7 @@ const teams = computed(() => page.props.teams ?? []);
 const menuContentClass = computed(() =>
     props.inHeader
         ? 'w-56'
-        : 'w-[--reka-dropdown-menu-trigger-width] min-w-56 rounded-lg',
+        : 'w-(--reka-dropdown-menu-trigger-width) min-w-56 rounded-lg',
 );
 const teamItemClass = computed(() =>
     props.inHeader ? 'cursor-pointer gap-2' : 'cursor-pointer gap-2 p-2',

--- a/kits/Inertia/Vue/resources/js/components/ui/sidebar/Sidebar.vue
+++ b/kits/Inertia/Vue/resources/js/components/ui/sidebar/Sidebar.vue
@@ -24,7 +24,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
   <div
     v-if="collapsible === 'none'"
     data-slot="sidebar"
-    :class="cn('bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col', props.class)"
+    :class="cn('bg-sidebar text-sidebar-foreground flex w-(--sidebar-width) flex-col', props.class)"
     v-bind="$attrs"
   >
     <slot />


### PR DESCRIPTION
With h-full:
<img width="3602" height="2018" alt="screenshot-2026-05-20-17-55-24" src="https://github.com/user-attachments/assets/edd9ba29-c498-434a-9489-91e0eb592879" />

Without h-full (still full height tho):
<img width="3602" height="2020" alt="screenshot-2026-05-20-17-55-36" src="https://github.com/user-attachments/assets/42b96bbf-1d2c-4c8e-b86f-29120ef66cdc" />
