### PR TITLE
Add leave team button to teams kits

### DIFF
--- a/browser_tests/teams/tests/Browser/Teams/TeamsListTest.php
+++ b/browser_tests/teams/tests/Browser/Teams/TeamsListTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\User;
 
@@ -61,6 +62,49 @@ test('new team appears in team switcher after creation', function () {
         ->assertSee('Team created.')
         ->click('@team-switcher-trigger')
         ->assertSee('New Switcher Team')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});
+
+test('members can leave a non-personal team from teams list', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create(['name' => 'Leave Browser Team']);
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+    $member->switchTeam($team);
+
+    actingAs($member);
+
+    visit(route('teams.index'))
+        ->assertSee('Leave Browser Team')
+        ->assertVisible('@team-leave-button')
+        ->click('@team-leave-button')
+        ->waitForText('Leave team')
+        ->assertVisible('@leave-team-confirm')
+        ->pressAndWaitFor('@leave-team-confirm')
+        ->assertPathEndsWith('/settings/teams')
+        ->assertDontSee('Leave Browser Team')
+        ->assertSee('You left the team "Leave Browser Team"')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+
+    expect($member->fresh()->belongsToTeam($team))->toBeFalse();
+});
+
+test('leave action is not available for personal or owned teams', function () {
+    $user = User::factory()->create();
+    $ownedTeam = Team::factory()->create(['name' => 'Owned Browser Team']);
+
+    $ownedTeam->members()->attach($user, ['role' => TeamRole::Owner->value]);
+
+    actingAs($user);
+
+    visit(route('teams.index'))
+        ->assertSee($user->personalTeam()->name)
+        ->assertSee('Owned Browser Team')
+        ->assertMissing('@team-leave-button')
         ->assertNoConsoleLogs()
         ->assertNoJavaScriptErrors();
 });

--- a/browser_tests/teams/tests/Browser/Teams/TeamsListTest.php
+++ b/browser_tests/teams/tests/Browser/Teams/TeamsListTest.php
@@ -85,8 +85,8 @@ test('members can leave a non-personal team from teams list', function () {
         ->assertVisible('@leave-team-confirm')
         ->pressAndWaitFor('@leave-team-confirm')
         ->assertPathEndsWith('/settings/teams')
-        ->assertDontSee('Leave Browser Team')
-        ->assertSee('You left the team "Leave Browser Team"')
+        ->waitForText('You left the team "Leave Browser Team"')
+        ->assertMissing('@team-leave-button')
         ->assertNoConsoleLogs()
         ->assertNoJavaScriptErrors();
 

--- a/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamController.php
+++ b/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamController.php
@@ -125,6 +125,7 @@ class TeamController extends Controller
         Gate::authorize('leave', $team);
 
         $user = $request->user();
+
         $fallbackTeam = $user->isCurrentTeam($team)
             ? $user->fallbackTeam($team)
             : null;

--- a/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamController.php
+++ b/kits/Inertia/Teams/Base/app/Http/Controllers/Teams/TeamController.php
@@ -118,6 +118,31 @@ class TeamController extends Controller
     }
 
     /**
+     * Leave the specified team.
+     */
+    public function leave(Request $request, Team $team): RedirectResponse
+    {
+        Gate::authorize('leave', $team);
+
+        $user = $request->user();
+        $fallbackTeam = $user->isCurrentTeam($team)
+            ? $user->fallbackTeam($team)
+            : null;
+
+        $team->memberships()
+            ->where('user_id', $user->id)
+            ->delete();
+
+        if ($fallbackTeam) {
+            $user->switchTeam($fallbackTeam);
+        }
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('You left the team ":name"', ['name' => $team->name])]);
+
+        return to_route('teams.index');
+    }
+
+    /**
      * Delete the specified team.
      */
     public function destroy(DeleteTeamRequest $request, Team $team): RedirectResponse

--- a/kits/Inertia/Teams/Base/tests/Feature/Teams/TeamTest.php
+++ b/kits/Inertia/Teams/Base/tests/Feature/Teams/TeamTest.php
@@ -240,6 +240,94 @@ class TeamTest extends TestCase
         $this->assertEquals($personalTeam->id, $user->fresh()->current_team_id);
     }
 
