### PR TITLE
Add Larastan to starter kits

### DIFF
--- a/kits/Inertia/Base/app/Models/User.php
+++ b/kits/Inertia/Base/app/Models/User.php
@@ -9,10 +9,24 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 use Laravel\Fortify\Contracts\PasskeyUser;
 use Laravel\Fortify\PasskeyAuthenticatable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property Carbon|null $email_verified_at
+ * @property string $password
+ * @property string|null $two_factor_secret
+ * @property string|null $two_factor_recovery_codes
+ * @property Carbon|null $two_factor_confirmed_at
+ * @property string|null $remember_token
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
 class User extends Authenticatable implements PasskeyUser

--- a/kits/Inertia/Blank/Base/.github/workflows/tests.yml
+++ b/kits/Inertia/Blank/Base/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
         run: npm run build
 
       - name: Run Type Analysis
-        run: composer test:types
+        run: composer types:check
 
       - name: Tests
         run: php artisan test

--- a/kits/Inertia/Blank/Base/.github/workflows/tests.yml
+++ b/kits/Inertia/Blank/Base/.github/workflows/tests.yml
@@ -54,5 +54,8 @@ jobs:
       - name: Build Assets
         run: npm run build
 
+      - name: Run Type Analysis
+        run: composer test:types
+
       - name: Tests
-        run: ./vendor/bin/phpunit
+        run: php artisan test

--- a/kits/Inertia/Blank/Base/app/Models/User.php
+++ b/kits/Inertia/Blank/Base/app/Models/User.php
@@ -9,7 +9,18 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property Carbon|null $email_verified_at
+ * @property string $password
+ * @property string|null $remember_token
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable

--- a/kits/Inertia/Blank/Base/composer.json
+++ b/kits/Inertia/Blank/Base/composer.json
@@ -17,6 +17,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",
+        "larastan/larastan": "^3.9",
         "laravel/pail": "^1.2.5",
         "laravel/pao": "^1.0.6",
         "laravel/pint": "^1.27",
@@ -63,9 +64,13 @@
             "npm run types:check",
             "@test"
         ],
+        "test:types": [
+            "phpstan analyse"
+        ],
         "test": [
             "@php artisan config:clear --ansi",
             "@lint:check",
+            "@test:types",
             "@php artisan test"
         ],
         "post-autoload-dump": [

--- a/kits/Inertia/Blank/Base/composer.json
+++ b/kits/Inertia/Blank/Base/composer.json
@@ -64,13 +64,13 @@
             "npm run types:check",
             "@test"
         ],
