### PR TITLE
Use Str::initials over custom methods

### DIFF
--- a/.agents/skills/maestro/SKILL.md
+++ b/.agents/skills/maestro/SKILL.md
@@ -306,9 +306,10 @@ Only Admin and Member roles are assignable. Owner is automatically set on team c
 1. **Build**: `cd orchestrator && php artisan build --kit=svelte`
 2. **Develop**: `composer kit:run` (starts dev server at localhost:8000 + watcher)
 3. **Edit**: If `build/` exists and the watcher is running, make changes in `build/` — the watcher syncs them to `kits/`. Otherwise, edit `kits/` directly.
-4. **Test**: Inside `build/`, run `composer setup && composer ci:check`
-5. **Commit**: Commit the changes in `kits/` (not `build/`)
-6. **PR**: Create PR; after merge, Maestro auto-creates PRs for affected kit repos
+4. **Stop `kit:run`**: Press Ctrl+C before running `kits:lint` or `kits:check` — running them while the watcher is active corrupts `kits/`.
+5. **Test**: `composer kits:pint` → `composer kits:lint` (Inertia only) → `composer kits:check`
+6. **Commit**: Commit the changes in `kits/` (not `build/`)
+7. **PR**: Create PR; after merge, Maestro auto-creates PRs for affected kit repos
 
 ## Browser Tests (Local CI Parity)
 
@@ -385,6 +386,7 @@ cd ..
 2. **Follow sibling patterns**: When creating a Svelte file, check the React and Vue equivalents for expected structure and behavior and vice-versa.
 3. **Layer awareness**: Know which layer a file belongs to. Shared files affect all kits. Framework-specific files only affect that framework. Teams layers sit on top of auth layers — place team-specific code in the appropriate `Teams/` directory.
 4. **Placeholder awareness**: Files in `kits/` contain `{{placeholders}}`. Files in `build/` have resolved values. The watcher handles conversion.
-5. **Lint changes**: Run `composer lint` in `orchestrator` for orchestrator PHP linting. Run `composer kits:pint` for fast PHP formatting of `kits/` and `browser_tests/`. Run `composer kits:lint` to run Pint then lint/format all Inertia variants and sync changes back to `kits/`.
-6. **Test after changes**: Run `composer setup && composer ci:check` inside `build/` to verify nothing is broken.
-7. **Teams layer placement**: When modifying teams code, choose the correct layer: `Shared/Teams/Base` for cross-stack logic (models, traits, middleware), `Shared/Teams/{Fortify|WorkOS}` for auth-variant-specific overrides, `Inertia/Teams/Base` or `Livewire/Teams/Base` for stack-specific backend, and `Inertia/Teams/{React|Svelte|Vue}` or `Livewire/Teams/{Fortify|WorkOS}` for frontend/variant-specific UI.
+5. **Lint/check while watcher is stopped**: `kits:lint` and `kits:check` both delete and rebuild `build/` for each variant. If `kit:run` is active, the watcher interprets those deletions as file removals and propagates them to `kits/`, corrupting the source. Always stop `kit:run` before running `kits:lint` or `kits:check`. `kits:pint` is safe to run at any time — it operates directly on `kits/` and never touches `build/`.
+6. **Lint changes**: Run `composer kits:pint` for fast PHP formatting of `kits/` and `browser_tests/`. Run `composer kits:lint` to run Pint then lint/format all Inertia variants and sync changes back to `kits/`.
+7. **Test after changes**: Run `composer setup && composer ci:check` inside `build/` to verify nothing is broken.
+8. **Teams layer placement**: When modifying teams code, choose the correct layer: `Shared/Teams/Base` for cross-stack logic (models, traits, middleware), `Shared/Teams/{Fortify|WorkOS}` for auth-variant-specific overrides, `Inertia/Teams/Base` or `Livewire/Teams/Base` for stack-specific backend, and `Inertia/Teams/{React|Svelte|Vue}` or `Livewire/Teams/{Fortify|WorkOS}` for frontend/variant-specific UI.

--- a/.claude/skills/maestro/SKILL.md
+++ b/.claude/skills/maestro/SKILL.md
@@ -306,9 +306,10 @@ Only Admin and Member roles are assignable. Owner is automatically set on team c
 1. **Build**: `cd orchestrator && php artisan build --kit=svelte`
 2. **Develop**: `composer kit:run` (starts dev server at localhost:8000 + watcher)
 3. **Edit**: If `build/` exists and the watcher is running, make changes in `build/` — the watcher syncs them to `kits/`. Otherwise, edit `kits/` directly.