+    public function test_members_can_leave_non_personal_teams()
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+        $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+        $response = $this
+            ->actingAs($member)
+            ->delete(route('teams.leave', $team));
+
+        $response->assertRedirect(route('teams.index'));
+        $response->assertInertiaFlash('toast', ['type' => 'success', 'message' => "You left the team \"{$team->name}\""]);
+
+        $this->assertFalse($member->fresh()->belongsToTeam($team));
+    }
+
+    public function test_leaving_current_team_switches_to_alphabetically_first_remaining_team()
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create();
+
+        $zuluTeam = Team::factory()->create(['name' => 'Zulu Team']);
+        $zuluTeam->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+        $zuluTeam->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+        $alphaTeam = Team::factory()->create(['name' => 'Alpha Team']);
+        $alphaTeam->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+        $betaTeam = Team::factory()->create(['name' => 'Beta Team']);
+        $betaTeam->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+        $member->update(['current_team_id' => $zuluTeam->id]);
+
+        $response = $this
+            ->actingAs($member)
+            ->delete(route('teams.leave', $zuluTeam));
+
+        $response->assertRedirect(route('teams.index'));
+
+        $this->assertFalse($member->fresh()->belongsToTeam($zuluTeam));
+        $this->assertEquals($alphaTeam->id, $member->fresh()->current_team_id);
+    }
+
+    public function test_personal_teams_cannot_be_left()
+    {
+        $user = User::factory()->create();
+        $personalTeam = $user->personalTeam();
+
+        $response = $this
+            ->actingAs($user)
+            ->delete(route('teams.leave', $personalTeam));
+
+        $response->assertForbidden();
+
+        $this->assertTrue($user->fresh()->belongsToTeam($personalTeam));
+    }
+
+    public function test_team_owners_cannot_leave_their_team()
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $response = $this
+            ->actingAs($owner)
+            ->delete(route('teams.leave', $team));
+
+        $response->assertForbidden();
+
+        $this->assertTrue($owner->fresh()->belongsToTeam($team));
+    }
+
+    public function test_users_cannot_leave_teams_they_dont_belong_to()
+    {
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->delete(route('teams.leave', $team));
+
+        $response->assertForbidden();
+    }
+
     public function test_deleting_team_switches_other_affected_users_to_their_personal_team()
     {
         $owner = User::factory()->create();

--- a/kits/Inertia/Teams/Base/tests/Feature/Teams/TeamTest.php
+++ b/kits/Inertia/Teams/Base/tests/Feature/Teams/TeamTest.php
@@ -262,7 +262,7 @@ class TeamTest extends TestCase
     public function test_leaving_current_team_switches_to_alphabetically_first_remaining_team()
     {
         $owner = User::factory()->create();
-        $member = User::factory()->create();
+        $member = User::factory()->create(['name' => 'Mike']);
 
         $zuluTeam = Team::factory()->create(['name' => 'Zulu Team']);
         $zuluTeam->members()->attach($owner, ['role' => TeamRole::Owner->value]);

--- a/kits/Inertia/Teams/Fortify/Base/routes/settings.php
+++ b/kits/Inertia/Teams/Fortify/Base/routes/settings.php
@@ -41,6 +41,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::patch('settings/teams/{team}', [TeamController::class, 'update'])->name('teams.update');
         Route::delete('settings/teams/{team}', [TeamController::class, 'destroy'])->name('teams.destroy');
         Route::post('settings/teams/{team}/switch', [TeamController::class, 'switch'])->name('teams.switch');
+        Route::delete('settings/teams/{team}/leave', [TeamController::class, 'leave'])->name('teams.leave');
 
         Route::patch('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->name('teams.members.update');
         Route::delete('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->name('teams.members.destroy');

--- a/kits/Inertia/Teams/React/resources/js/components/leave-team-modal.tsx
+++ b/kits/Inertia/Teams/React/resources/js/components/leave-team-modal.tsx
@@ -1,0 +1,65 @@
+import { router } from '@inertiajs/react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { leave as leaveTeamAction } from '@/routes/teams';
+import type { Team } from '@/types';
+
+type Props = {
+    team: Team | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+};
+
+export default function LeaveTeamModal({ team, open, onOpenChange }: Props) {
+    const [processing, setProcessing] = useState(false);
+
+    const leaveTeam = () => {
+        if (!team) {
+            return;
+        }
+
+        router.visit(leaveTeamAction(team.slug), {
+            onStart: () => setProcessing(true),
+            onFinish: () => setProcessing(false),
+            onSuccess: () => onOpenChange(false),
+        });
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Leave team</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to leave{' '}
+                        <strong>{team?.name}</strong>?
+                    </DialogDescription>
+                </DialogHeader>
+
+                <DialogFooter className="gap-2">
+                    <DialogClose asChild>
+                        <Button variant="secondary">Cancel</Button>
+                    </DialogClose>
+
+                    <Button
+                        variant="destructive"
+                        data-test="leave-team-confirm"
+                        disabled={processing}
+                        onClick={leaveTeam}
+                    >
+                        Leave team
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/kits/Inertia/Teams/React/resources/js/pages/teams/index.tsx
+++ b/kits/Inertia/Teams/React/resources/js/pages/teams/index.tsx
@@ -1,7 +1,9 @@
 import { Head, Link } from '@inertiajs/react';
-import { Eye, Pencil, Plus } from 'lucide-react';
+import { Eye, LogOut, Pencil, Plus } from 'lucide-react';
+import { useState } from 'react';
 import CreateTeamModal from '@/components/create-team-modal';
 import Heading from '@/components/heading';
+import LeaveTeamModal from '@/components/leave-team-modal';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -18,6 +20,14 @@ type Props = {
 };
 
 export default function TeamsIndex({ teams }: Props) {
+    const [leaveTeamDialogOpen, setLeaveTeamDialogOpen] = useState(false);
+    const [teamLeaving, setTeamLeaving] = useState<Team | null>(null);
+
+    const openLeaveTeamDialog = (team: Team) => {
+        setTeamLeaving(team);
+        setLeaveTeamDialogOpen(true);
+    };
+
     return (
         <>
             <Head title="Teams" />
@@ -40,77 +50,108 @@ export default function TeamsIndex({ teams }: Props) {
                 </div>
 
                 <div className="space-y-3">
-                    {teams.map((team) => (
-                        <div
-                            key={team.id}
-                            data-test="team-row"
-                            className="flex items-center justify-between rounded-lg border p-4"
-                        >
-                            <div className="flex items-center gap-4">
-                                <div>
-                                    <div className="flex items-center gap-2">
-                                        <span className="font-medium">
-                                            {team.name}
-                                        </span>
-                                        {team.isPersonal ? (
-                                            <Badge variant="secondary">
-                                                Personal
-                                            </Badge>
-                                        ) : null}
-                                    </div>
-                                    <span className="text-sm text-muted-foreground">
-                                        {team.roleLabel}
-                                    </span>
-                                </div>
-                            </div>
+                    {teams.map((team) => {
+                        const canLeaveTeam =
+                            !team.isPersonal && team.role !== 'owner';
 
-                            <TooltipProvider>
-                                <div className="flex items-center gap-2">
-                                    {team.role === 'member' ? (
-                                        <Tooltip>
-                                            <TooltipTrigger asChild>
-                                                <Button
-                                                    variant="ghost"
-                                                    size="sm"
-                                                    data-test="team-view-button"
-                                                    asChild
-                                                >
-                                                    <Link
-                                                        href={edit(team.slug)}
-                                                    >
-                                                        <Eye className="h-4 w-4" />
-                                                    </Link>
-                                                </Button>
-                                            </TooltipTrigger>
-                                            <TooltipContent>
-                                                <p>View team</p>
-                                            </TooltipContent>
-                                        </Tooltip>
-                                    ) : (
-                                        <Tooltip>
-                                            <TooltipTrigger asChild>
-                                                <Button
-                                                    variant="ghost"
-                                                    size="sm"
-                                                    data-test="team-edit-button"
-                                                    asChild
-                                                >
-                                                    <Link
-                                                        href={edit(team.slug)}
-                                                    >
-                                                        <Pencil className="h-4 w-4" />
-                                                    </Link>
-                                                </Button>
-                                            </TooltipTrigger>
-                                            <TooltipContent>
-                                                <p>Edit team</p>
-                                            </TooltipContent>
-                                        </Tooltip>
-                                    )}
+                        return (
+                            <div
+                                key={team.id}
+                                data-test="team-row"
+                                className="flex items-center justify-between gap-4 rounded-lg border p-4"
+                            >
+                                <div className="flex items-center gap-4">
+                                    <div>
+                                        <div className="flex items-center gap-2">
+                                            <span className="font-medium">
+                                                {team.name}
+                                            </span>
+                                            {team.isPersonal ? (
+                                                <Badge variant="secondary">
+                                                    Personal
+                                                </Badge>
+                                            ) : null}
+                                        </div>
+                                        <span className="text-sm text-muted-foreground">
+                                            {team.roleLabel}
+                                        </span>
+                                    </div>
                                 </div>
-                            </TooltipProvider>
-                        </div>
-                    ))}
+
+                                <TooltipProvider>
+                                    <div className="flex items-center gap-2">
+                                        {canLeaveTeam ? (
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        data-test="team-leave-button"
+                                                        onClick={() =>
+                                                            openLeaveTeamDialog(
+                                                                team,
+                                                            )
+                                                        }
+                                                    >
+                                                        <LogOut className="h-4 w-4" />
+                                                    </Button>
+                                                </TooltipTrigger>
+                                                <TooltipContent>
+                                                    <p>Leave team</p>
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        ) : null}
+
+                                        {team.role === 'member' ? (
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        data-test="team-view-button"
+                                                        asChild
+                                                    >
+                                                        <Link
+                                                            href={edit(
+                                                                team.slug,
+                                                            )}
+                                                        >
+                                                            <Eye className="h-4 w-4" />
+                                                        </Link>
+                                                    </Button>
+                                                </TooltipTrigger>
+                                                <TooltipContent>
+                                                    <p>View team</p>
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        ) : (
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        data-test="team-edit-button"
+                                                        asChild
+                                                    >
+                                                        <Link
+                                                            href={edit(
+                                                                team.slug,
+                                                            )}
+                                                        >
+                                                            <Pencil className="h-4 w-4" />
+                                                        </Link>
+                                                    </Button>
+                                                </TooltipTrigger>
+                                                <TooltipContent>
+                                                    <p>Edit team</p>
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        )}
+                                    </div>
+                                </TooltipProvider>
+                            </div>
+                        );
+                    })}
 
                     {teams.length === 0 ? (
                         <p className="py-8 text-center text-muted-foreground">
@@ -119,6 +160,12 @@ export default function TeamsIndex({ teams }: Props) {
                     ) : null}
                 </div>
             </div>
+
+            <LeaveTeamModal
+                team={teamLeaving}
+                open={leaveTeamDialogOpen}
+                onOpenChange={setLeaveTeamDialogOpen}
+            />
         </>
     );
 }

--- a/kits/Inertia/Teams/Svelte/resources/js/components/LeaveTeamModal.svelte
+++ b/kits/Inertia/Teams/Svelte/resources/js/components/LeaveTeamModal.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+    import { router } from '@inertiajs/svelte';
+    import { Button } from '@/components/ui/button';
+    import {
+        Dialog,
+        DialogClose,
+        DialogContent,
+        DialogDescription,
+        DialogFooter,
+        DialogTitle,
+    } from '@/components/ui/dialog';
+    import { leave as leaveTeamAction } from '@/routes/teams';
+    import type { Team } from '@/types';
+
+    let {
+        team,
+        open = $bindable(),
+    }: {
+        team: Team | null;
+        open: boolean;
+    } = $props();
+
+    let processing = $state(false);
+
+    const leaveTeam = () => {
+        if (!team) {
+            return;
+        }
+
+        router.visit(leaveTeamAction(team.slug), {
+            onStart: () => (processing = true),
+            onFinish: () => (processing = false),
+            onSuccess: () => {
+                open = false;
+            },
+        });
+    };
+</script>
+
+<Dialog bind:open>
+    <DialogContent>
+        <div class="space-y-3">
+            <DialogTitle>Leave team</DialogTitle>
+            <DialogDescription>
+                Are you sure you want to leave <strong>{team?.name}</strong>?
+            </DialogDescription>
+        </div>
+
+        <DialogFooter class="gap-2">
+            <DialogClose>
+                <Button variant="secondary">Cancel</Button>
+            </DialogClose>
+
+            <Button
+                variant="destructive"
+                disabled={processing}
+                onclick={leaveTeam}
+                data-test="leave-team-confirm">Leave team</Button
+            >
+        </DialogFooter>
+    </DialogContent>
+</Dialog>

--- a/kits/Inertia/Teams/Svelte/resources/js/pages/teams/Index.svelte
+++ b/kits/Inertia/Teams/Svelte/resources/js/pages/teams/Index.svelte
@@ -14,11 +14,13 @@
 <script lang="ts">
     import { Link } from '@inertiajs/svelte';
     import Eye from 'lucide-svelte/icons/eye';
+    import LogOut from 'lucide-svelte/icons/log-out';
     import Pencil from 'lucide-svelte/icons/pencil';
     import Plus from 'lucide-svelte/icons/plus';
     import AppHead from '@/components/AppHead.svelte';
     import CreateTeamModal from '@/components/CreateTeamModal.svelte';
     import Heading from '@/components/Heading.svelte';
+    import LeaveTeamModal from '@/components/LeaveTeamModal.svelte';
     import { Badge } from '@/components/ui/badge';
     import { Button } from '@/components/ui/button';
     import {
@@ -36,6 +38,9 @@
         teams: Team[];
     } = $props();
 
+    let leaveTeamDialogOpen = $state(false);
+    let teamLeaving = $state<Team | null>(null);
+
     const callClickHandler = (handler: unknown, event: MouseEvent) => {
         if (typeof handler === 'function') {
             handler(event);
@@ -47,6 +52,11 @@
         event: MouseEvent,
     ) => {
         callClickHandler(props.onClick, event);
+    };
+
+    const openLeaveTeamDialog = (team: Team) => {
+        teamLeaving = team;
+        leaveTeamDialogOpen = true;
     };
 </script>
 
@@ -77,7 +87,7 @@
     <div class="space-y-3">
         {#each teams as team (team.id)}
             <div
-                class="flex items-center justify-between rounded-lg border p-4"
+                class="flex items-center justify-between gap-4 rounded-lg border p-4"
                 data-test="team-row"
             >
                 <div class="flex items-center gap-4">
@@ -98,6 +108,28 @@
 
                 <TooltipProvider delayDuration={0}>
                     <div class="flex items-center gap-2">
+                        {#if !team.isPersonal && team.role !== 'owner'}
+                            <Tooltip>
+                                <TooltipTrigger>
+                                    {#snippet child({ props })}
+                                        <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            {...props}
+                                            onclick={() =>
+                                                openLeaveTeamDialog(team)}
+                                            data-test="team-leave-button"
+                                        >
+                                            <LogOut class="h-4 w-4" />
+                                        </Button>
+                                    {/snippet}
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    <p>Leave team</p>
+                                </TooltipContent>
+                            </Tooltip>
+                        {/if}
+
                         {#if team.role === 'member'}
                             <Tooltip>
                                 <TooltipTrigger>
@@ -163,3 +195,5 @@
         {/if}
     </div>
 </div>
+
+<LeaveTeamModal bind:open={leaveTeamDialogOpen} team={teamLeaving} />

--- a/kits/Inertia/Teams/Vue/resources/js/components/LeaveTeamModal.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/components/LeaveTeamModal.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3';
+import { ref } from 'vue';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { leave as leaveTeamAction } from '@/routes/teams';
+import type { Team } from '@/types';
+
+type Props = {
+    team: Team | null;
+    open: boolean;
+};
+
+const props = defineProps<Props>();
+const emit = defineEmits<{
+    'update:open': [value: boolean];
+}>();
+
+const processing = ref(false);
+
+const leaveTeam = () => {
+    if (!props.team) {
+        return;
+    }
+
+    router.visit(leaveTeamAction(props.team.slug), {
+        onStart: () => (processing.value = true),
+        onFinish: () => (processing.value = false),
+        onSuccess: () => emit('update:open', false),
+    });
+};
+</script>
+
+<template>
+    <Dialog :open="props.open" @update:open="emit('update:open', $event)">
+        <DialogContent>
+            <DialogHeader>
+                <DialogTitle>Leave team</DialogTitle>
+                <DialogDescription>
+                    Are you sure you want to leave
+                    <strong>{{ props.team?.name }}</strong
+                    >?
+                </DialogDescription>
+            </DialogHeader>
+
+            <DialogFooter class="gap-2">
+                <DialogClose as-child>
+                    <Button variant="secondary"> Cancel </Button>
+                </DialogClose>
+
+                <Button
+                    data-test="leave-team-confirm"
+                    variant="destructive"
+                    :disabled="processing"
+                    @click="leaveTeam"
+                >
+                    Leave team
+                </Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/kits/Inertia/Teams/Vue/resources/js/pages/teams/Index.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/pages/teams/Index.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { Head, Link } from '@inertiajs/vue3';
-import { Eye, Pencil, Plus } from '@lucide/vue';
+import { Eye, LogOut, Pencil, Plus } from '@lucide/vue';
+import { ref } from 'vue';
 import CreateTeamModal from '@/components/CreateTeamModal.vue';
 import Heading from '@/components/Heading.vue';
+import LeaveTeamModal from '@/components/LeaveTeamModal.vue';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -19,6 +21,16 @@ type Props = {
 };
 
 defineProps<Props>();
+
+const leaveTeamDialogOpen = ref(false);
+const teamLeaving = ref<Team | null>(null);
+
+const canLeaveTeam = (team: Team) => !team.isPersonal && team.role !== 'owner';
+
+const openLeaveTeamDialog = (team: Team) => {
+    teamLeaving.value = team;
+    leaveTeamDialogOpen.value = true;
+};
 
 defineOptions({
     layout: {
@@ -57,7 +69,7 @@ defineOptions({
                 v-for="team in teams"
                 :key="team.id"
                 data-test="team-row"
-                class="flex items-center justify-between rounded-lg border p-4"
+                class="flex items-center justify-between gap-4 rounded-lg border p-4"
             >
                 <div class="flex items-center gap-4">
                     <div>
@@ -75,6 +87,22 @@ defineOptions({
 
                 <TooltipProvider>
                     <div class="flex items-center gap-2">
+                        <Tooltip v-if="canLeaveTeam(team)">
+                            <TooltipTrigger as-child>
+                                <Button
+                                    data-test="team-leave-button"
+                                    variant="ghost"
+                                    size="sm"
+                                    @click="openLeaveTeamDialog(team)"
+                                >
+                                    <LogOut class="h-4 w-4" />
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                <p>Leave team</p>
+                            </TooltipContent>
+                        </Tooltip>
+
                         <Tooltip v-if="team.role === 'member'">
                             <TooltipTrigger as-child>
                                 <Button
@@ -122,4 +150,6 @@ defineOptions({
             </p>
         </div>
     </div>
+
+    <LeaveTeamModal v-model:open="leaveTeamDialogOpen" :team="teamLeaving" />
 </template>

--- a/kits/Inertia/Teams/WorkOS/Base/routes/settings.php
+++ b/kits/Inertia/Teams/WorkOS/Base/routes/settings.php
@@ -28,6 +28,7 @@ Route::middleware([
         Route::patch('settings/teams/{team}', [TeamController::class, 'update'])->name('teams.update');
         Route::delete('settings/teams/{team}', [TeamController::class, 'destroy'])->name('teams.destroy');
         Route::post('settings/teams/{team}/switch', [TeamController::class, 'switch'])->name('teams.switch');
+        Route::delete('settings/teams/{team}/leave', [TeamController::class, 'leave'])->name('teams.leave');
 
         Route::patch('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->name('teams.members.update');
         Route::delete('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->name('teams.members.destroy');

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/index.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/index.blade.php
@@ -2,10 +2,12 @@
 
 use App\Actions\Teams\CreateTeam;
 use App\Data\UserTeam;
+use App\Models\Team;
 use App\Rules\TeamName;
 use Flux\Flux;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Title;
 use Livewire\Component;
@@ -28,6 +30,32 @@ new #[Title('Teams')] class extends Component {
         Flux::toast(variant: 'success', text: __('Team created.'));
 
         $this->redirectRoute('teams.edit', ['team' => $team->slug], navigate: true);
+    }
+
+    public function leaveTeam(int $teamId): void
+    {
+        $team = Team::findOrFail($teamId);
+        $user = Auth::user();
+
+        Gate::authorize('leave', $team);
+
+        $fallbackTeam = $user->isCurrentTeam($team)
+            ? $user->fallbackTeam($team)
+            : null;
+
+        $team->memberships()
+            ->where('user_id', $user->id)
+            ->delete();
+
+        if ($fallbackTeam) {
+            $user->switchTeam($fallbackTeam);
+        }
+
+        $this->dispatch('close-modal', name: "leave-team-{$teamId}");
+
+        Flux::toast(variant: 'success', text: __('You left the team ":name"', ['name' => $team->name]));
+
+        $this->redirectRoute('teams.index', navigate: true);
     }
 
     /**
@@ -56,7 +84,7 @@ new #[Title('Teams')] class extends Component {
 
         <div class="mt-6 space-y-3">
             @forelse ($this->teams as $team)
-                <div class="flex items-center justify-between rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900" data-test="team-row">
+                <div class="flex items-center justify-between gap-4 rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900" data-test="team-row">
                     <div class="flex items-center gap-4">
                         <div>
                             <div class="flex items-center gap-2">
@@ -70,6 +98,21 @@ new #[Title('Teams')] class extends Component {
                     </div>
 
                     <div class="flex items-center gap-1">
+                        @if (! $team->isPersonal && $team->role !== 'owner')
+                            <flux:modal.trigger :name="'leave-team-'.$team->id">
+                                <flux:tooltip :content="__('Leave team')">
+                                    <flux:button
+                                        variant="ghost"
+                                        size="sm"
+                                        icon="arrow-right-start-on-rectangle"
+                                        x-data=""
+                                        x-on:click.prevent="$dispatch('open-modal', 'leave-team-{{ $team->id }}')"
+                                        data-test="team-leave-button"
+                                    />
+                                </flux:tooltip>
+                            </flux:modal.trigger>
+                        @endif
+
                         <flux:tooltip :content="$team->role === 'member' ? __('View team') : __('Edit team')">
                             <flux:button
                                 variant="ghost"
@@ -82,6 +125,29 @@ new #[Title('Teams')] class extends Component {
                         </flux:tooltip>
                     </div>
                 </div>
+
+                @if (! $team->isPersonal && $team->role !== 'owner')
+                    <flux:modal :name="'leave-team-'.$team->id" focusable class="max-w-lg">
+                        <form wire:submit="leaveTeam({{ $team->id }})" class="space-y-6">
+                            <div>
+                                <flux:heading size="lg">{{ __('Leave team') }}</flux:heading>
+                                <flux:subheading>
+                                    {{ __('Are you sure you want to leave :name?', ['name' => $team->name]) }}
+                                </flux:subheading>
+                            </div>
+
+                            <div class="flex justify-end space-x-2 rtl:space-x-reverse">
+                                <flux:modal.close>
+                                    <flux:button variant="filled">{{ __('Cancel') }}</flux:button>
+                                </flux:modal.close>
+
+                                <flux:button variant="danger" type="submit" data-test="leave-team-confirm">
+                                    {{ __('Leave team') }}
+                                </flux:button>
+                            </div>
+                        </form>
+                    </flux:modal>
+                @endif
             @empty
                 <flux:text class="py-8 text-center text-zinc-500 dark:text-zinc-400">
                     {{ __('You don\'t belong to any teams yet.') }}

--- a/kits/Livewire/Teams/Base/tests/Feature/Teams/TeamTest.php
+++ b/kits/Livewire/Teams/Base/tests/Feature/Teams/TeamTest.php
@@ -247,7 +247,7 @@ class TeamTest extends TestCase
     public function test_leaving_current_team_switches_to_alphabetically_first_remaining_team(): void
     {
         $owner = User::factory()->create();
-        $member = User::factory()->create();
+        $member = User::factory()->create(['name' => 'Mike']);
 
         $zuluTeam = Team::factory()->create(['name' => 'Zulu Team']);
         $zuluTeam->members()->attach($owner, ['role' => TeamRole::Owner->value]);

--- a/kits/Livewire/Teams/Base/tests/Feature/Teams/TeamTest.php
+++ b/kits/Livewire/Teams/Base/tests/Feature/Teams/TeamTest.php
@@ -226,6 +226,121 @@ class TeamTest extends TestCase
         $this->assertEquals($personalTeam->id, $user->fresh()->current_team_id);
     }
 
+    public function test_members_can_leave_non_personal_teams(): void
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+        $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+        $this->actingAs($member);
+
+        Livewire::test('pages::teams.index')
+            ->call('leaveTeam', $team->id)
+            ->assertHasNoErrors();
+
+        $this->assertFalse($member->fresh()->belongsToTeam($team));
+    }
+
+    public function test_leaving_current_team_switches_to_alphabetically_first_remaining_team(): void
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create();
+
+        $zuluTeam = Team::factory()->create(['name' => 'Zulu Team']);
+        $zuluTeam->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+        $zuluTeam->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+        $alphaTeam = Team::factory()->create(['name' => 'Alpha Team']);
+        $alphaTeam->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+        $betaTeam = Team::factory()->create(['name' => 'Beta Team']);
+        $betaTeam->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+        $member->update(['current_team_id' => $zuluTeam->id]);
+
+        $this->actingAs($member);
+
+        Livewire::test('pages::teams.index')
+            ->call('leaveTeam', $zuluTeam->id)
+            ->assertHasNoErrors();
+
+        $this->assertFalse($member->fresh()->belongsToTeam($zuluTeam));
+        $this->assertEquals($alphaTeam->id, $member->fresh()->current_team_id);
+    }
+
+    public function test_personal_teams_cannot_be_left(): void
+    {
+        $user = User::factory()->create();
+        $personalTeam = $user->personalTeam();
+
+        $this->actingAs($user);
+
+        Livewire::test('pages::teams.index')
+            ->call('leaveTeam', $personalTeam->id)
+            ->assertForbidden();
+
+        $this->assertTrue($user->fresh()->belongsToTeam($personalTeam));
+    }
+
+    public function test_team_owners_cannot_leave_their_team(): void
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create();
+
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+        $this->actingAs($owner);
+
+        Livewire::test('pages::teams.index')
+            ->call('leaveTeam', $team->id)
+            ->assertForbidden();
+
+        $this->assertTrue($owner->fresh()->belongsToTeam($team));
+    }
+
+    public function test_users_cannot_leave_teams_they_dont_belong_to(): void
+    {
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+
+        $this->actingAs($user);
+
+        Livewire::test('pages::teams.index')
+            ->call('leaveTeam', $team->id)
+            ->assertForbidden();
+    }
+
+    public function test_leave_control_is_only_rendered_for_leaveable_teams(): void
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create();
+        $leaveableTeam = Team::factory()->create();
+
+        $leaveableTeam->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+        $leaveableTeam->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+        $this->actingAs($member);
+
+        Livewire::test('pages::teams.index')
+            ->assertSeeHtml('data-test="team-leave-button"');
+    }
+
+    public function test_leave_control_is_not_rendered_for_personal_or_owned_teams(): void
+    {
+        $user = User::factory()->create();
+        $ownedTeam = Team::factory()->create();
+
+        $ownedTeam->members()->attach($user, ['role' => TeamRole::Owner->value]);
+
+        $this->actingAs($user);
+
+        Livewire::test('pages::teams.index')
+            ->assertDontSeeHtml('data-test="team-leave-button"');
+    }
+
     public function test_deleting_team_switches_other_affected_users_to_their_personal_team(): void
     {
         $owner = User::factory()->create();

--- a/kits/Shared/Teams/Base/app/Policies/TeamPolicy.php
+++ b/kits/Shared/Teams/Base/app/Policies/TeamPolicy.php
@@ -41,6 +41,16 @@ class TeamPolicy
     }
 
     /**
+     * Determine whether the user can leave the team.
+     */
+    public function leave(User $user, Team $team): bool
+    {
+        return ! $team->is_personal
+            && $user->belongsToTeam($team)
+            && ! $user->ownsTeam($team);
+    }
+
+    /**
      * Determine whether the user can add a member to the team.
      */
     public function addMember(User $user, Team $team): bool


### PR DESCRIPTION
This adds the ability for team members to leave non-personal teams directly from the teams list page. A confirmation modal is shown before leaving, and if the user is currently on the team they are leaving, they are automatically switched to their first remaining team.