-        "test:types": [
+        "types:check": [
             "phpstan analyse"
         ],
         "test": [
             "@php artisan config:clear --ansi",
             "@lint:check",
-            "@test:types",
+            "@types:check",
             "@php artisan test"
         ],
         "post-autoload-dump": [

--- a/kits/Inertia/Fortify/Base/composer.json
+++ b/kits/Inertia/Fortify/Base/composer.json
@@ -19,6 +19,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",
+        "larastan/larastan": "^3.9",
         "laravel/pail": "^1.2.5",
         "laravel/pao": "^1.0.6",
         "laravel/pint": "^1.27",
@@ -65,9 +66,13 @@
             "npm run types:check",
             "@test"
         ],
+        "test:types": [
+            "phpstan analyse"
+        ],
         "test": [
             "@php artisan config:clear --ansi",
             "@lint:check",
+            "@test:types",
             "@php artisan test"
         ],
         "post-autoload-dump": [

--- a/kits/Inertia/Fortify/Base/composer.json
+++ b/kits/Inertia/Fortify/Base/composer.json
@@ -66,13 +66,13 @@
             "npm run types:check",
             "@test"
         ],
-        "test:types": [
+        "types:check": [
             "phpstan analyse"
         ],
         "test": [
             "@php artisan config:clear --ansi",
             "@lint:check",
-            "@test:types",
+            "@types:check",
             "@php artisan test"
         ],
         "post-autoload-dump": [

--- a/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamController.php
+++ b/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamController.php
@@ -7,6 +7,7 @@ use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\DeleteTeamRequest;
 use App\Http\Requests\Teams\SaveTeamRequest;
+use App\Models\Membership;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
@@ -56,14 +57,19 @@ class TeamController extends Controller
                 'slug' => $team->slug,
                 'isPersonal' => $team->is_personal,
             ],
-            'members' => $team->members()->get()->map(fn ($member) => [
-                'id' => $member->id,
-                'name' => $member->name,
-                'email' => $member->email,
-                'avatar' => $member->avatar ?? null,
-                'role' => $member->pivot->role->value,
-                'role_label' => $member->pivot->role->label(),
-            ]),
+            'members' => $team->members()->get()->map(function (User $member) {
+                /** @var Membership $membership */
+                $membership = $member->getRelation('pivot');
+
+                return [
+                    'id' => $member->id,
+                    'name' => $member->name,
+                    'email' => $member->email,
+                    'avatar' => $member->avatar ?? null,
+                    'role' => $membership->role->value,
+                    'role_label' => $membership->role->label(),
+                ];
+            }),
             'invitations' => $team->invitations()
                 ->whereNull('accepted_at')
                 ->get()

--- a/kits/Inertia/Teams/Base/app/Http/Requests/Teams/AcceptTeamInvitationRequest.php
+++ b/kits/Inertia/Teams/Base/app/Http/Requests/Teams/AcceptTeamInvitationRequest.php
@@ -22,6 +22,8 @@ class AcceptTeamInvitationRequest extends FormRequest
 
     /**
      * Get the validation data from the request.
+     *
+     * @return array<string, mixed>
      */
     public function validationData(): array
     {

--- a/kits/Inertia/Teams/Base/app/Http/Requests/Teams/CreateTeamInvitationRequest.php
+++ b/kits/Inertia/Teams/Base/app/Http/Requests/Teams/CreateTeamInvitationRequest.php
@@ -20,9 +20,7 @@ class CreateTeamInvitationRequest extends FormRequest
     {
         $team = $this->route('team');
 
-        if (! $team instanceof Team) {
-            abort(404);
-        }
+        abort_if(! $team instanceof Team, 404);
 
         return [
             'email' => ['required', 'string', 'email', 'max:255', new UniqueTeamInvitation($team)],

--- a/kits/Inertia/Teams/Base/app/Http/Requests/Teams/CreateTeamInvitationRequest.php
+++ b/kits/Inertia/Teams/Base/app/Http/Requests/Teams/CreateTeamInvitationRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Teams;
 
 use App\Enums\TeamRole;
+use App\Models\Team;
 use App\Rules\UniqueTeamInvitation;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
@@ -18,8 +19,19 @@ class CreateTeamInvitationRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => ['required', 'string', 'email', 'max:255', new UniqueTeamInvitation($this->route('team'))],
+            'email' => ['required', 'string', 'email', 'max:255', new UniqueTeamInvitation($this->team())],
             'role' => ['required', 'string', Rule::enum(TeamRole::class)],
         ];
+    }
+
+    private function team(): Team
+    {
+        $team = $this->route('team');
+
+        if (! $team instanceof Team) {
+            abort(404);
+        }
+
+        return $team;
     }
 }

--- a/kits/Inertia/Teams/Base/app/Http/Requests/Teams/CreateTeamInvitationRequest.php
+++ b/kits/Inertia/Teams/Base/app/Http/Requests/Teams/CreateTeamInvitationRequest.php
@@ -18,20 +18,15 @@ class CreateTeamInvitationRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'email' => ['required', 'string', 'email', 'max:255', new UniqueTeamInvitation($this->team())],
-            'role' => ['required', 'string', Rule::enum(TeamRole::class)],
-        ];
-    }
-
-    private function team(): Team
-    {
         $team = $this->route('team');
 
         if (! $team instanceof Team) {
             abort(404);
         }
 
-        return $team;
+        return [
+            'email' => ['required', 'string', 'email', 'max:255', new UniqueTeamInvitation($team)],
+            'role' => ['required', 'string', Rule::enum(TeamRole::class)],
+        ];
     }
 }

--- a/kits/Inertia/Teams/Base/app/Http/Requests/Teams/DeleteTeamRequest.php
+++ b/kits/Inertia/Teams/Base/app/Http/Requests/Teams/DeleteTeamRequest.php
@@ -51,9 +51,7 @@ class DeleteTeamRequest extends FormRequest
     {
         $team = $this->route('team');
 
-        if (! $team instanceof Team) {
-            abort(404);
-        }
+        abort_if(! $team instanceof Team, 404);
 
         return $team;
     }

--- a/kits/Inertia/Teams/Base/app/Http/Requests/Teams/DeleteTeamRequest.php
+++ b/kits/Inertia/Teams/Base/app/Http/Requests/Teams/DeleteTeamRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Teams;
 
+use App\Models\Team;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
@@ -38,13 +39,22 @@ class DeleteTeamRequest extends FormRequest
     public function after(): array
     {
         return [
-            function (Validator $validator) {
-                $team = $this->route('team');
-
-                if ($this->input('name') !== $team->name) {
+            function (Validator $validator): void {
+                if ($this->input('name') !== $this->team()->name) {
                     $validator->errors()->add('name', __('The team name does not match.'));
                 }
             },
         ];
+    }
+
+    private function team(): Team
+    {
+        $team = $this->route('team');
+
+        if (! $team instanceof Team) {
+            abort(404);
+        }
+
+        return $team;
     }
 }

--- a/kits/Inertia/Teams/Base/app/Http/Requests/Teams/DeleteTeamRequest.php
+++ b/kits/Inertia/Teams/Base/app/Http/Requests/Teams/DeleteTeamRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Teams;
 
+use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
@@ -31,6 +32,8 @@ class DeleteTeamRequest extends FormRequest
 
     /**
      * Configure the validator instance.
+     *
+     * @return array<int, Closure(Validator): void>
      */
     public function after(): array
     {

--- a/kits/Inertia/Teams/Base/tests/Feature/Teams/TeamTest.php
+++ b/kits/Inertia/Teams/Base/tests/Feature/Teams/TeamTest.php
@@ -6,6 +6,7 @@ use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
 
 class TeamTest extends TestCase
@@ -72,7 +73,13 @@ class TeamTest extends TestCase
             ->actingAs($user)
             ->get(route('teams.edit', $team));
 
-        $response->assertOk();
+        $response
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('{{teams_edit}}')
+                ->where('members.0.role', TeamRole::Owner->value)
+                ->where('members.0.role_label', TeamRole::Owner->label()),
+            );
     }
 
     public function test_teams_can_be_updated_by_owners()