-4. **Test**: Inside `build/`, run `composer setup && composer ci:check`
-5. **Commit**: Commit the changes in `kits/` (not `build/`)
-6. **PR**: Create PR; after merge, Maestro auto-creates PRs for affected kit repos
+4. **Stop `kit:run`**: Press Ctrl+C before running `kits:lint` or `kits:check` — running them while the watcher is active corrupts `kits/`.
+5. **Test**: `composer kits:pint` → `composer kits:lint` (Inertia only) → `composer kits:check`
+6. **Commit**: Commit the changes in `kits/` (not `build/`)
+7. **PR**: Create PR; after merge, Maestro auto-creates PRs for affected kit repos
 
 ## Browser Tests (Local CI Parity)
 
@@ -385,6 +386,7 @@ cd ..
 2. **Follow sibling patterns**: When creating a Svelte file, check the React and Vue equivalents for expected structure and behavior and vice-versa.
 3. **Layer awareness**: Know which layer a file belongs to. Shared files affect all kits. Framework-specific files only affect that framework. Teams layers sit on top of auth layers — place team-specific code in the appropriate `Teams/` directory.
 4. **Placeholder awareness**: Files in `kits/` contain `{{placeholders}}`. Files in `build/` have resolved values. The watcher handles conversion.
-5. **Lint changes**: Run `composer lint` in `orchestrator` for orchestrator PHP linting. Run `composer kits:pint` for fast PHP formatting of `kits/` and `browser_tests/`. Run `composer kits:lint` to run Pint then lint/format all Inertia variants and sync changes back to `kits/`.
-6. **Test after changes**: Run `composer setup && composer ci:check` inside `build/` to verify nothing is broken.
-7. **Teams layer placement**: When modifying teams code, choose the correct layer: `Shared/Teams/Base` for cross-stack logic (models, traits, middleware), `Shared/Teams/{Fortify|WorkOS}` for auth-variant-specific overrides, `Inertia/Teams/Base` or `Livewire/Teams/Base` for stack-specific backend, and `Inertia/Teams/{React|Svelte|Vue}` or `Livewire/Teams/{Fortify|WorkOS}` for frontend/variant-specific UI.
+5. **Lint/check while watcher is stopped**: `kits:lint` and `kits:check` both delete and rebuild `build/` for each variant. If `kit:run` is active, the watcher interprets those deletions as file removals and propagates them to `kits/`, corrupting the source. Always stop `kit:run` before running `kits:lint` or `kits:check`. `kits:pint` is safe to run at any time — it operates directly on `kits/` and never touches `build/`.
+6. **Lint changes**: Run `composer kits:pint` for fast PHP formatting of `kits/` and `browser_tests/`. Run `composer kits:lint` to run Pint then lint/format all Inertia variants and sync changes back to `kits/`.
+7. **Test after changes**: Run `composer setup && composer ci:check` inside `build/` to verify nothing is broken.
+8. **Teams layer placement**: When modifying teams code, choose the correct layer: `Shared/Teams/Base` for cross-stack logic (models, traits, middleware), `Shared/Teams/{Fortify|WorkOS}` for auth-variant-specific overrides, `Inertia/Teams/Base` or `Livewire/Teams/Base` for stack-specific backend, and `Inertia/Teams/{React|Svelte|Vue}` or `Livewire/Teams/{Fortify|WorkOS}` for frontend/variant-specific UI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Maestro is the monorepo orchestrator for the official Laravel starter kits. Use 
 - Lint: `composer kits:lint` (from `orchestrator/`) — runs `kits:pint`, then frontend lint/format for Inertia variants
 - Browser tests (all 8 kits): `composer kits:browser-tests` (from `orchestrator/`)
 - Edit in `build/` only if it exists and `composer kit:run` is running; otherwise edit `kits/` directly. Always commit in `kits/`.
