### PR TITLE
GitHub Actions hardening

### DIFF
--- a/kits/Inertia/Blank/Base/.github/workflows/tests.yml
+++ b/kits/Inertia/Blank/Base/.github/workflows/tests.yml
@@ -14,6 +14,9 @@ on:
       - master
       - workos
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/kits/Livewire/Blank/.github/workflows/tests.yml
+++ b/kits/Livewire/Blank/.github/workflows/tests.yml
@@ -14,6 +14,9 @@ on:
       - master
       - workos
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/kits/Shared/Blank/.github/dependabot.yml
+++ b/kits/Shared/Blank/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
We are doing 3 things across the organization:

1. Pinning GitHub Actions to full commit SHAs (instead of mutable tags/branches).
2. Tightening workflow `permissions:` to least-privilege (write scope only where a step needs it).
3. Adding a Dependabot config to keep the pinned actions updated.

This pull request is part of that work.

These files are the kit templates that `push-kit-changes.yml` builds and pushes into the generated starter-kit repositories (`blank-livewire-starter-kit`, `react-starter-kit`, etc.), so changing them here is what propagates to all of those repos on the next build:

- `kits/Livewire/Blank/.github/workflows/tests.yml` and `kits/Inertia/Blank/Base/.github/workflows/tests.yml` — added `permissions: { contents: read }` (read-only test jobs; checkout already sets `persist-credentials: false`).
- `kits/Shared/Blank/.github/dependabot.yml` — new; `Shared/Blank` is the base layer seeded into every build, so a single file ships a Dependabot config into every generated starter kit (all kits/variants), giving freshly-scaffolded apps a `github-actions` Dependabot config out of the box.
- `lint.yml` is intentionally left at `contents: write` (its `git-auto-commit` step is currently commented out but kept in case it is re-enabled).

The workflow actions are already SHA-pinned, so no pinning changes were needed here. (Note: maestro's own `.github/dependabot.yml` already tracks the kit-template workflows via its `directories:` list, keeping the pinned SHAs fresh upstream.)