### PR TITLE
Read deferred installer hooks from superglobals

### DIFF
--- a/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
+++ b/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
@@ -30,7 +30,7 @@ class InstallFeaturesCommand extends Command
 
     public function handle(): int
     {
-        if (getenv('LARAVEL_INSTALLER_DEFER_HOOKS') && $this->option('answers') === null) {
+        if ($this->shouldDeferInstallerHooks()) {
             return self::SUCCESS;
         }
 
@@ -67,6 +67,20 @@ class InstallFeaturesCommand extends Command
         $this->buildAssets();
 
         return self::SUCCESS;
+    }
+
+    protected function shouldDeferInstallerHooks(): bool
+    {
+        if ($this->option('answers') !== null) {
+            return false;
+        }
+
+        return filter_var(
+            $_ENV['LARAVEL_INSTALLER_DEFER_HOOKS']
+                ?? $_SERVER['LARAVEL_INSTALLER_DEFER_HOOKS']
+                ?? getenv('LARAVEL_INSTALLER_DEFER_HOOKS'),
+            FILTER_VALIDATE_BOOL,
+        );
     }
 
     protected function installNodeDependencies(): void


### PR DESCRIPTION
Related to laravel/installer#525 and laravel/framework#60253.

The Fortify starter kit command currently checks `getenv('LARAVEL_INSTALLER_DEFER_HOOKS')` before skipping `install:features` during `laravel new`. On Windows, the installer defer flag may be available through PHP's populated superglobals even when the command is being invoked inside Composer's script subprocess.

This keeps the existing behavior, but centralizes the check and also reads `$_ENV` / `$_SERVER` before falling back to `getenv()`. Explicit `--answers` still bypasses the defer guard so non-interactive answers continue to run the install flow.

Validation:
- `php -l kits\Shared\Fortify\app\Console\Commands\InstallFeaturesCommand.php`
- `git diff --check`

I could not run Maestro's Composer-based checks locally because the locked orchestrator dependencies require PHP 8.4+, and this machine only has PHP 8.3 available on PATH.