--- a/kits/Inertia/Teams/Fortify/Base/app/Models/User.php
+++ b/kits/Inertia/Teams/Fortify/Base/app/Models/User.php
@@ -7,13 +7,33 @@ use App\Concerns\HasTeams;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 use Laravel\Fortify\Contracts\PasskeyUser;
 use Laravel\Fortify\PasskeyAuthenticatable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property Carbon|null $email_verified_at
+ * @property string $password
+ * @property string|null $two_factor_secret
+ * @property string|null $two_factor_recovery_codes
+ * @property Carbon|null $two_factor_confirmed_at
+ * @property string|null $remember_token
+ * @property int|null $current_team_id
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Team|null $currentTeam
+ * @property-read Collection<int, Team> $ownedTeams
+ * @property-read Collection<int, Membership> $teamMemberships
+ * @property-read Collection<int, Team> $teams
+ */
 #[Fillable(['name', 'email', 'password', 'current_team_id'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
 class User extends Authenticatable implements PasskeyUser

--- a/kits/Inertia/Teams/WorkOS/Base/app/Models/User.php
+++ b/kits/Inertia/Teams/WorkOS/Base/app/Models/User.php
@@ -7,10 +7,28 @@ use App\Concerns\HasTeams;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property Carbon|null $email_verified_at
+ * @property string $workos_id
+ * @property string|null $remember_token
+ * @property string $avatar
+ * @property int|null $current_team_id
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Team|null $currentTeam
+ * @property-read Collection<int, Team> $ownedTeams
+ * @property-read Collection<int, Membership> $teamMemberships
+ * @property-read Collection<int, Team> $teams
+ */
 #[Fillable(['name', 'email', 'workos_id', 'avatar', 'current_team_id'])]
 #[Hidden(['workos_id', 'remember_token'])]
 class User extends Authenticatable