+- **Stop `kit:run` before running `kits:lint` or `kits:check`** — running them while the watcher is active corrupts `kits/`. `kits:pint` is safe at any time.
 
 ### Selective Execution
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Maestro is the monorepo orchestrator for the official Laravel starter kits. Use 
 - Lint: `composer kits:lint` (from `orchestrator/`) — runs `kits:pint`, then frontend lint/format for Inertia variants
 - Browser tests (all 8 kits): `composer kits:browser-tests` (from `orchestrator/`)
 - Edit in `build/` only if it exists and `composer kit:run` is running; otherwise edit `kits/` directly. Always commit in `kits/`.
+- **Stop `kit:run` before running `kits:lint` or `kits:check`** — running them while the watcher is active corrupts `kits/`. `kits:pint` is safe at any time.
 
 ### Selective Execution
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ composer kits:lint
 
 This command runs Pint on `kits/` and `browser_tests/` first, then loops over all Inertia variants, builds each variant, runs frontend linting/formatting in `build` (`npm install`, then lint/format), and then runs `npm run watch:kits -- --initial-sync-only` to sync changes back to `kits`.
 
+> [!WARNING]
+> Stop `composer kit:run` before running `composer kits:lint` or `composer kits:check`. Those commands delete and rebuild `build/`, and the active watcher can sync those deletions back to `kits/`. `composer kits:pint` is safe to run while the watcher is active.
+
 To run only the Pint step without the frontend lint pass:
 
 ```bash

--- a/kits/Inertia/Blank/Svelte/svelte.config.js
+++ b/kits/Inertia/Blank/Svelte/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+    preprocess: vitePreprocess({ script: true }),
+};

--- a/kits/Inertia/React/resources/js/hooks/use-initials.tsx
+++ b/kits/Inertia/React/resources/js/hooks/use-initials.tsx
@@ -2,20 +2,24 @@ import { useCallback } from 'react';
 
 export type GetInitialsFn = (fullName: string) => string;
 
+function getInitial(name: string): string {
+    return Array.from(name)[0] ?? '';
+}
+
 export function useInitials(): GetInitialsFn {
     return useCallback((fullName: string): string => {
-        const names = fullName.trim().split(' ');
+        const names = fullName.trim().split(/\s+/u).filter(Boolean);
 
         if (names.length === 0) {
             return '';
         }
 
         if (names.length === 1) {
-            return names[0].charAt(0).toUpperCase();
+            return getInitial(names[0]).toUpperCase();
         }
 
-        const firstInitial = names[0].charAt(0);
-        const lastInitial = names[names.length - 1].charAt(0);
+        const firstInitial = getInitial(names[0]);
+        const lastInitial = getInitial(names[names.length - 1]);
 
         return `${firstInitial}${lastInitial}`.toUpperCase();
     }, []);

--- a/kits/Inertia/Svelte/resources/js/lib/initials.ts
+++ b/kits/Inertia/Svelte/resources/js/lib/initials.ts
@@ -2,22 +2,26 @@ export type InitialsApi = {
     getInitials: (fullName?: string) => string;
 };
 
+function getInitial(name: string): string {
+    return Array.from(name)[0] ?? '';
+}
+
 export function getInitials(fullName?: string): string {
     if (!fullName) {
         return '';
     }
 
-    const names = fullName.trim().split(' ');
+    const names = fullName.trim().split(/\s+/u).filter(Boolean);
 
     if (names.length === 0) {
         return '';
     }
 
     if (names.length === 1) {
-        return names[0].charAt(0).toUpperCase();
+        return getInitial(names[0]).toUpperCase();
     }
 
-    return `${names[0].charAt(0)}${names[names.length - 1].charAt(0)}`.toUpperCase();
+    return `${getInitial(names[0])}${getInitial(names[names.length - 1])}`.toUpperCase();
 }
 
 export function initialsApi(): InitialsApi {

--- a/kits/Inertia/Vue/resources/js/composables/useInitials.ts
+++ b/kits/Inertia/Vue/resources/js/composables/useInitials.ts
@@ -2,22 +2,26 @@ export type UseInitialsReturn = {
     getInitials: (fullName?: string) => string;
 };
 
+function getInitial(name: string): string {
+    return Array.from(name)[0] ?? '';
+}
+
 export function getInitials(fullName?: string): string {
     if (!fullName) {
         return '';
     }
 
-    const names = fullName.trim().split(' ');
+    const names = fullName.trim().split(/\s+/u).filter(Boolean);
 
     if (names.length === 0) {
         return '';
     }
 
     if (names.length === 1) {
-        return names[0].charAt(0).toUpperCase();
+        return getInitial(names[0]).toUpperCase();
     }
 
-    return `${names[0].charAt(0)}${names[names.length - 1].charAt(0)}`.toUpperCase();
+    return `${getInitial(names[0])}${getInitial(names[names.length - 1])}`.toUpperCase();
 }
 
 export function useInitials(): UseInitialsReturn {

--- a/kits/Livewire/Base/app/Models/User.php
+++ b/kits/Livewire/Base/app/Models/User.php
@@ -55,6 +55,6 @@ class User extends Authenticatable implements PasskeyUser
     {
         $initials = Str::initials($this->name);
 
-        return $initials[0] . $initials[-1];
+        return $initials[0].$initials[-1];
     }
 }

--- a/kits/Livewire/Base/app/Models/User.php
+++ b/kits/Livewire/Base/app/Models/User.php
@@ -55,6 +55,6 @@ class User extends Authenticatable implements PasskeyUser
     {
         $initials = Str::initials($this->name, true);
 
-        return $initials[0].$initials[-1];
+        return strlen($initials) > 1 ? $initials[0].$initials[-1] : $initials;
     }
 }

--- a/kits/Livewire/Base/app/Models/User.php
+++ b/kits/Livewire/Base/app/Models/User.php
@@ -53,7 +53,7 @@ class User extends Authenticatable implements PasskeyUser
      */
     public function initials(): string
     {
-        $initials = Str::initials($this->name);
+        $initials = Str::initials($this->name, true);
 
         return $initials[0].$initials[-1];
     }

--- a/kits/Livewire/Base/app/Models/User.php
+++ b/kits/Livewire/Base/app/Models/User.php
@@ -53,6 +53,8 @@ class User extends Authenticatable implements PasskeyUser
      */
     public function initials(): string
     {
-        return Str::initials($this->name);
+        $initials = Str::initials($this->name);
+
+        return $initials[0] . $initials[-1];
     }
 }

--- a/kits/Livewire/Base/app/Models/User.php
+++ b/kits/Livewire/Base/app/Models/User.php
@@ -53,10 +53,6 @@ class User extends Authenticatable implements PasskeyUser
      */
     public function initials(): string
     {
-        return Str::of($this->name)
-            ->explode(' ')
-            ->take(2)
-            ->map(fn ($word) => Str::substr($word, 0, 1))
-            ->implode('');
+        return Str::initials($this->name);
     }
 }

--- a/kits/Livewire/Base/app/Models/User.php
+++ b/kits/Livewire/Base/app/Models/User.php
@@ -55,6 +55,8 @@ class User extends Authenticatable implements PasskeyUser
     {
         $initials = Str::initials($this->name, true);
 
-        return strlen($initials) > 1 ? $initials[0].$initials[-1] : $initials;
+        return Str::length($initials) > 1
+            ? Str::substr($initials, 0, 1).Str::substr($initials, -1)
+            : $initials;
     }
 }

--- a/kits/Livewire/Blank/app/Models/User.php
+++ b/kits/Livewire/Blank/app/Models/User.php
@@ -49,6 +49,6 @@ class User extends Authenticatable
     {
         $initials = Str::initials($this->name);
 
-        return $initials[0] . $initials[-1];
+        return $initials[0].$initials[-1];
     }
 }

--- a/kits/Livewire/Blank/app/Models/User.php
+++ b/kits/Livewire/Blank/app/Models/User.php
@@ -47,7 +47,7 @@ class User extends Authenticatable
      */
     public function initials(): string
     {
-        $initials = Str::initials($this->name);
+        $initials = Str::initials($this->name, true);
 
         return $initials[0].$initials[-1];
     }

--- a/kits/Livewire/Blank/app/Models/User.php
+++ b/kits/Livewire/Blank/app/Models/User.php
@@ -49,6 +49,6 @@ class User extends Authenticatable
     {
         $initials = Str::initials($this->name, true);
 
-        return $initials[0].$initials[-1];
+        return strlen($initials) > 1 ? $initials[0].$initials[-1] : $initials;
     }
 }

--- a/kits/Livewire/Blank/app/Models/User.php
+++ b/kits/Livewire/Blank/app/Models/User.php
@@ -47,6 +47,8 @@ class User extends Authenticatable
      */
     public function initials(): string
     {
-        return Str::initials($this->name);
+        $initials = Str::initials($this->name);
+
+        return $initials[0] . $initials[-1];
     }
 }

--- a/kits/Livewire/Blank/app/Models/User.php
+++ b/kits/Livewire/Blank/app/Models/User.php
@@ -47,10 +47,6 @@ class User extends Authenticatable
      */
     public function initials(): string
     {
-        return Str::of($this->name)
-            ->explode(' ')
-            ->take(2)
-            ->map(fn ($word) => Str::substr($word, 0, 1))
-            ->implode('');
+        return Str::initials($this->name);
     }
 }

--- a/kits/Livewire/Blank/app/Models/User.php
+++ b/kits/Livewire/Blank/app/Models/User.php
@@ -49,6 +49,8 @@ class User extends Authenticatable
     {
         $initials = Str::initials($this->name, true);
 
-        return strlen($initials) > 1 ? $initials[0].$initials[-1] : $initials;
+        return Str::length($initials) > 1
+            ? Str::substr($initials, 0, 1).Str::substr($initials, -1)
+            : $initials;
     }
 }

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/edit.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/edit.blade.php
@@ -98,6 +98,7 @@ new class extends Component
             'name' => $member->name,
             'email' => $member->email,
             'avatar' => $member->avatar ?? null,
+            'initials' => $member->initials(),
             'role' => $member->pivot->role->value,
             'role_label' => $member->pivot->role->label(),
         ])->toArray();
@@ -183,7 +184,7 @@ new class extends Component
                     @foreach ($members as $member)
                         <div class="flex items-center justify-between rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900" data-test="member-row">
                             <div class="flex items-center gap-4">
-                                <flux:avatar :name="$member['name']" :initials="strtoupper(substr($member['name'], 0, 1))" />
+                                <flux:avatar :name="$member['name']" :initials="$member['initials']" />
                                 <div>
                                     <div class="font-medium">{{ $member['name'] }}</div>
                                     <flux:text class="text-sm text-zinc-500 dark:text-zinc-400">{{ $member['email'] }}</flux:text>

--- a/kits/Livewire/Teams/Fortify/app/Models/User.php
+++ b/kits/Livewire/Teams/Fortify/app/Models/User.php
@@ -63,6 +63,8 @@ class User extends Authenticatable implements PasskeyUser
      */
     public function initials(): string
     {
-        return Str::initials($this->name);
+        $initials = Str::initials($this->name);
+
+        return $initials[0] . $initials[-1];
     }
 }

--- a/kits/Livewire/Teams/Fortify/app/Models/User.php
+++ b/kits/Livewire/Teams/Fortify/app/Models/User.php
@@ -63,7 +63,7 @@ class User extends Authenticatable implements PasskeyUser
      */
     public function initials(): string
     {
-        $initials = Str::initials($this->name);
+        $initials = Str::initials($this->name, true);
 
         return $initials[0].$initials[-1];
     }

--- a/kits/Livewire/Teams/Fortify/app/Models/User.php
+++ b/kits/Livewire/Teams/Fortify/app/Models/User.php
@@ -63,10 +63,6 @@ class User extends Authenticatable implements PasskeyUser
      */
     public function initials(): string
     {
-        return Str::of($this->name)
-            ->explode(' ')
-            ->take(2)
-            ->map(fn ($word) => Str::substr($word, 0, 1))
-            ->implode('');
+        return Str::initials($this->name);
     }
 }

--- a/kits/Livewire/Teams/Fortify/app/Models/User.php
+++ b/kits/Livewire/Teams/Fortify/app/Models/User.php
@@ -65,6 +65,8 @@ class User extends Authenticatable implements PasskeyUser
     {
         $initials = Str::initials($this->name, true);
 
-        return strlen($initials) > 1 ? $initials[0].$initials[-1] : $initials;
+        return Str::length($initials) > 1
+            ? Str::substr($initials, 0, 1).Str::substr($initials, -1)
+            : $initials;
     }
 }

--- a/kits/Livewire/Teams/Fortify/app/Models/User.php
+++ b/kits/Livewire/Teams/Fortify/app/Models/User.php
@@ -65,6 +65,6 @@ class User extends Authenticatable implements PasskeyUser
     {
         $initials = Str::initials($this->name, true);
 
-        return $initials[0].$initials[-1];
+        return strlen($initials) > 1 ? $initials[0].$initials[-1] : $initials;
     }
 }

--- a/kits/Livewire/Teams/Fortify/app/Models/User.php
+++ b/kits/Livewire/Teams/Fortify/app/Models/User.php
@@ -65,6 +65,6 @@ class User extends Authenticatable implements PasskeyUser
     {
         $initials = Str::initials($this->name);
 
-        return $initials[0] . $initials[-1];
+        return $initials[0].$initials[-1];
     }
 }

--- a/kits/Livewire/Teams/WorkOS/app/Models/User.php
+++ b/kits/Livewire/Teams/WorkOS/app/Models/User.php
@@ -44,7 +44,7 @@ class User extends Authenticatable
     {
         $initials = Str::initials($this->name);
 
-        return $initials[0] . $initials[-1];
+        return $initials[0].$initials[-1];
     }
 
     /**

--- a/kits/Livewire/Teams/WorkOS/app/Models/User.php
+++ b/kits/Livewire/Teams/WorkOS/app/Models/User.php
@@ -42,7 +42,7 @@ class User extends Authenticatable
      */
     public function initials(): string
     {
-        $initials = Str::initials($this->name);
+        $initials = Str::initials($this->name, true);
 
         return $initials[0].$initials[-1];
     }

--- a/kits/Livewire/Teams/WorkOS/app/Models/User.php
+++ b/kits/Livewire/Teams/WorkOS/app/Models/User.php
@@ -44,7 +44,7 @@ class User extends Authenticatable
     {
         $initials = Str::initials($this->name, true);
 
-        return $initials[0].$initials[-1];
+        return strlen($initials) > 1 ? $initials[0].$initials[-1] : $initials;
     }
 
     /**

--- a/kits/Livewire/Teams/WorkOS/app/Models/User.php
+++ b/kits/Livewire/Teams/WorkOS/app/Models/User.php
@@ -42,7 +42,9 @@ class User extends Authenticatable
      */
     public function initials(): string
     {
-        return Str::initials($this->name);
+        $initials = Str::initials($this->name);
+
+        return $initials[0] . $initials[-1];
     }
 
     /**

--- a/kits/Livewire/Teams/WorkOS/app/Models/User.php
+++ b/kits/Livewire/Teams/WorkOS/app/Models/User.php
@@ -44,7 +44,9 @@ class User extends Authenticatable
     {
         $initials = Str::initials($this->name, true);
 
-        return strlen($initials) > 1 ? $initials[0].$initials[-1] : $initials;
+        return Str::length($initials) > 1
+            ? Str::substr($initials, 0, 1).Str::substr($initials, -1)
+            : $initials;
     }
 
     /**

--- a/kits/Livewire/Teams/WorkOS/app/Models/User.php
+++ b/kits/Livewire/Teams/WorkOS/app/Models/User.php
@@ -42,10 +42,7 @@ class User extends Authenticatable
      */
     public function initials(): string
     {
-        return Str::of($this->name)
-            ->explode(' ')
-            ->map(fn (string $name) => Str::of($name)->substr(0, 1))
-            ->implode('');
+        return Str::initials($this->name);
     }
 
     /**

--- a/kits/Livewire/WorkOS/app/Models/User.php
+++ b/kits/Livewire/WorkOS/app/Models/User.php
@@ -35,10 +35,7 @@ class User extends Authenticatable
      */
     public function initials(): string
     {
-        return Str::of($this->name)
-            ->explode(' ')
-            ->map(fn (string $name) => Str::of($name)->substr(0, 1))
-            ->implode('');
+        return Str::initials($this->name);
     }
 
     /**

--- a/kits/Livewire/WorkOS/app/Models/User.php
+++ b/kits/Livewire/WorkOS/app/Models/User.php
@@ -37,7 +37,7 @@ class User extends Authenticatable
     {
         $initials = Str::initials($this->name, true);
 
-        return $initials[0].$initials[-1];
+        return strlen($initials) > 1 ? $initials[0].$initials[-1] : $initials;
     }
 
     /**

--- a/kits/Livewire/WorkOS/app/Models/User.php
+++ b/kits/Livewire/WorkOS/app/Models/User.php
@@ -35,7 +35,7 @@ class User extends Authenticatable
      */
     public function initials(): string
     {
-        $initials = Str::initials($this->name);
+        $initials = Str::initials($this->name, true);
 
         return $initials[0].$initials[-1];
     }

--- a/kits/Livewire/WorkOS/app/Models/User.php
+++ b/kits/Livewire/WorkOS/app/Models/User.php
@@ -37,7 +37,9 @@ class User extends Authenticatable
     {
         $initials = Str::initials($this->name, true);
 
-        return strlen($initials) > 1 ? $initials[0].$initials[-1] : $initials;
+        return Str::length($initials) > 1
+            ? Str::substr($initials, 0, 1).Str::substr($initials, -1)
+            : $initials;
     }
 
     /**

--- a/kits/Livewire/WorkOS/app/Models/User.php
+++ b/kits/Livewire/WorkOS/app/Models/User.php
@@ -37,7 +37,7 @@ class User extends Authenticatable
     {
         $initials = Str::initials($this->name);
 
-        return $initials[0] . $initials[-1];
+        return $initials[0].$initials[-1];
     }
 
     /**

--- a/kits/Livewire/WorkOS/app/Models/User.php
+++ b/kits/Livewire/WorkOS/app/Models/User.php
@@ -35,7 +35,9 @@ class User extends Authenticatable
      */
     public function initials(): string
     {
-        return Str::initials($this->name);
+        $initials = Str::initials($this->name);
+
+        return $initials[0] . $initials[-1];
     }
 
     /**

--- a/orchestrator/scripts/browser-tests-kits.js
+++ b/orchestrator/scripts/browser-tests-kits.js
@@ -231,6 +231,7 @@ runMatrix({
     scriptLabel: 'kits:browser-tests',
     allVariants: variants,
     runVariant: browserTestVariant,
+    guardActiveWatcher: true,
 }).catch(error => {
     log(`\nBrowser tests failed: ${error.message}`, 'red');
     process.exit(1);

--- a/orchestrator/scripts/check-kits.js
+++ b/orchestrator/scripts/check-kits.js
@@ -186,6 +186,7 @@ runMatrix({
     scriptLabel: 'kits:check',
     allVariants: variants,
     runVariant: checkVariant,
+    guardActiveWatcher: true,
 }).catch(error => {
     log(`\nCheck kits failed: ${error.message}`, 'red');
     process.exit(1);

--- a/orchestrator/scripts/format-kits.js
+++ b/orchestrator/scripts/format-kits.js
@@ -141,4 +141,5 @@ await runMatrix({
     allVariants: variants,
     runVariant: formatVariant,
     successVerb: 'Formatted',
+    guardActiveWatcher: true,
 });

--- a/orchestrator/scripts/kit-helpers.js
+++ b/orchestrator/scripts/kit-helpers.js
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 
 /**
  * All recognized framework flags.
@@ -35,6 +35,8 @@ export const rootDir = path.dirname(orchestratorDir);
 export const buildDir = path.join(rootDir, 'build');
 export const kitsDir = path.join(rootDir, 'kits');
 export const browserTestsDir = path.join(rootDir, 'browser_tests');
+const realOrchestratorDir = fs.realpathSync(orchestratorDir);
+const watchScript = fs.realpathSync(path.join(orchestratorDir, 'scripts', 'watch.js'));
 
 /**
  * ANSI color codes for terminal output.
@@ -197,6 +199,78 @@ export function runInherit(command, args, options = {}) {
     });
 }
 
+function readProcessArgs(pid) {
+    try {
+        return fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8').split('\0').filter(Boolean);
+    } catch {
+        return [];
+    }
+}
+
+function readProcessCwd(pid) {
+    try {
+        return fs.realpathSync(`/proc/${pid}/cwd`);
+    } catch {
+        return null;
+    }
+}
+
+function isRepoWatcherProcess(pid) {
+    const cwd = readProcessCwd(pid);
+
+    if (cwd !== realOrchestratorDir) {
+        return false;
+    }
+
+    const args = readProcessArgs(pid);
+
+    if (args.includes('--initial-sync-only')) {
+        return false;
+    }
+
+    return args.some(arg => path.resolve(cwd, arg) === watchScript);
+}
+
+export function isWatcherRunning() {
+    const result = spawnSync('pgrep', ['-f', 'watch.js'], { encoding: 'utf8' });
+
+    if (result.error || result.status !== 0 || !result.stdout || result.stdout.trim().length === 0) {
+        return false;
+    }
+
+    return result.stdout
+        .trim()
+        .split('\n')
+        .some(pid => isRepoWatcherProcess(pid));
+}
+
+function watcherRunningMessage(scriptLabel) {
+    return `kit:run (watcher) is running. Stop it before running ${scriptLabel}.`;
+}
+
+export function ensureNoActiveWatcher({ scriptLabel, jsonMode, startedAt, selectedFrameworks = null, selectedVariants = null }) {
+    if (!isWatcherRunning()) {
+        return;
+    }
+
+    const error = new Error(watcherRunningMessage(scriptLabel));
+
+    if (jsonMode) {
+        writeJsonSummary(buildJsonSummary({
+            scriptLabel,
+            startedAt,
+            finishedAt: new Date(),
+            selectedFrameworks,
+            selectedVariants,
+            results: [{ key: 'watcher', display: 'Watcher check', status: 'failed', elapsed: 0, error }],
+        }));
+    } else {
+        log(`\n${error.message}`, 'red');
+    }
+
+    process.exit(1);
+}
+
 /**
  * Human-readable elapsed time.
  */
@@ -245,11 +319,13 @@ function normalizeResult(result) {
     }
 
     if (result.error) {
+        const message = typeof result.error === 'string' ? result.error : result.error.message;
+
         normalized.error = {
-            message: result.error.message,
+            message,
         };
 
-        if (result.error.output) {
+        if (typeof result.error !== 'string' && result.error.output) {
             normalized.error.output = result.error.output;
         }
     }
@@ -402,8 +478,9 @@ export function removeBuildDirectory() {
  * @param {Array}    options.allVariants     Full variant list before filtering.
  * @param {Function} options.runVariant      Async (variant, index, total) => void.
  * @param {string}   [options.successVerb]   Verb for the per-variant success line (default 'Passed').
+ * @param {boolean}  [options.guardActiveWatcher] Stop before destructive build operations if the watcher is running.
  */
-export async function runMatrix({ scriptLabel, allVariants, runVariant, successVerb = 'Passed' }) {
+export async function runMatrix({ scriptLabel, allVariants, runVariant, successVerb = 'Passed', guardActiveWatcher = false }) {
     const argv = process.argv.slice(2);
     const jsonMode = isJsonOutputRequested(argv, process.env);
     const startedAt = new Date();
@@ -431,6 +508,10 @@ export async function runMatrix({ scriptLabel, allVariants, runVariant, successV
 
         log(message, 'yellow');
         process.exit(0);
+    }
+
+    if (guardActiveWatcher) {
+        ensureNoActiveWatcher({ scriptLabel, jsonMode, startedAt, selectedFrameworks, selectedVariants });
     }
 
     const labels = [];

--- a/orchestrator/scripts/lint-kits.js
+++ b/orchestrator/scripts/lint-kits.js
@@ -4,6 +4,7 @@ import {
     buildDir,
     buildJsonSummary,
     buildSkippedResults,
+    ensureNoActiveWatcher,
     filterVariants,
     isJsonOutputRequested,
     log,
@@ -239,6 +240,10 @@ async function main() {
     const skipped = buildSkippedResults(variants, active);
     const results = [];
     const context = { jsonMode };
+
+    if (active.length > 0) {
+        ensureNoActiveWatcher({ scriptLabel: 'kits:lint', jsonMode, startedAt, selectedFrameworks, selectedVariants });
+    }
 
     // Always run Pint first (it applies to all frameworks including Livewire).
     if (jsonMode) {


### PR DESCRIPTION
Someone highlighted this method at Laravel Live UK (cant remember who), but I thought about it on the train home with a sore head, so I had to try this PR.

This basically drops the custom method and uses the [framework for it ](https://github.com/laravel/framework/blob/60fed9bde8e8ca8053e1e2c6740a53a0b1ca7d92/src/Illuminate/Support/Str.php#L1469-L1477) but, while I was doing this I noticed some of the WorkOS methods was missing take(2), perhaps there's a reason for it? but I'm not sure (Im just a man from the West Midlands)
 
 This only takes the first and last initials too.