### PR TITLE
Fix Svelte passkey component reactivity

### DIFF
--- a/kits/Inertia/Fortify/Svelte/resources/js/components/PasskeyRegister.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/components/PasskeyRegister.svelte
@@ -27,7 +27,7 @@
 
     let name = $state(getDefaultPasskeyName());
     let showForm = $state(false);
-    const { register, isLoading, error, isSupported } = usePasskeyRegister({
+    const passkeyRegister = usePasskeyRegister({
         onSuccess: () => {
             name = '';
             showForm = false;
@@ -42,7 +42,7 @@
             return;
         }
 
-        await register(name.trim());
+        await passkeyRegister.register(name.trim());
     };
 
     const handleCancel = () => {
@@ -51,7 +51,7 @@
     };
 </script>
 
-{#if !isSupported}
+{#if !passkeyRegister.isSupported}
     <div class="text-sm text-muted-foreground">
         Passkeys are not supported in this browser.
     </div>
@@ -79,13 +79,18 @@
             </p>
         </div>
 
-        {#if error}
-            <InputError message={error} />
+        {#if passkeyRegister.error}
+            <InputError message={passkeyRegister.error} />
         {/if}
 
         <div class="flex gap-2">
-            <Button type="submit" disabled={isLoading || !name.trim()}>
-                {isLoading ? 'Registering...' : 'Register passkey'}
+            <Button
+                type="submit"
+                disabled={passkeyRegister.isLoading || !name.trim()}
+            >
+                {passkeyRegister.isLoading
+                    ? 'Registering...'
+                    : 'Register passkey'}
             </Button>
             <Button type="button" variant="ghost" onclick={handleCancel}>
                 Cancel

--- a/kits/Inertia/Fortify/Svelte/resources/js/components/PasskeyVerify.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/components/PasskeyVerify.svelte
@@ -22,7 +22,7 @@
     let props: Props = $props();
     const initialRoutes = untrack(() => props.routes);
 
-    const { verify, isLoading, error, isSupported } = usePasskeyVerify({
+    const passkeyVerify = usePasskeyVerify({
         ...(initialRoutes
             ? {
                   routes: {
@@ -38,28 +38,28 @@
     });
 </script>
 
-{#if isSupported}
+{#if passkeyVerify.isSupported}
     <div class="grid gap-2">
         <Button
             type="button"
             variant="outline"
             class="w-full"
-            onclick={verify}
-            disabled={isLoading}
+            onclick={passkeyVerify.verify}
+            disabled={passkeyVerify.isLoading}
         >
-            {#if isLoading}
+            {#if passkeyVerify.isLoading}
                 <Spinner />
             {:else}
                 <KeyRound class="h-4 w-4" />
             {/if}
-            {isLoading
+            {passkeyVerify.isLoading
                 ? (props.loadingLabel ?? 'Authenticating...')
                 : (props.label ?? 'Sign in with passkey')}
         </Button>
 
-        {#if error}
+        {#if passkeyVerify.error}
             <div class="text-center">
-                <InputError message={error} />
+                <InputError message={passkeyVerify.error} />
             </div>
         {/if}
     </div>


### PR DESCRIPTION
## Summary
- keep the Svelte passkey hooks as reactive objects instead of destructuring their returned state
- update both `PasskeyVerify.svelte` and `PasskeyRegister.svelte` to read `isLoading`, `error`, and `isSupported` through those objects

## Why
While reviewing #126, I noticed the Svelte passkey components still destructured the state returned by `@laravel/passkeys/svelte`. In Svelte, that risks breaking updates for `isLoading`, `error`, and `isSupported`, so the passkey UI can get stuck with stale state.

## Notes
- this is intentionally separate from #126, which is only about UI copy alignment
- ran `composer kits:lint -- --svelte`