--- a/kits/Inertia/WorkOS/Base/app/Http/Controllers/Settings/ProfileController.php
+++ b/kits/Inertia/WorkOS/Base/app/Http/Controllers/Settings/ProfileController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 use Laravel\WorkOS\Http\Requests\AuthKitAccountDeletionRequest;
+use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
 
 class ProfileController extends Controller
 {
@@ -38,7 +39,7 @@ class ProfileController extends Controller
     /**
      * Delete the user's account.
      */
-    public function destroy(AuthKitAccountDeletionRequest $request): RedirectResponse
+    public function destroy(AuthKitAccountDeletionRequest $request): SymfonyRedirectResponse
     {
         return $request->delete(
             using: fn (User $user) => $user->delete(),

--- a/kits/Inertia/WorkOS/Base/app/Models/User.php
+++ b/kits/Inertia/WorkOS/Base/app/Models/User.php
@@ -9,7 +9,19 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property Carbon|null $email_verified_at
+ * @property string $workos_id
+ * @property string|null $remember_token
+ * @property string $avatar
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 #[Fillable(['name', 'email', 'workos_id', 'avatar'])]
 #[Hidden(['workos_id', 'remember_token'])]
 class User extends Authenticatable

--- a/kits/Inertia/WorkOS/Base/composer.json
+++ b/kits/Inertia/WorkOS/Base/composer.json
@@ -65,13 +65,13 @@
             "npm run types:check",
             "@test"
         ],
-        "test:types": [
+        "types:check": [
             "phpstan analyse"
         ],
         "test": [
             "@php artisan config:clear --ansi",
             "@lint:check",
-            "@test:types",
+            "@types:check",
             "@php artisan test"
         ],
         "post-autoload-dump": [

--- a/kits/Inertia/WorkOS/Base/composer.json
+++ b/kits/Inertia/WorkOS/Base/composer.json
@@ -18,6 +18,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",
+        "larastan/larastan": "^3.9",
         "laravel/pail": "^1.2.5",
         "laravel/pao": "^1.0.6",
         "laravel/pint": "^1.27",
@@ -64,9 +65,13 @@
             "npm run types:check",
             "@test"
         ],
+        "test:types": [
+            "phpstan analyse"
+        ],
         "test": [
             "@php artisan config:clear --ansi",
             "@lint:check",
+            "@test:types",
             "@php artisan test"
         ],
         "post-autoload-dump": [

--- a/kits/Livewire/Base/app/Models/User.php
+++ b/kits/Livewire/Base/app/Models/User.php
@@ -9,11 +9,25 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Fortify\Contracts\PasskeyUser;
 use Laravel\Fortify\PasskeyAuthenticatable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property Carbon|null $email_verified_at
+ * @property string $password
+ * @property string|null $two_factor_secret
+ * @property string|null $two_factor_recovery_codes
+ * @property Carbon|null $two_factor_confirmed_at
+ * @property string|null $remember_token
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
 class User extends Authenticatable implements PasskeyUser

--- a/kits/Livewire/Blank/.github/workflows/tests.yml
+++ b/kits/Livewire/Blank/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
         run: npm run build
 
       - name: Run Type Analysis
-        run: composer test:types
+        run: composer types:check
 
       - name: Run Tests
         run: php artisan test

--- a/kits/Livewire/Blank/.github/workflows/tests.yml
+++ b/kits/Livewire/Blank/.github/workflows/tests.yml
@@ -57,5 +57,8 @@ jobs:
       - name: Build Assets
         run: npm run build
 
+      - name: Run Type Analysis
+        run: composer test:types
+
       - name: Run Tests
-        run: ./vendor/bin/phpunit
+        run: php artisan test

--- a/kits/Livewire/Blank/app/Models/User.php
+++ b/kits/Livewire/Blank/app/Models/User.php
@@ -9,8 +9,19 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property Carbon|null $email_verified_at
+ * @property string $password
+ * @property string|null $remember_token
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable

--- a/kits/Livewire/Blank/composer.json
+++ b/kits/Livewire/Blank/composer.json
@@ -16,6 +16,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",
+        "larastan/larastan": "^3.9",
         "laravel/pail": "^1.2.5",
         "laravel/pao": "^1.0.6",
         "laravel/pint": "^1.27",
@@ -64,9 +65,13 @@
             "Composer\\Config::disableProcessTimeout",
             "@test"
         ],
+        "test:types": [
+            "phpstan analyse"
+        ],
         "test": [
             "@php artisan config:clear --ansi",
             "@lint:check",
+            "@test:types",
             "@php artisan test"
         ],
         "post-autoload-dump": [

--- a/kits/Livewire/Blank/composer.json
+++ b/kits/Livewire/Blank/composer.json
@@ -65,13 +65,13 @@
             "Composer\\Config::disableProcessTimeout",
             "@test"
         ],
-        "test:types": [
+        "types:check": [
             "phpstan analyse"
         ],
         "test": [
             "@php artisan config:clear --ansi",
             "@lint:check",
-            "@test:types",
+            "@types:check",
             "@php artisan test"
         ],
         "post-autoload-dump": [

--- a/kits/Livewire/Components/app/Livewire/Settings/Profile.php
+++ b/kits/Livewire/Components/app/Livewire/Settings/Profile.php
@@ -72,14 +72,13 @@ class Profile extends Component
     #[Computed]
     public function hasUnverifiedEmail(): bool
     {
-        return Auth::user() instanceof MustVerifyEmail && ! Auth::user()->hasVerifiedEmail();
+        return is_a(Auth::user(), MustVerifyEmail::class) && ! Auth::user()->hasVerifiedEmail();
     }
 
     #[Computed]
     public function showDeleteUser(): bool
     {
-        return ! Auth::user() instanceof MustVerifyEmail
-            || (Auth::user() instanceof MustVerifyEmail && Auth::user()->hasVerifiedEmail());
+        return ! is_a(Auth::user(), MustVerifyEmail::class) || Auth::user()->hasVerifiedEmail();
     }
     /* @end-chisel-email-verification */
 }

--- a/kits/Livewire/Components/app/Livewire/Settings/Profile.php
+++ b/kits/Livewire/Components/app/Livewire/Settings/Profile.php
@@ -72,13 +72,17 @@ class Profile extends Component
     #[Computed]
     public function hasUnverifiedEmail(): bool
     {
-        return is_a(Auth::user(), MustVerifyEmail::class) && ! Auth::user()->hasVerifiedEmail();
+        $user = Auth::user();
+
+        return $user instanceof MustVerifyEmail && ! $user->hasVerifiedEmail();
     }
 
     #[Computed]
     public function showDeleteUser(): bool
     {
-        return ! is_a(Auth::user(), MustVerifyEmail::class) || Auth::user()->hasVerifiedEmail();
+        $user = Auth::user();
+
+        return ! $user instanceof MustVerifyEmail || $user->hasVerifiedEmail();
     }
     /* @end-chisel-email-verification */
 }

--- a/kits/Livewire/Components/app/Livewire/Settings/Security.php
+++ b/kits/Livewire/Components/app/Livewire/Settings/Security.php
@@ -69,7 +69,7 @@ class Security extends Component
     public bool $canManagePasskeys;
 
     /**
-     * @var list<array{id: int, name: string, authenticator: string|null, created_at_diff: string, last_used_at_diff: string|null}>
+     * @var array<int, array{id: int, name: string, authenticator: string|null, created_at_diff: string, last_used_at_diff: string|null}>
      */
     #[Locked]
     public array $passkeys = [];
@@ -152,7 +152,7 @@ class Security extends Component
                 'created_at_diff' => $passkey->created_at->diffForHumans(),
                 'last_used_at_diff' => $passkey->last_used_at?->diffForHumans(),
             ])
-            ->toArray();
+            ->all();
     }
 
     /**

--- a/kits/Livewire/Components/app/Livewire/Settings/Security.php
+++ b/kits/Livewire/Components/app/Livewire/Settings/Security.php
@@ -68,6 +68,9 @@ class Security extends Component
     #[Locked]
     public bool $canManagePasskeys;
 
+    /**
+     * @var list<array{id: int, name: string, authenticator: string|null, created_at_diff: string, last_used_at_diff: string|null}>
+     */
     #[Locked]
     public array $passkeys = [];
 
