### PR TITLE
Remove unused kit node dependencies

### DIFF
--- a/kits/Inertia/Blank/React/package.json
+++ b/kits/Inertia/Blank/React/package.json
@@ -35,7 +35,6 @@
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^5.2.0",
-        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
         "globals": "^15.14.0",

--- a/kits/Inertia/Blank/Svelte/package.json
+++ b/kits/Inertia/Blank/Svelte/package.json
@@ -33,7 +33,6 @@
         "@inertiajs/vite": "^3.0.0",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tailwindcss/vite": "^4.1.11",
-        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^3.1",

--- a/kits/Inertia/Blank/Vue/package.json
+++ b/kits/Inertia/Blank/Vue/package.json
@@ -33,8 +33,6 @@
         "@inertiajs/vue3": "^3.0.0",
         "@tailwindcss/vite": "^4.1.11",
         "@vitejs/plugin-vue": "^6.0.0",
-        "@vueuse/core": "^12.8.2",
-        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^3.1",

--- a/kits/Inertia/Fortify/React/package.json
+++ b/kits/Inertia/Fortify/React/package.json
@@ -29,7 +29,6 @@
         "typescript-eslint": "^8.23.0"
     },
     "dependencies": {
-        "@headlessui/react": "^2.2.0",
         "@inertiajs/react": "^3.0.0",
         "@inertiajs/vite": "^3.0.0",
         "@laravel/passkeys": "^0.2.0",

--- a/kits/Inertia/Fortify/Svelte/package.json
+++ b/kits/Inertia/Fortify/Svelte/package.json
@@ -38,7 +38,6 @@
         "@laravel/passkeys": "^0.2.0",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "bits-ui": "^2.15.0",
-        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "laravel-vite-plugin": "^3.0.0",
         "lucide-svelte": "^0.468.0",

--- a/kits/Inertia/React/package.json
+++ b/kits/Inertia/React/package.json
@@ -29,7 +29,6 @@
         "typescript-eslint": "^8.23.0"
     },
     "dependencies": {
-        "@headlessui/react": "^2.2.0",
         "@inertiajs/react": "^3.0.0",
         "@inertiajs/vite": "^3.0.0",
         "@radix-ui/react-avatar": "^1.1.3",
@@ -53,7 +52,6 @@
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
         "globals": "^15.14.0",
-        "input-otp": "^1.4.2",
         "laravel-vite-plugin": "^3.1",
         "lucide-react": "^0.475.0",
         "react": "^19.2.0",

--- a/kits/Inertia/Svelte/package.json
+++ b/kits/Inertia/Svelte/package.json
@@ -37,7 +37,6 @@
         "@inertiajs/vite": "^3.0.0",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "bits-ui": "^2.15.0",
-        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "laravel-vite-plugin": "^3.1",
         "lucide-svelte": "^0.468.0",

--- a/kits/Inertia/Vue/package.json
+++ b/kits/Inertia/Vue/package.json
@@ -46,7 +46,6 @@
         "tailwindcss": "^4.1.1",
         "tw-animate-css": "^1.2.5",
         "vue": "^3.5.13",
-        "vue-input-otp": "^0.3.2",
         "vue-sonner": "^2.0.0"
     },
     "optionalDependencies": {

--- a/kits/Livewire/Blank/package.json
+++ b/kits/Livewire/Blank/package.json
@@ -8,7 +8,6 @@
     },
     "dependencies": {
         "@tailwindcss/vite": "^4.1.11",
-        "autoprefixer": "^10.4.20",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^3.1",
         "tailwindcss": "^4.0.7",

--- a/kits/Livewire/Fortify/package.json
+++ b/kits/Livewire/Fortify/package.json
@@ -9,7 +9,6 @@
     "dependencies": {
         "@laravel/passkeys": "^0.2.0",
         "@tailwindcss/vite": "^4.1.11",
-        "autoprefixer": "^10.4.20",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^3.1",
         "tailwindcss": "^4.0.7",


### PR DESCRIPTION
Some starter kit manifests still declared packages that are no longer used. This removes those dependencies completely where they are obsolete, such as \`autoprefixer\` and \`@headlessui/react\`, and removes layer-specific duplicates while keeping packages in the layers that still need them, such as OTP packages for Fortify 2FA and variant helpers for React and Vue UI components.