### PR TITLE
Move team data objects to the Data namespace

### DIFF
--- a/kits/Livewire/Teams/Base/resources/views/components/team-switcher.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/components/team-switcher.blade.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Data\UserTeam;
 use App\Models\Team;
-use App\Support\UserTeam;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/delete-team-modal.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/delete-team-modal.blade.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Data\UserTeam;
 use App\Models\Team;
 use App\Models\User;
 use Flux\Flux;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/edit.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/edit.blade.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Data\TeamPermissions;
 use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Rules\TeamName;
-use App\Support\TeamPermissions;
 use Flux\Flux;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/index.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/index.blade.php
@@ -1,8 +1,8 @@
 <?php
 
 use App\Actions\Teams\CreateTeam;
+use App\Data\UserTeam;
 use App\Rules\TeamName;
-use App\Support\UserTeam;
 use Flux\Flux;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;

--- a/kits/Shared/Teams/Base/app/Concerns/HasTeams.php
+++ b/kits/Shared/Teams/Base/app/Concerns/HasTeams.php
@@ -2,12 +2,12 @@
 
 namespace App\Concerns;
 
+use App\Data\TeamPermissions;
+use App\Data\UserTeam;
 use App\Enums\TeamPermission;
 use App\Enums\TeamRole;
 use App\Models\Membership;
 use App\Models\Team;
-use App\Support\TeamPermissions;
-use App\Support\UserTeam;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;

--- a/kits/Shared/Teams/Base/app/Data/TeamPermissions.php
+++ b/kits/Shared/Teams/Base/app/Data/TeamPermissions.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Support;
+namespace App\Data;
 
 readonly class TeamPermissions
 {

--- a/kits/Shared/Teams/Base/app/Data/UserTeam.php
+++ b/kits/Shared/Teams/Base/app/Data/UserTeam.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Support;
+namespace App\Data;
 
 readonly class UserTeam
 {


### PR DESCRIPTION
The teams feature uses small immutable objects to pass team and permission data around the application. This moves those objects from \`App\Support\` to \`App\Data\`, making their purpose clearer and keeping the namespace aligned with how they are used.

The shared Teams concern now returns the data objects from the new namespace, and the Livewire team views import the updated classes where they type-hint those values.