### PR TITLE
Fix Svelte CI checks

### DIFF
--- a/kits/Inertia/Blank/Svelte/vite.config.ts
+++ b/kits/Inertia/Blank/Svelte/vite.config.ts
@@ -6,6 +6,12 @@ import laravel from 'laravel-vite-plugin';
 import { bunny } from 'laravel-vite-plugin/fonts';
 import { defineConfig } from 'vite';
 
+const isSvelteCheck = process.argv.some((argument) => argument.includes('svelte-check'));
+
+if (isSvelteCheck) {
+    process.env.LARAVEL_BYPASS_ENV_CHECK ??= '1';
+}
+
 export default defineConfig({
     plugins: [
         laravel({


### PR DESCRIPTION
Svelte CI started failing after \`svelte-check\` released a new compatible version today. The kits do not commit npm lockfiles, so CI resolved the newer package during \`npm install\`; that version loads \`vite.config.ts\` while GitHub Actions has \`CI=true\`, which triggered Laravel Vite’s HMR environment guard during type checks.

This updates the Svelte Vite config to bypass Laravel Vite’s CI environment check only when the current process is \`svelte-check\`. The guard still applies to actual Vite dev server usage in CI, while Svelte type checks can load the config normally again.