### PR TITLE
Fix team invitation alert casing

### DIFF
--- a/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
+++ b/browser_tests/teams/tests/Browser/Teams/InvitationsTest.php
@@ -115,7 +115,7 @@ test('login page shows team invitation alert', function () {
 
     visit(route('login', ['invitation' => $invitation->code]))
         ->assertVisible('@team-invitation-alert')
-        ->assertSee('Log in to join the "Login Alert Team" Team.')
+        ->assertSee('Log in to join the "Login Alert Team" team.')
         ->assertNoConsoleLogs()
         ->assertNoJavaScriptErrors();
 });
@@ -134,7 +134,7 @@ test('register page preserves team invitation alert from login', function () {
     visit(route('login', ['invitation' => $invitation->code]))
         ->click('@register-link')
         ->assertVisible('@team-invitation-alert')
-        ->assertSee('Register to join the "Register Alert Team" Team.')
+        ->assertSee('Register to join the "Register Alert Team" team.')
         ->assertNoConsoleLogs()
         ->assertNoJavaScriptErrors();
 });

--- a/kits/Inertia/Teams/Fortify/React/resources/js/components/team-invitation-alert.tsx
+++ b/kits/Inertia/Teams/Fortify/React/resources/js/components/team-invitation-alert.tsx
@@ -15,7 +15,7 @@ export default function TeamInvitationAlert({ invitation, action }: Props) {
         >
             <InfoIcon />
             <AlertDescription className="text-blue-900 dark:text-blue-100">
-                {action} to join the "{invitation.teamName}" Team.
+                {action} to join the "{invitation.teamName}" team.
             </AlertDescription>
         </Alert>
     );

--- a/kits/Inertia/Teams/Fortify/Svelte/resources/js/components/TeamInvitationAlert.svelte
+++ b/kits/Inertia/Teams/Fortify/Svelte/resources/js/components/TeamInvitationAlert.svelte
@@ -18,7 +18,7 @@
     >
         <Info class="size-4" />
         <AlertDescription class="text-blue-900 dark:text-blue-100">
-            {action} to join the "{invitation.teamName}" Team.
+            {action} to join the "{invitation.teamName}" team.
         </AlertDescription>
     </Alert>
 </div>

--- a/kits/Inertia/Teams/Fortify/Vue/resources/js/components/TeamInvitationAlert.vue
+++ b/kits/Inertia/Teams/Fortify/Vue/resources/js/components/TeamInvitationAlert.vue
@@ -18,7 +18,7 @@ defineProps<Props>();
         >
             <Info class="size-4" />
             <AlertDescription class="text-blue-900 dark:text-blue-100">
-                {{ action }} to join the "{{ invitation.teamName }}" Team.
+                {{ action }} to join the "{{ invitation.teamName }}" team.
             </AlertDescription>
         </Alert>
     </div>

--- a/kits/Livewire/Teams/Fortify/resources/views/components/team-invitation-alert.blade.php
+++ b/kits/Livewire/Teams/Fortify/resources/views/components/team-invitation-alert.blade.php
@@ -8,7 +8,7 @@
         <flux:icon name="information-circle" class="mt-0.5 size-4 shrink-0 text-blue-600 dark:text-blue-400" />
 
         <div>
-            {{ __(':action to join the ":team" Team.', ['action' => $action, 'team' => $invitation['teamName']]) }}
+            {{ __(':action to join the ":team" team.', ['action' => $action, 'team' => $invitation['teamName']]) }}
         </div>
     </div>
 </div>


### PR DESCRIPTION
The team invitation alert currently capitalizes "Team" as a generic noun, which reads awkwardly in login and registration flows.

This updates the alert copy across Livewire, React, Svelte, and Vue Teams kits to use lowercase "team", and adjusts the Teams browser test expectations to match.