@@ -299,6 +302,8 @@ class Security extends Component
 
     /**
      * Get the current modal configuration state.
+     *
+     * @return array{title: string, description: string, buttonText: string}
      */
     #[Computed]
     public function modalConfig(): array

--- a/kits/Livewire/Components/app/Livewire/Settings/TwoFactor/RecoveryCodes.php
+++ b/kits/Livewire/Components/app/Livewire/Settings/TwoFactor/RecoveryCodes.php
@@ -9,6 +9,7 @@ use Livewire\Component;
 
 class RecoveryCodes extends Component
 {
+    /** @var array<int, string> */
     #[Locked]
     public array $recoveryCodes = [];
 

--- a/kits/Livewire/Components/app/Livewire/Settings/TwoFactor/RecoveryCodes.php
+++ b/kits/Livewire/Components/app/Livewire/Settings/TwoFactor/RecoveryCodes.php
@@ -9,7 +9,7 @@ use Livewire\Component;
 
 class RecoveryCodes extends Component
 {
-    /** @var array<int, string> */
+    /** @var list<string> */
     #[Locked]
     public array $recoveryCodes = [];
 

--- a/kits/Livewire/Fortify/app/Livewire/Actions/Logout.php
+++ b/kits/Livewire/Fortify/app/Livewire/Actions/Logout.php
@@ -2,15 +2,17 @@
 
 namespace App\Livewire\Actions;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
+use Livewire\Features\SupportRedirects\Redirector;
 
 class Logout
 {
     /**
      * Log the current user out of the application.
      */
-    public function __invoke()
+    public function __invoke(): Redirector|RedirectResponse
     {
         Auth::guard('web')->logout();
 

--- a/kits/Livewire/Fortify/composer.json
+++ b/kits/Livewire/Fortify/composer.json
@@ -19,6 +19,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",
+        "larastan/larastan": "^3.9",
         "laravel/pail": "^1.2.5",
         "laravel/pao": "^1.0.6",
         "laravel/pint": "^1.27",
@@ -62,9 +63,13 @@
             "Composer\\Config::disableProcessTimeout",
             "@test"
         ],
+        "test:types": [
+            "phpstan analyse"
+        ],
         "test": [
             "@php artisan config:clear --ansi",
             "@lint:check",
+            "@test:types",
             "@php artisan test"
         ],
         "post-autoload-dump": [

--- a/kits/Livewire/Fortify/composer.json
+++ b/kits/Livewire/Fortify/composer.json
@@ -63,13 +63,13 @@
             "Composer\\Config::disableProcessTimeout",
             "@test"
         ],
-        "test:types": [
+        "types:check": [
             "phpstan analyse"
         ],
         "test": [
             "@php artisan config:clear --ansi",
             "@lint:check",
-            "@test:types",
+            "@types:check",
             "@php artisan test"
         ],
         "post-autoload-dump": [

--- a/kits/Livewire/Teams/Fortify/app/Models/User.php
+++ b/kits/Livewire/Teams/Fortify/app/Models/User.php
@@ -7,14 +7,34 @@ use App\Concerns\HasTeams;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Fortify\Contracts\PasskeyUser;
 use Laravel\Fortify\PasskeyAuthenticatable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property Carbon|null $email_verified_at
+ * @property string $password
+ * @property string|null $two_factor_secret
+ * @property string|null $two_factor_recovery_codes
+ * @property Carbon|null $two_factor_confirmed_at
+ * @property string|null $remember_token
+ * @property int|null $current_team_id
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Team|null $currentTeam
+ * @property-read Collection<int, Team> $ownedTeams
+ * @property-read Collection<int, Membership> $teamMemberships
+ * @property-read Collection<int, Team> $teams
+ */
 #[Fillable(['name', 'email', 'password', 'current_team_id'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
 class User extends Authenticatable implements PasskeyUser

--- a/kits/Livewire/Teams/WorkOS/app/Models/User.php
+++ b/kits/Livewire/Teams/WorkOS/app/Models/User.php
@@ -7,11 +7,29 @@ use App\Concerns\HasTeams;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property Carbon|null $email_verified_at
+ * @property string $workos_id
+ * @property string|null $remember_token
+ * @property string $avatar
+ * @property int|null $current_team_id
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Team|null $currentTeam
+ * @property-read Collection<int, Team> $ownedTeams
+ * @property-read Collection<int, Membership> $teamMemberships
+ * @property-read Collection<int, Team> $teams
+ */
 #[Fillable(['name', 'email', 'workos_id', 'avatar', 'current_team_id'])]
 #[Hidden(['workos_id', 'remember_token'])]
 class User extends Authenticatable

--- a/kits/Livewire/WorkOS/app/Models/User.php
+++ b/kits/Livewire/WorkOS/app/Models/User.php
@@ -9,8 +9,20 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property Carbon|null $email_verified_at
+ * @property string $workos_id
+ * @property string|null $remember_token
+ * @property string $avatar
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 #[Fillable(['name', 'email', 'workos_id', 'avatar'])]
 #[Hidden(['workos_id', 'remember_token'])]
 class User extends Authenticatable

--- a/kits/Livewire/WorkOS/composer.json
+++ b/kits/Livewire/WorkOS/composer.json
@@ -18,6 +18,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",
+        "larastan/larastan": "^3.9",
         "laravel/pail": "^1.2.5",
         "laravel/pao": "^1.0.6",
         "laravel/pint": "^1.27",
@@ -61,9 +62,13 @@
             "Composer\\Config::disableProcessTimeout",
             "@test"
         ],
+        "test:types": [
+            "phpstan analyse"
+        ],
         "test": [
             "@php artisan config:clear --ansi",
             "@lint:check",
+            "@test:types",
             "@php artisan test"
         ],
         "post-autoload-dump": [

--- a/kits/Livewire/WorkOS/composer.json
+++ b/kits/Livewire/WorkOS/composer.json
@@ -62,13 +62,13 @@
             "Composer\\Config::disableProcessTimeout",
             "@test"
         ],
-        "test:types": [
+        "types:check": [
             "phpstan analyse"
         ],
         "test": [
             "@php artisan config:clear --ansi",
             "@lint:check",
-            "@test:types",
+            "@types:check",
             "@php artisan test"
         ],
         "post-autoload-dump": [

--- a/kits/Shared/Blank/config/filesystems.php
+++ b/kits/Shared/Blank/config/filesystems.php
@@ -41,7 +41,7 @@ return [
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
-            'url' => rtrim(env('APP_URL', 'http://localhost'), '/').'/storage',
+            'url' => rtrim((string) env('APP_URL', 'http://localhost'), '/').'/storage',
             'visibility' => 'public',
             'throw' => false,
             'report' => false,

--- a/kits/Shared/Blank/phpstan.neon
+++ b/kits/Shared/Blank/phpstan.neon
@@ -1,0 +1,13 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+    - vendor/nesbot/carbon/extension.neon
+
+parameters:
+    paths:
+        - app/
+        - bootstrap/app.php
+        - config/
+        - database/
+        - routes/
+
+    level: 5

--- a/kits/Shared/Blank/phpstan.neon
+++ b/kits/Shared/Blank/phpstan.neon
@@ -10,4 +10,4 @@ parameters:
         - database/
         - routes/
 
-    level: 5
+    level: 6

--- a/kits/Shared/Blank/phpstan.neon
+++ b/kits/Shared/Blank/phpstan.neon
@@ -10,4 +10,4 @@ parameters:
         - database/
         - routes/
 
-    level: 6
+    level: 7

--- a/kits/Shared/Fortify/app/Concerns/PasswordValidationRules.php
+++ b/kits/Shared/Fortify/app/Concerns/PasswordValidationRules.php
@@ -10,7 +10,7 @@ trait PasswordValidationRules
     /**
      * Get the validation rules used to validate passwords.
      *
-     * @return array<int, ValidationRule|array<mixed>|string>
+     * @return array<int, Password|ValidationRule|array<mixed>|string>
      */
     protected function passwordRules(): array
     {
@@ -20,7 +20,7 @@ trait PasswordValidationRules
     /**
      * Get the validation rules used to validate the current password.
      *
-     * @return array<int, ValidationRule|array<mixed>|string>
+     * @return array<int, Password|ValidationRule|array<mixed>|string>
      */
     protected function currentPasswordRules(): array
     {

--- a/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
+++ b/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use Laravel\Chisel\Chisel;
 use Laravel\Chisel\Question;
 use Laravel\Chisel\Script;
-use RuntimeException;
 
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\spin;
@@ -48,19 +47,13 @@ class InstallFeaturesCommand extends Command
         $answers = $script
             ->collectAnswers()
             ->onQuestion(function (Question $question) {
-                /** @var string $type */
-                $type = $question->type;
-
-                return match ($type) {
-                    'multiselect' => multiselect(
-                        label: $question->label,
-                        options: $question->options,
-                        default: $question->default ?? [],
-                        required: $question->required,
-                        hint: $question->hint,
-                    ),
-                    default => throw new RuntimeException("Unsupported question type [{$question->type}]."),
-                };
+                return multiselect(
+                    label: $question->label,
+                    options: $question->options,
+                    default: $question->default ?? [],
+                    required: $question->required,
+                    hint: $question->hint,
+                );
             })
             ->interactive($this->input->isInteractive())
             ->withAnswers($providedAnswers);

--- a/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
+++ b/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Laravel\Chisel\Chisel;
 use Laravel\Chisel\Question;
 use Laravel\Chisel\Script;
+
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\spin;
 

--- a/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
+++ b/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Laravel\Chisel\Chisel;
 use Laravel\Chisel\Question;
 use Laravel\Chisel\Script;
+use RuntimeException;
 
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\spin;
@@ -46,14 +47,15 @@ class InstallFeaturesCommand extends Command
 
         $answers = $script
             ->collectAnswers()
-            ->onQuestion(function (Question $question) {
-                return multiselect(
+            ->onQuestion(fn (Question $question) => match ($question->type) {
+                'multiselect' => multiselect(
                     label: $question->label,
                     options: $question->options,
                     default: $question->default ?? [],
                     required: $question->required,
                     hint: $question->hint,
-                );
+                ),
+                default => throw new RuntimeException("Unsupported question type [{$question->type}]."),
             })
             ->interactive($this->input->isInteractive())
             ->withAnswers($providedAnswers);

--- a/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
+++ b/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
@@ -6,8 +6,6 @@ use Illuminate\Console\Command;
 use Laravel\Chisel\Chisel;
 use Laravel\Chisel\Question;
 use Laravel\Chisel\Script;
-use RuntimeException;
-
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\spin;
 
@@ -47,16 +45,13 @@ class InstallFeaturesCommand extends Command
 
         $answers = $script
             ->collectAnswers()
-            ->onQuestion(fn (Question $question) => match ($question->type) {
-                'multiselect' => multiselect(
-                    label: $question->label,
-                    options: $question->options,
-                    default: $question->default ?? [],
-                    required: $question->required,
-                    hint: $question->hint,
-                ),
-                default => throw new RuntimeException("Unsupported question type [{$question->type}]."),
-            })
+            ->onQuestion(fn (Question $question) => multiselect(
+                label: $question->label,
+                options: $question->options,
+                default: $question->default ?? [],
+                required: $question->required,
+                hint: $question->hint,
+            ))
             ->interactive($this->input->isInteractive())
             ->withAnswers($providedAnswers);
 

--- a/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
+++ b/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
@@ -47,15 +47,20 @@ class InstallFeaturesCommand extends Command
 
         $answers = $script
             ->collectAnswers()
-            ->onQuestion(fn (Question $question) => match ($question->type) {
-                'multiselect' => multiselect(
-                    label: $question->label,
-                    options: $question->options,
-                    default: $question->default ?? [],
-                    required: $question->required,
-                    hint: $question->hint,
-                ),
-                default => throw new RuntimeException("Unsupported question type [{$question->type}]."),
+            ->onQuestion(function (Question $question) {
+                /** @var string $type */
+                $type = $question->type;
+
+                return match ($type) {
+                    'multiselect' => multiselect(
+                        label: $question->label,
+                        options: $question->options,
+                        default: $question->default ?? [],
+                        required: $question->required,
+                        hint: $question->hint,
+                    ),
+                    default => throw new RuntimeException("Unsupported question type [{$question->type}]."),
+                };
             })
             ->interactive($this->input->isInteractive())
             ->withAnswers($providedAnswers);

--- a/kits/Shared/Teams/Base/app/Models/Membership.php
+++ b/kits/Shared/Teams/Base/app/Models/Membership.php
@@ -4,10 +4,20 @@ namespace App\Models;
 
 use App\Enums\TeamRole;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property int $id
+ * @property int $team_id
+ * @property int $user_id
+ * @property TeamRole $role
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Team $team
+ * @property-read User $user
+ */
 #[Fillable(['team_id', 'user_id', 'role'])]
 class Membership extends Pivot
 {
@@ -38,7 +48,7 @@ class Membership extends Pivot
     /**
      * Get the user that belongs to this membership.
      *
-     * @return BelongsTo<Model, $this>
+     * @return BelongsTo<User, $this>
      */
     public function user(): BelongsTo
     {

--- a/kits/Shared/Teams/Base/app/Models/Team.php
+++ b/kits/Shared/Teams/Base/app/Models/Team.php
@@ -6,12 +6,26 @@ use App\Concerns\GeneratesUniqueTeamSlugs;
 use App\Enums\TeamRole;
 use Database\Factories\TeamFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $slug
+ * @property bool $is_personal
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ * @property-read Collection<int, TeamInvitation> $invitations
+ * @property-read Collection<int, Membership> $memberships
+ * @property-read Collection<int, User> $members
+ */
 #[Fillable(['name', 'slug', 'is_personal'])]
 class Team extends Model
 {
@@ -51,7 +65,7 @@ class Team extends Model
     /**
      * Get all members of this team.
      *
-     * @return BelongsToMany<Model, $this>
+     * @return BelongsToMany<User, $this, Membership, 'pivot'>
      */
     public function members(): BelongsToMany
     {

--- a/kits/Shared/Teams/Base/app/Models/TeamInvitation.php
+++ b/kits/Shared/Teams/Base/app/Models/TeamInvitation.php
@@ -8,8 +8,23 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 
+/**
+ * @property int $id
+ * @property string $code
+ * @property int $team_id
+ * @property string $email
+ * @property TeamRole $role
+ * @property int $invited_by
+ * @property Carbon|null $expires_at
+ * @property Carbon|null $accepted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Team $team
+ * @property-read User $inviter
+ */
 #[Fillable(['team_id', 'email', 'role', 'invited_by', 'expires_at', 'accepted_at'])]
 class TeamInvitation extends Model
 {
@@ -43,7 +58,7 @@ class TeamInvitation extends Model
     /**
      * Get the user who sent the invitation.
      *
-     * @return BelongsTo<Model, $this>
+     * @return BelongsTo<User, $this>
      */
     public function inviter(): BelongsTo
     {

--- a/kits/Shared/Teams/Base/app/Rules/TeamName.php
+++ b/kits/Shared/Teams/Base/app/Rules/TeamName.php
@@ -26,6 +26,8 @@ class TeamName implements ValidationRule
 
     /**
      * Get a list of all reserved names.
+     *
+     * @return array<int, string>
      */
     protected function reservedNames(): array
     {
@@ -368,6 +370,8 @@ class TeamName implements ValidationRule
 
     /**
      * Get a list of reserved names from the application's route prefixes.
+     *
+     * @return array<int, string>
      */
     protected function routesPrefixes(): array
     {

--- a/kits/Shared/Teams/Fortify/app/Http/Responses/Concerns/RedirectsToCurrentTeam.php
+++ b/kits/Shared/Teams/Fortify/app/Http/Responses/Concerns/RedirectsToCurrentTeam.php
@@ -21,15 +21,11 @@ trait RedirectsToCurrentTeam
     {
         $user = $request->user();
 
-        if (! $user) {
-            abort(403);
-        }
+        abort_if(! $user, 403);
 
         $team = $user->currentTeam ?? $user->personalTeam();
 
-        if (! $team) {
-            abort(403);
-        }
+        abort_if(! $team, 403);
 
         return $team;
     }

--- a/kits/Shared/Teams/Fortify/app/Http/Responses/Concerns/RedirectsToCurrentTeam.php
+++ b/kits/Shared/Teams/Fortify/app/Http/Responses/Concerns/RedirectsToCurrentTeam.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Responses\Concerns;
 
+use App\Models\Team;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\URL;
 
 trait RedirectsToCurrentTeam
 {
-    protected function redirectPathForCurrentTeam($request, string $redirect): string
+    protected function redirectPathForCurrentTeam(Request $request, string $redirect): string
     {
         $team = $this->currentTeam($request);
 
@@ -15,10 +17,15 @@ trait RedirectsToCurrentTeam
         return "/{$team->slug}{$redirect}";
     }
 
-    protected function currentTeam($request)
+    protected function currentTeam(Request $request): Team
     {
         $user = $request->user();
-        $team = $user?->currentTeam ?? $user?->personalTeam();
+
+        if (! $user) {
+            abort(403);
+        }
+
+        $team = $user->currentTeam ?? $user->personalTeam();
 
         if (! $team) {
             abort(403);


### PR DESCRIPTION
## Overview

Static analysis helps keep the starter kits easier to maintain as the generated applications grow. This adds Larastan to the Livewire and Inertia kits, wires PHPStan into the test scripts and CI workflows, and updates the affected application code with the types and annotations needed to pass level 7 analysis.

## Why level 7

Level 7 gives these starter kits a strong static analysis baseline without turning the code into something that only exists to satisfy the tool. It catches the important type issues we want to avoid in generated applications, while still keeping the code practical, readable, and close to what developers expect from a Laravel starter kit.

Going higher would require more annotations and small structural changes that do not improve the code. Level 7 feels like the right balance: strict enough to guard the kits, but not so strict that static analysis starts shaping the code more than the framework conventions do.

Closes #104 