### PR TITLE
Align Inertia UI copy with existing Livewire translations

### DIFF
--- a/browser_tests/common/tests/Browser/Auth/PasswordConfirmationTest.php
+++ b/browser_tests/common/tests/Browser/Auth/PasswordConfirmationTest.php
@@ -9,7 +9,7 @@ test('confirm password screen can be rendered', function () {
     actingAs(User::factory()->create());
 
     visit(route('password.confirm'))
-        ->assertSee('Confirm your password')
+        ->assertSee('Confirm password')
         ->assertSee('This is a secure area of the application. Please confirm your password before continuing.')
         ->assertNoConsoleLogs()
         ->assertNoJavaScriptErrors();

--- a/kits/Inertia/Fortify/React/resources/js/components/passkey-verify.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/components/passkey-verify.tsx
@@ -52,7 +52,7 @@ export default function PasskeyVerify({
                     {isLoading ? <Spinner /> : <KeyRound className="h-4 w-4" />}
                     {isLoading
                         ? (loadingLabel ?? 'Authenticating...')
-                        : (label ?? 'Sign in with passkey')}
+                        : (label ?? 'Sign in with a passkey')}
                 </Button>
                 {error && (
                     <InputError message={error} className="text-center" />

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/confirm-password.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/confirm-password.tsx
@@ -64,7 +64,7 @@ export default function ConfirmPassword() {
 }
 
 ConfirmPassword.layout = {
-    title: 'Confirm your password',
+    title: 'Confirm password',
     description:
         'This is a secure area of the application. Please confirm your password before continuing.',
 };

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/login.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/login.tsx
@@ -62,7 +62,7 @@ export default function Login({ status, canResetPassword }: Props) {
                                             className="ml-auto text-sm"
                                             tabIndex={5}
                                         >
-                                            Forgot password?
+                                            Forgot your password?
                                         </TextLink>
                                     )}
                                 </div>

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/verify-email.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/verify-email.tsx
@@ -40,7 +40,7 @@ export default function VerifyEmail({ status }: { status?: string }) {
 }
 
 VerifyEmail.layout = {
-    title: 'Verify email',
+    title: 'Email verification',
     description:
         'Please verify your email address by clicking on the link we just emailed to you.',
 };

--- a/kits/Inertia/Fortify/React/resources/js/pages/settings/security.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/settings/security.tsx
@@ -119,7 +119,7 @@ export default function Security(props: Props) {
                                     disabled={processing}
                                     data-test="update-password-button"
                                 >
-                                    Save password
+                                    Save
                                 </Button>
                             </div>
                         </>

--- a/kits/Inertia/Fortify/Svelte/resources/js/components/PasskeyVerify.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/components/PasskeyVerify.svelte
@@ -54,7 +54,7 @@
             {/if}
             {isLoading
                 ? (props.loadingLabel ?? 'Authenticating...')
-                : (props.label ?? 'Sign in with passkey')}
+                : (props.label ?? 'Sign in with a passkey')}
         </Button>
 
         {#if error}

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/ConfirmPassword.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/ConfirmPassword.svelte
@@ -1,6 +1,6 @@
 <script module lang="ts">
     export const layout = {
-        title: 'Confirm your password',
+        title: 'Confirm password',
         description:
             'This is a secure area of the application. Please confirm your password before continuing.',
     };

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Login.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Login.svelte
@@ -71,7 +71,7 @@
                     <Label for="password">Password</Label>
                     {#if canResetPassword}
                         <TextLink href={request()} class="text-sm">
-                            Forgot password?
+                            Forgot your password?
                         </TextLink>
                     {/if}
                 </div>

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/VerifyEmail.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/VerifyEmail.svelte
@@ -1,6 +1,6 @@
 <script module lang="ts">
     export const layout = {
-        title: 'Verify email',
+        title: 'Email verification',
         description:
             'Please verify your email address by clicking on the link we just emailed to you.',
     };

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/settings/Security.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/settings/Security.svelte
@@ -112,7 +112,7 @@
                     disabled={processing}
                     data-test="update-password-button"
                 >
-                    Save password
+                    Save
                 </Button>
             </div>
         {/snippet}

--- a/kits/Inertia/Fortify/Vue/resources/js/components/PasskeyVerify.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/components/PasskeyVerify.vue
@@ -50,7 +50,7 @@ const { verify, isLoading, error, isSupported } = usePasskeyVerify({
                 {{
                     isLoading
                         ? (props.loadingLabel ?? 'Authenticating...')
-                        : (props.label ?? 'Sign in with passkey')
+                        : (props.label ?? 'Sign in with a passkey')
                 }}
             </Button>
 

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ConfirmPassword.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ConfirmPassword.vue
@@ -16,7 +16,7 @@ import PasskeyVerify from '@/components/PasskeyVerify.vue';
 
 defineOptions({
     layout: {
-        title: 'Confirm your password',
+        title: 'Confirm password',
         description:
             'This is a secure area of the application. Please confirm your password before continuing.',
     },

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Login.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Login.vue
@@ -75,7 +75,7 @@ defineProps<{
                         class="text-sm"
                         :tabindex="5"
                     >
-                        Forgot password?
+                        Forgot your password?
                     </TextLink>
                 </div>
                 <PasswordInput

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/VerifyEmail.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/VerifyEmail.vue
@@ -8,7 +8,7 @@ import { send } from '@/routes/verification';
 
 defineOptions({
     layout: {
-        title: 'Verify email',
+        title: 'Email verification',
         description:
             'Please verify your email address by clicking on the link we just emailed to you.',
     },

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/settings/Security.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/settings/Security.vue
@@ -104,7 +104,7 @@ defineOptions({
                     :disabled="processing"
                     data-test="update-password-button"
                 >
-                    Save password
+                    Save
                 </Button>
             </div>
         </Form>

--- a/kits/Inertia/React/resources/js/pages/settings/appearance.tsx
+++ b/kits/Inertia/React/resources/js/pages/settings/appearance.tsx
@@ -14,7 +14,7 @@ export default function Appearance() {
                 <Heading
                     variant="small"
                     title="Appearance settings"
-                    description="Update your account's appearance settings"
+                    description="Update the appearance settings for your account"
                 />
                 <AppearanceTabs />
             </div>

--- a/kits/Inertia/React/resources/js/pages/settings/profile.tsx
+++ b/kits/Inertia/React/resources/js/pages/settings/profile.tsx
@@ -41,7 +41,7 @@ export default function Profile(
             <div className="space-y-6">
                 <Heading
                     variant="small"
-                    title="Profile information"
+                    title="Profile"
                     description="Update your name and email address"
                 />
 
@@ -104,7 +104,7 @@ export default function Profile(
                                                 as="button"
                                                 className="text-foreground underline decoration-neutral-300 underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-neutral-500"
                                             >
-                                                Click here to resend the
+                                                Click here to re-send the
                                                 verification email.
                                             </Link>
                                         </p>

--- a/kits/Inertia/Svelte/resources/js/pages/settings/Appearance.svelte
+++ b/kits/Inertia/Svelte/resources/js/pages/settings/Appearance.svelte
@@ -25,7 +25,7 @@
     <Heading
         variant="small"
         title="Appearance settings"
-        description="Update your account's appearance settings"
+        description="Update the appearance settings for your account"
     />
     <AppearanceTabs />
 </div>

--- a/kits/Inertia/Svelte/resources/js/pages/settings/Profile.svelte
+++ b/kits/Inertia/Svelte/resources/js/pages/settings/Profile.svelte
@@ -38,7 +38,7 @@
 <div class="flex flex-col space-y-6">
     <Heading
         variant="small"
-        title="Profile information"
+        title="Profile"
         description="Update your name and email address"
     />
 
@@ -83,7 +83,7 @@
                     <p class="-mt-4 text-sm text-muted-foreground">
                         Your email address is unverified.
                         <TextLink href={send()} as="button">
-                            Click here to resend the verification email.
+                            Click here to re-send the verification email.
                         </TextLink>
                     </p>
 

--- a/kits/Inertia/Vue/resources/js/pages/settings/Appearance.vue
+++ b/kits/Inertia/Vue/resources/js/pages/settings/Appearance.vue
@@ -25,7 +25,7 @@ defineOptions({
         <Heading
             variant="small"
             title="Appearance settings"
-            description="Update your account's appearance settings"
+            description="Update the appearance settings for your account"
         />
         <AppearanceTabs />
     </div>

--- a/kits/Inertia/Vue/resources/js/pages/settings/Profile.vue
+++ b/kits/Inertia/Vue/resources/js/pages/settings/Profile.vue
@@ -39,7 +39,7 @@ const user = computed(() => page.props.auth.user);
     <div class="flex flex-col space-y-6">
         <Heading
             variant="small"
-            title="Profile information"
+            title="Profile"
             description="Update your name and email address"
         />
 
@@ -86,7 +86,7 @@ const user = computed(() => page.props.auth.user);
                         as="button"
                         class="text-foreground underline decoration-neutral-300 underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-neutral-500"
                     >
-                        Click here to resend the verification email.
+                        Click here to re-send the verification email.
                     </Link>
                 </p>
 

--- a/kits/Inertia/WorkOS/React/resources/js/pages/settings/profile.tsx
+++ b/kits/Inertia/WorkOS/React/resources/js/pages/settings/profile.tsx
@@ -20,7 +20,7 @@ export default function Profile() {
             <div className="space-y-6">
                 <Heading
                     variant="small"
-                    title="Profile information"
+                    title="Profile"
                     description="Update your name and email address"
                 />
 

--- a/kits/Inertia/WorkOS/Svelte/resources/js/pages/settings/Profile.svelte
+++ b/kits/Inertia/WorkOS/Svelte/resources/js/pages/settings/Profile.svelte
@@ -32,7 +32,7 @@
 <div class="flex flex-col space-y-6">
     <Heading
         variant="small"
-        title="Profile information"
+        title="Profile"
         description="Update your name and email address"
     />
 

--- a/kits/Inertia/WorkOS/Vue/resources/js/pages/settings/Profile.vue
+++ b/kits/Inertia/WorkOS/Vue/resources/js/pages/settings/Profile.vue
@@ -39,7 +39,7 @@ const user = computed(() => page.props.auth.user);
     <div class="flex flex-col space-y-6">
         <Heading
             variant="small"
-            title="Profile information"
+            title="Profile"
             description="Update your name and email address"
         />
 


### PR DESCRIPTION
## Summary
- align the remaining Inertia auth/settings copy with the wording already used by the Livewire starter kit
- update the Svelte passkey button label so it matches the React and Vue variants already included in this branch

## Why align to the Livewire wording?
Although changing Livewire would have produced a smaller diff, this PR intentionally aligns Inertia to the existing Livewire copy because the translation keys in `Laravel-Lang/starter-kits` are already based on those strings.

For example, that repository already ships keys such as "Sign in with a passkey" based on the current starter-kit wording:
https://github.com/Laravel-Lang/starter-kits/blob/c53719499595a187efabf4c0ffe8ab88b72bf6c1/locales/en/json.json#L138

So even small wording differences like "Sign in with passkey" vs "Sign in with a passkey" end up creating separate translation entries for effectively the same UI action.

So this is not meant to claim that Livewire is always the source of truth; it is a targeted alignment to preserve existing translation assets and keep the starter-kit UI labels consistent across stacks.

## Notes
- checked open issues/PRs and did not find an existing PR covering this wording alignment
- ran `composer kits:lint -- --react --svelte --vue`