### PR TITLE
Pin starter kit actions & ensure dependabot updates them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/kits/Inertia/Blank/Base/.github/workflows"
+      - "/kits/Livewire/Blank/.github/workflows"
     schedule:
       interval: "weekly"
     groups:

--- a/kits/Inertia/Blank/Base/.github/workflows/lint.yml
+++ b/kits/Inertia/Blank/Base/.github/workflows/lint.yml
@@ -21,10 +21,12 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: '8.4'
 

--- a/kits/Inertia/Blank/Base/.github/workflows/tests.yml
+++ b/kits/Inertia/Blank/Base/.github/workflows/tests.yml
@@ -23,17 +23,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
           coverage: xdebug
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
 

--- a/kits/Livewire/Blank/.github/workflows/lint.yml
+++ b/kits/Livewire/Blank/.github/workflows/lint.yml
@@ -21,10 +21,12 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: '8.4'
 

--- a/kits/Livewire/Blank/.github/workflows/tests.yml
+++ b/kits/Livewire/Blank/.github/workflows/tests.yml
@@ -23,17 +23,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
           coverage: xdebug
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
 


### PR DESCRIPTION
Was messing with the installer, and noticed the starter kit shipped with actions

<img width="500" height="300" alt="Zed_H9BW4IhM2g" src="https://github.com/user-attachments/assets/28eb7d2f-f6c6-4dc4-9251-5c4c36db4191" />



Since https://github.com/laravel/maestro/pull/97 pinned all the repo actions, I thought it could be worth pinning for starter kits too, just for added security these days (so thought I'd yolo try this PR)

While I was there also noticed the /kits workflows don't get the dependabot updates, [as according to the docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#directories-or-directory--) it won't include them without the dependabot.yml update.  

I verified this [in my fork](https://github.com/jackbayliss/maestro/pull/1) and it did a PR when expected with the new yml, which doesnt trigger without this change ([I did try](https://github.com/jackbayliss/maestro/actions/runs/26371246096/job/77623703459))

So 2 for 1 PR... 

Happy to pull out bits if you dont agree, but thought I'd give it a go!