### PR TITLE
Improve kit script automation output

### DIFF
--- a/orchestrator/scripts/browser-tests-kits.js
+++ b/orchestrator/scripts/browser-tests-kits.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from 'child_process';
+import { execSync, spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import {
@@ -72,6 +72,52 @@ const variants = [
         buildArgs: ['build', '--no-interaction', '--kit=Vue', '--teams'],
     },
 ];
+
+function runCapturedToFile(command, args, options = {}) {
+    return new Promise((resolve, reject) => {
+        const outputPath = path.join(options.cwd ?? process.cwd(), `.browser-tests-output-${Date.now()}.log`);
+        const output = fs.openSync(outputPath, 'w');
+        let outputRead = false;
+        const child = spawn(command, args, {
+            ...options,
+            stdio: ['ignore', output, output],
+        });
+
+        const readOutput = () => {
+            if (outputRead) {
+                return '';
+            }
+
+            outputRead = true;
+            fs.closeSync(output);
+
+            const captured = fs.readFileSync(outputPath, 'utf-8');
+            fs.rmSync(outputPath, { force: true });
+
+            return captured;
+        };
+
+        child.on('close', code => {
+            const captured = readOutput();
+
+            if (code === 0) {
+                resolve({ stdout: captured, stderr: '' });
+
+                return;
+            }
+
+            const display = [command, ...args].join(' ');
+            const error = new Error(`Command failed: ${display}`);
+            error.output = captured;
+            reject(error);
+        });
+
+        child.on('error', error => {
+            error.output = readOutput();
+            reject(error);
+        });
+    });
+}
 
 function prepareBrowserTests(variant, { jsonMode }) {
     if (!jsonMode) {
@@ -158,7 +204,7 @@ async function runBrowserTestsForCurrentBuild(context) {
         log('  Running browser tests...', 'blue');
     }
 
-    const run = context.jsonMode ? runQuiet : runInherit;
+    const run = context.jsonMode ? runCapturedToFile : runInherit;
 
     await run('php', ['vendor/bin/pest', '--parallel'], { cwd: buildDir });
 }

--- a/orchestrator/scripts/browser-tests-kits.js
+++ b/orchestrator/scripts/browser-tests-kits.js
@@ -73,13 +73,19 @@ const variants = [
     },
 ];
 
-function prepareBrowserTests(variant) {
-    log('  Copying browser test bootstrap into build...', 'dim');
+function prepareBrowserTests(variant, { jsonMode }) {
+    if (!jsonMode) {
+        log('  Copying browser test bootstrap into build...', 'dim');
+    }
+
     fs.cpSync(path.join(browserTestsDir, 'bootstrap'), buildDir, { recursive: true });
 
     const suite = variant === 'teams' ? 'teams' : 'common';
 
-    log(`  Copying ${suite} browser tests into build...`, 'dim');
+    if (!jsonMode) {
+        log(`  Copying ${suite} browser tests into build...`, 'dim');
+    }
+
     fs.cpSync(path.join(browserTestsDir, suite), buildDir, { recursive: true });
 }
 
@@ -100,50 +106,79 @@ function playwrightBrowsersInstalled() {
     }
 }
 
-async function ensurePlaywrightBrowsers() {
+async function ensurePlaywrightBrowsers({ jsonMode }) {
     if (playwrightBrowsersInstalled()) {
-        log('  Playwright browsers already installed, skipping...', 'dim');
+        if (!jsonMode) {
+            log('  Playwright browsers already installed, skipping...', 'dim');
+        }
 
         return;
     }
 
-    log('  Installing Playwright browsers...', 'blue');
-    await runInherit('npx', ['playwright', 'install', 'chromium', '--with-deps', '--only-shell'], { cwd: buildDir });
+    if (!jsonMode) {
+        log('  Installing Playwright browsers...', 'blue');
+    }
+
+    const run = jsonMode ? runQuiet : runInherit;
+
+    await run('npx', ['playwright', 'install', 'chromium', '--with-deps', '--only-shell'], { cwd: buildDir });
 }
 
-async function runBrowserTestsForCurrentBuild() {
-    log('  Configuring Pest + Playwright deps...', 'dim');
+async function runBrowserTestsForCurrentBuild(context) {
+    if (!context.jsonMode) {
+        log('  Configuring Pest + Playwright deps...', 'dim');
+    }
+
     await runQuiet('composer', ['remove', '--dev', 'phpunit/phpunit', '--no-interaction', '--no-update'], { cwd: buildDir });
     await runQuiet('composer', ['require', '--dev', 'pestphp/pest', 'pestphp/pest-plugin-browser', 'pestphp/pest-plugin-laravel', '--no-interaction'], { cwd: buildDir });
 
-    log('  Installing npm deps...', 'dim');
+    if (!context.jsonMode) {
+        log('  Installing npm deps...', 'dim');
+    }
+
     await runQuiet('npm', ['install'], { cwd: buildDir });
     await runQuiet('npm', ['install', 'playwright'], { cwd: buildDir });
 
-    await ensurePlaywrightBrowsers();
+    await ensurePlaywrightBrowsers(context);
 
-    log('  Preparing environment...', 'dim');
+    if (!context.jsonMode) {
+        log('  Preparing environment...', 'dim');
+    }
+
     await runQuiet('cp', ['.env.example', '.env'], { cwd: buildDir });
     await runQuiet('php', ['artisan', 'key:generate'], { cwd: buildDir });
 
-    log('  Building frontend...', 'dim');
+    if (!context.jsonMode) {
+        log('  Building frontend...', 'dim');
+    }
+
     await runQuiet('npm', ['run', 'build'], { cwd: buildDir });
 
-    log('  Running browser tests...', 'blue');
-    await runInherit('php', ['vendor/bin/pest', '--parallel'], { cwd: buildDir });
+    if (!context.jsonMode) {
+        log('  Running browser tests...', 'blue');
+    }
+
+    const run = context.jsonMode ? runQuiet : runInherit;
+
+    await run('php', ['vendor/bin/pest', '--parallel'], { cwd: buildDir });
 }
 
-async function browserTestVariant(variant, index, total) {
-    log(`\n[${index}/${total}] ${variant.display}`, 'blue');
+async function browserTestVariant(variant, index, total, context) {
+    if (!context.jsonMode) {
+        log(`\n[${index}/${total}] ${variant.display}`, 'blue');
+    }
 
     removeBuildDirectory();
 
-    log('  Building variant...', 'dim');
+    if (!context.jsonMode) {
+        log('  Building variant...', 'dim');
+    }
+
     await runQuiet('php', ['artisan', ...variant.buildArgs], { cwd: orchestratorDir });
 
-    prepareBrowserTests(variant.variant);
+    prepareBrowserTests(variant.variant, context);
 
-    await runBrowserTestsForCurrentBuild();
+    await runBrowserTestsForCurrentBuild(context);
 }
 
 runMatrix({

--- a/orchestrator/scripts/check-kits.js
+++ b/orchestrator/scripts/check-kits.js
@@ -152,23 +152,34 @@ const variants = [
     },
 ];
 
-async function checkCurrentBuild() {
-    log('  Installing dependencies...', 'dim');
+async function checkCurrentBuild({ jsonMode }) {
+    if (!jsonMode) {
+        log('  Installing dependencies...', 'dim');
+    }
+
     await runQuiet('composer', ['setup'], { cwd: buildDir });
 
-    log('  Running ci:check...', 'dim');
+    if (!jsonMode) {
+        log('  Running ci:check...', 'dim');
+    }
+
     await runQuiet('composer', ['ci:check'], { cwd: buildDir });
 }
 
-async function checkVariant(variant, index, total) {
-    log(`\n[${index}/${total}] ${variant.display}`, 'blue');
+async function checkVariant(variant, index, total, context) {
+    if (!context.jsonMode) {
+        log(`\n[${index}/${total}] ${variant.display}`, 'blue');
+    }
 
     removeBuildDirectory();
 
-    log('  Building variant...', 'dim');
+    if (!context.jsonMode) {
+        log('  Building variant...', 'dim');
+    }
+
     await runQuiet('php', ['artisan', ...variant.buildArgs], { cwd: orchestratorDir });
 
-    await checkCurrentBuild();
+    await checkCurrentBuild(context);
 }
 
 runMatrix({

--- a/orchestrator/scripts/kit-helpers.js
+++ b/orchestrator/scripts/kit-helpers.js
@@ -16,6 +16,16 @@ const FRAMEWORK_FLAGS = ['--livewire', '--react', '--svelte', '--vue'];
 const VARIANT_FLAGS = ['--blank', '--fortify', '--workos', '--components', '--teams'];
 
 /**
+ * Output-mode flags that should not be treated as matrix filters.
+ */
+export const OUTPUT_FLAGS = ['--json'];
+
+/**
+ * Environment variables that indicate an agent prefers machine-readable output.
+ */
+const AGENT_OUTPUT_ENV_FLAGS = ['AI_AGENT', 'OPENCODE'];
+
+/**
  * Resolved directory paths shared across scripts.
  */
 const __filename = fileURLToPath(import.meta.url);
@@ -47,12 +57,31 @@ export function log(message, color = 'reset') {
 }
 
 /**
+ * Determine whether JSON output should be used for this run.
+ */
+export function isJsonOutputRequested(argv = process.argv.slice(2), env = process.env) {
+    if (argv.includes('--json')) {
+        return true;
+    }
+
+    return AGENT_OUTPUT_ENV_FLAGS.some(key => {
+        const value = env[key];
+
+        if (value === undefined) {
+            return false;
+        }
+
+        return !['', '0', 'false', 'no', 'off'].includes(String(value).toLowerCase());
+    });
+}
+
+/**
  * Parse process.argv (after slice(2)) and return the set of selected frameworks.
  * Returns null when no framework flags are present (means "run all").
  * Exits with a non-zero code if any unrecognized --* flag is found.
  */
 export function parseFrameworkFlags(argv) {
-    const allFlags = [...FRAMEWORK_FLAGS, ...VARIANT_FLAGS];
+    const allFlags = [...FRAMEWORK_FLAGS, ...VARIANT_FLAGS, ...OUTPUT_FLAGS];
     const unknownFlags = argv.filter(arg => arg.startsWith('--') && !allFlags.includes(arg));
 
     if (unknownFlags.length > 0) {
@@ -188,6 +217,131 @@ function formatElapsed(ms) {
     return `${minutes}m ${remainingSeconds}s`;
 }
 
+function setToArray(value) {
+    return value ? [...value] : [];
+}
+
+function normalizeResult(result) {
+    const normalized = {
+        key: result.key,
+        display: result.display,
+        status: result.status,
+    };
+
+    if (result.framework) {
+        normalized.framework = result.framework;
+    }
+
+    if (result.variant) {
+        normalized.variant = result.variant;
+    }
+
+    if (Number.isFinite(result.elapsedMs ?? result.elapsed)) {
+        normalized.elapsedMs = result.elapsedMs ?? result.elapsed;
+    }
+
+    if (result.reason) {
+        normalized.reason = result.reason;
+    }
+
+    if (result.error) {
+        normalized.error = {
+            message: result.error.message,
+        };
+
+        if (result.error.output) {
+            normalized.error.output = result.error.output;
+        }
+    }
+
+    return normalized;
+}
+
+/**
+ * Convert matrix results into a stable machine-readable JSON summary object.
+ */
+export function buildJsonSummary({
+    scriptLabel,
+    startedAt,
+    finishedAt,
+    selectedFrameworks,
+    selectedVariants,
+    results,
+    message = null,
+}) {
+    const started = startedAt instanceof Date ? startedAt : new Date(startedAt);
+    const finished = finishedAt instanceof Date ? finishedAt : new Date(finishedAt);
+    const normalizedResults = results.map(normalizeResult);
+    const failed = normalizedResults.filter(result => result.status === 'failed').length;
+
+    const summary = {
+        script: scriptLabel,
+        status: failed > 0 ? 'failed' : 'passed',
+        startedAt: started.toISOString(),
+        finishedAt: finished.toISOString(),
+        elapsedMs: finished.getTime() - started.getTime(),
+        jsonMode: true,
+        filters: {
+            frameworks: setToArray(selectedFrameworks),
+            variants: setToArray(selectedVariants),
+        },
+        totals: {
+            passed: normalizedResults.filter(result => result.status === 'passed').length,
+            failed,
+            skipped: normalizedResults.filter(result => result.status === 'skipped').length,
+        },
+        results: normalizedResults,
+    };
+
+    if (message) {
+        summary.message = message;
+    }
+
+    return summary;
+}
+
+/**
+ * Format a JSON summary as the exact stdout payload for JSON mode.
+ */
+export function formatJsonSummary(summary) {
+    return `${JSON.stringify(summary, null, 2)}\n`;
+}
+
+/**
+ * Write a single JSON summary object to stdout.
+ */
+export function writeJsonSummary(summary) {
+    process.stdout.write(formatJsonSummary(summary));
+}
+
+/**
+ * Build skipped result entries for every variant excluded by active filters.
+ */
+export function buildSkippedResults(allVariants, activeVariants, reason = 'kit not selected') {
+    return allVariants
+        .filter(variant => !activeVariants.includes(variant))
+        .map(variant => ({
+            key: variant.key,
+            display: variant.display,
+            framework: variant.framework,
+            variant: variant.variant,
+            status: 'skipped',
+            reason,
+        }));
+}
+
+function failedResultError(error) {
+    const result = {
+        message: error.message,
+    };
+
+    if (error.output) {
+        result.output = error.output;
+    }
+
+    return result;
+}
+
 /**
  * Print an end-of-run summary table.
  *
@@ -251,12 +405,31 @@ export function removeBuildDirectory() {
  */
 export async function runMatrix({ scriptLabel, allVariants, runVariant, successVerb = 'Passed' }) {
     const argv = process.argv.slice(2);
+    const jsonMode = isJsonOutputRequested(argv, process.env);
+    const startedAt = new Date();
     const selectedFrameworks = parseFrameworkFlags(argv);
     const selectedVariants = parseVariantFlags(argv);
     const active = filterVariants(allVariants, selectedFrameworks, selectedVariants);
+    const skipped = buildSkippedResults(allVariants, active);
 
     if (active.length === 0) {
-        log('No variants matched the selected flags.', 'yellow');
+        const message = 'No variants matched the selected flags.';
+
+        if (jsonMode) {
+            writeJsonSummary(buildJsonSummary({
+                scriptLabel,
+                startedAt,
+                finishedAt: new Date(),
+                selectedFrameworks,
+                selectedVariants,
+                results: skipped,
+                message,
+            }));
+
+            process.exit(0);
+        }
+
+        log(message, 'yellow');
         process.exit(0);
     }
 
@@ -270,25 +443,31 @@ export async function runMatrix({ scriptLabel, allVariants, runVariant, successV
         labels.push(`variants: ${[...selectedVariants].join(', ')}`);
     }
 
-    if (labels.length > 0) {
+    if (!jsonMode && labels.length > 0) {
         log(`Filters — ${labels.join(' | ')}`, 'blue');
     }
 
     const total = active.length;
     const results = [];
 
-    const skipped = allVariants.filter(v => !active.includes(v));
-
     for (let index = 0; index < total; index++) {
         const variant = active[index];
         const start = Date.now();
 
         try {
-            await runVariant(variant, index + 1, total);
-            results.push({ key: variant.key, display: variant.display, status: 'passed', elapsed: Date.now() - start });
-            log(`  ${colors.green}✓ ${successVerb}${colors.reset}`);
+            await runVariant(variant, index + 1, total, { jsonMode });
+            results.push({ ...variant, status: 'passed', elapsed: Date.now() - start });
+
+            if (!jsonMode) {
+                log(`  ${colors.green}✓ ${successVerb}${colors.reset}`);
+            }
         } catch (error) {
-            results.push({ key: variant.key, display: variant.display, status: 'failed', elapsed: Date.now() - start });
+            results.push({ ...variant, status: 'failed', elapsed: Date.now() - start, error: failedResultError(error) });
+
+            if (jsonMode) {
+                continue;
+            }
+
             log(`  ✗ Failed: ${error.message}`, 'red');
 
             if (error.output) {
@@ -299,11 +478,20 @@ export async function runMatrix({ scriptLabel, allVariants, runVariant, successV
         }
     }
 
-    for (const s of skipped) {
-        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'kit not selected' });
-    }
+    results.push(...skipped);
 
-    printSummary(scriptLabel, results);
+    if (jsonMode) {
+        writeJsonSummary(buildJsonSummary({
+            scriptLabel,
+            startedAt,
+            finishedAt: new Date(),
+            selectedFrameworks,
+            selectedVariants,
+            results,
+        }));
+    } else {
+        printSummary(scriptLabel, results);
+    }
 
     removeBuildDirectory();
 

--- a/orchestrator/scripts/lint-kits.js
+++ b/orchestrator/scripts/lint-kits.js
@@ -2,7 +2,10 @@
 
 import {
     buildDir,
+    buildJsonSummary,
+    buildSkippedResults,
     filterVariants,
+    isJsonOutputRequested,
     log,
     orchestratorDir,
     parseFrameworkFlags,
@@ -11,6 +14,7 @@ import {
     removeBuildDirectory,
     runInherit,
     runQuiet,
+    writeJsonSummary,
     colors,
 } from './kit-helpers.js';
 
@@ -129,62 +133,152 @@ const variants = [
 
 const MAX_LINT_PASSES = 2;
 
-async function lintCurrentBuild() {
-    log('  Installing composer deps...', 'dim');
+async function lintCurrentBuild({ jsonMode }) {
+    if (!jsonMode) {
+        log('  Installing composer deps...', 'dim');
+    }
+
     await runQuiet('composer', ['install'], { cwd: buildDir });
 
-    log('  Installing npm deps...', 'dim');
+    if (!jsonMode) {
+        log('  Installing npm deps...', 'dim');
+    }
+
     await runQuiet('npm', ['install'], { cwd: buildDir });
 
-    log('  Building frontend...', 'dim');
+    if (!jsonMode) {
+        log('  Building frontend...', 'dim');
+    }
+
     await runQuiet('npm', ['run', 'build'], { cwd: buildDir });
 
     for (let pass = 1; pass <= MAX_LINT_PASSES; pass++) {
-        log(`  Running lint pass ${pass}...`, 'dim');
+        if (!jsonMode) {
+            log(`  Running lint pass ${pass}...`, 'dim');
+        }
+
         await runQuiet('npm', ['run', 'lint'], { cwd: buildDir });
 
-        log(`  Running format pass ${pass}...`, 'dim');
+        if (!jsonMode) {
+            log(`  Running format pass ${pass}...`, 'dim');
+        }
+
         await runQuiet('npm', ['run', 'format'], { cwd: buildDir });
     }
 }
 
-function runWatcherInitialSync() {
-    log('  Syncing changes back to kits...', 'dim');
+function runWatcherInitialSync({ jsonMode }) {
+    if (!jsonMode) {
+        log('  Syncing changes back to kits...', 'dim');
+    }
 
     return runQuiet('node', ['scripts/watch.js', '--initial-sync-only'], {
         cwd: orchestratorDir,
     });
 }
 
-async function lintVariant(variant, index, total) {
-    log(`\n[${index}/${total}] ${variant.display}`, 'blue');
+async function lintVariant(variant, index, total, context) {
+    if (!context.jsonMode) {
+        log(`\n[${index}/${total}] ${variant.display}`, 'blue');
+    }
 
     removeBuildDirectory();
 
-    log('  Building variant...', 'dim');
+    if (!context.jsonMode) {
+        log('  Building variant...', 'dim');
+    }
+
     await runQuiet('php', ['artisan', ...variant.buildArgs], { cwd: orchestratorDir });
 
-    await lintCurrentBuild();
-    await runWatcherInitialSync();
+    await lintCurrentBuild(context);
+    await runWatcherInitialSync(context);
 }
 
-async function runPint() {
-    log('Running Pint on kits/ and browser_tests/...', 'blue');
-    await runInherit('pint', ['--parallel', '../kits'], { cwd: orchestratorDir });
-    await runInherit('pint', ['--parallel', '../browser_tests'], { cwd: orchestratorDir });
+async function runPint({ jsonMode }) {
+    if (!jsonMode) {
+        log('Running Pint on kits/ and browser_tests/...', 'blue');
+    }
+
+    const run = jsonMode ? runQuiet : runInherit;
+
+    await run('pint', ['--parallel', '../kits'], { cwd: orchestratorDir });
+    await run('pint', ['--parallel', '../browser_tests'], { cwd: orchestratorDir });
+}
+
+function failedResultError(error) {
+    const result = {
+        message: error.message,
+    };
+
+    if (error.output) {
+        result.output = error.output;
+    }
+
+    return result;
+}
+
+function writeLintJsonSummary({ startedAt, selectedFrameworks, selectedVariants, results, message = null }) {
+    writeJsonSummary(buildJsonSummary({
+        scriptLabel: 'kits:lint',
+        startedAt,
+        finishedAt: new Date(),
+        selectedFrameworks,
+        selectedVariants,
+        results,
+        message,
+    }));
 }
 
 async function main() {
     const argv = process.argv.slice(2);
+    const jsonMode = isJsonOutputRequested(argv, process.env);
+    const startedAt = new Date();
     const selectedFrameworks = parseFrameworkFlags(argv);
     const selectedVariants = parseVariantFlags(argv);
     const active = filterVariants(variants, selectedFrameworks, selectedVariants);
+    const skipped = buildSkippedResults(variants, active);
+    const results = [];
+    const context = { jsonMode };
 
     // Always run Pint first (it applies to all frameworks including Livewire).
-    await runPint();
+    if (jsonMode) {
+        const pintStart = Date.now();
+
+        try {
+            await runPint(context);
+            results.push({ key: 'pint', display: 'Pint', status: 'passed', elapsed: Date.now() - pintStart });
+        } catch (error) {
+            results.push({ key: 'pint', display: 'Pint', status: 'failed', elapsed: Date.now() - pintStart, error: failedResultError(error) });
+            results.push(...skipped);
+            writeLintJsonSummary({ startedAt, selectedFrameworks, selectedVariants, results });
+            process.exit(1);
+        }
+    } else {
+        await runPint(context);
+    }
 
     // If only --livewire was selected, there are no Inertia variants to run.
     if (active.length === 0) {
+        if (jsonMode) {
+            const message = selectedFrameworks && selectedFrameworks.has('livewire') && selectedFrameworks.size === 1
+                ? 'Livewire has no frontend lint phase. Only the shared Pint step applies.'
+                : 'No Inertia variants matched the selected flags.';
+
+            if (selectedFrameworks && selectedFrameworks.has('livewire') && selectedFrameworks.size === 1) {
+                results.push({
+                    key: 'livewire-frontend-lint',
+                    display: 'Livewire frontend lint',
+                    framework: 'livewire',
+                    status: 'skipped',
+                    reason: 'Livewire has no frontend lint phase.',
+                });
+            }
+
+            results.push(...skipped);
+            writeLintJsonSummary({ startedAt, selectedFrameworks, selectedVariants, results, message });
+            process.exit(0);
+        }
+
         if (selectedFrameworks && selectedFrameworks.has('livewire') && selectedFrameworks.size === 1) {
             log('Livewire has no frontend lint phase. Only the shared Pint step applies.', 'yellow');
         } else {
@@ -204,26 +298,30 @@ async function main() {
         labels.push(`variants: ${[...selectedVariants].join(', ')}`);
     }
 
-    if (labels.length > 0) {
+    if (!jsonMode && labels.length > 0) {
         log(`Filters — ${labels.join(' | ')}`, 'blue');
     }
 
     const total = active.length;
-    const results = [];
-
-    // Track skipped variants for summary
-    const skipped = variants.filter(v => !active.includes(v));
 
     for (let index = 0; index < total; index++) {
         const variant = active[index];
         const start = Date.now();
 
         try {
-            await lintVariant(variant, index + 1, total);
-            results.push({ key: variant.key, display: variant.display, status: 'passed', elapsed: Date.now() - start });
-            log(`  ${colors.green}✓ Finished${colors.reset}`);
+            await lintVariant(variant, index + 1, total, context);
+            results.push({ ...variant, status: 'passed', elapsed: Date.now() - start });
+
+            if (!jsonMode) {
+                log(`  ${colors.green}✓ Finished${colors.reset}`);
+            }
         } catch (error) {
-            results.push({ key: variant.key, display: variant.display, status: 'failed', elapsed: Date.now() - start });
+            results.push({ ...variant, status: 'failed', elapsed: Date.now() - start, error: failedResultError(error) });
+
+            if (jsonMode) {
+                continue;
+            }
+
             log(`  ✗ Failed: ${error.message}`, 'red');
 
             if (error.output) {
@@ -234,11 +332,13 @@ async function main() {
         }
     }
 
-    for (const s of skipped) {
-        results.push({ key: s.key, display: s.display, status: 'skipped', reason: 'kit not selected' });
-    }
+    results.push(...skipped);
 
-    printSummary('kits:lint', results);
+    if (jsonMode) {
+        writeLintJsonSummary({ startedAt, selectedFrameworks, selectedVariants, results });
+    } else {
+        printSummary('kits:lint', results);
+    }
 
     removeBuildDirectory();
 

--- a/orchestrator/scripts/watch.js
+++ b/orchestrator/scripts/watch.js
@@ -631,6 +631,10 @@ function copyToKit(srcPath, relativePath, folders, kitType, uiComponents, starte
 function deleteFromKit(relativePath, folders, starterKit, manifest) {
     const destRelativePath = remapComponentsPath(relativePath, starterKit, manifest);
 
+    if (isChiselFile(destRelativePath)) {
+        return;
+    }
+
     // Find the highest-priority folder that has this file
     const targetFolder = findSourceKitFolder(destRelativePath, folders);
 
@@ -656,6 +660,10 @@ function deleteFromKit(relativePath, folders, starterKit, manifest) {
  */
 function deleteDirFromKit(relativePath, folders, starterKit, manifest) {
     const destRelativePath = remapComponentsPath(relativePath, starterKit, manifest);
+
+    if (isChiselFile(destRelativePath)) {
+        return;
+    }
 
     for (let i = folders.length - 1; i >= 0; i--) {
         const targetDir = path.join(kitsDir, folders[i], destRelativePath);
@@ -683,6 +691,10 @@ function handleFileChange(eventType, filePath, folders, ig, kitType, uiComponent
 
     // Skip files that match .gitignore patterns
     if (ig.ignores(relativePath)) {
+        return;
+    }
+
+    if ((eventType === 'unlink' || eventType === 'unlinkDir') && isChiselFile(relativePath)) {
         return;
     }
 


### PR DESCRIPTION
This improves the kit orchestration scripts for automation-heavy workflows. The matrix scripts can now return clean JSON summaries with selected filters, totals, skipped variants, elapsed time, and captured failure output while keeping the existing human output as the default.

It also fixes the watcher so chisel files are not deleted during sync cleanup, and adjusts browser-test JSON runs so Pest output is captured without causing the parallel browser command to hang.