### PR TITLE
Add Dependabot cooldown of 5 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       - "/kits/Livewire/Blank/.github/workflows"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
This adds a 5-day cooldown to the Dependabot configuration so dependency update pull requests are only opened once an update has been available for 5 days. Applied to every update entry in `.github/dependabot.yml`.