### PR TITLE
Re-add Blaze to Livewire starter kits

### DIFF
--- a/kits/Livewire/Blank/composer.json
+++ b/kits/Livewire/Blank/composer.json
@@ -12,6 +12,7 @@
         "php": "^8.3",
         "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
+        "livewire/blaze": "^1.0",
         "livewire/livewire": "^4.1"
     },
     "require-dev": {

--- a/kits/Livewire/Fortify/composer.json
+++ b/kits/Livewire/Fortify/composer.json
@@ -14,6 +14,7 @@
         "laravel/fortify": "^1.37.2",
         "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
+        "livewire/blaze": "^1.0",
         "livewire/flux": "^2.13.1",
         "livewire/livewire": "^4.1"
     },

--- a/kits/Livewire/WorkOS/composer.json
+++ b/kits/Livewire/WorkOS/composer.json
@@ -13,6 +13,7 @@
         "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
         "laravel/workos": "^0.6.0",
+        "livewire/blaze": "^1.0",
         "livewire/flux": "^2.12.0",
         "livewire/livewire": "^4.1"
     },


### PR DESCRIPTION
Livewire starter kits should include Blaze again so generated Livewire applications have the expected package available.

This adds `livewire/blaze` back to the Blank, Fortify, and WorkOS Livewire composer manifests.