### PR TITLE
Add Fortify feature flags

### DIFF
--- a/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
+++ b/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
@@ -12,13 +12,26 @@ use function Laravel\Prompts\spin;
 
 class InstallFeaturesCommand extends Command
 {
+    private const FEATURES = [
+        'email-verification',
+        'registration',
+        '2fa',
+        'passkeys',
+        'password-confirmation',
+    ];
+
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
     protected $signature = 'install:features
-        {--answers= : JSON string of answers to skip interactive prompts}';
+        {--all : Enable all starter kit features}
+        {--email-verification : Enable email verification}
+        {--registration : Enable registration}
+        {--2fa : Enable two-factor authentication}
+        {--passkeys : Enable passkeys}
+        {--password-confirmation : Enable password confirmation}';
 
     /**
      * The console command description.
@@ -40,9 +53,7 @@ class InstallFeaturesCommand extends Command
         /** @var Script $script */
         $script = require base_path('chisel.php');
 
-        $providedAnswers = $this->option('answers') === null
-            ? []
-            : json_decode((string) $this->option('answers'), true, 512, JSON_THROW_ON_ERROR);
+        $featureAnswers = $this->featureAnswers();
 
         $answers = $script
             ->collectAnswers()
@@ -54,7 +65,7 @@ class InstallFeaturesCommand extends Command
                 hint: $question->hint,
             ))
             ->interactive($this->input->isInteractive())
-            ->withAnswers($providedAnswers);
+            ->withAnswers($featureAnswers);
 
         $this->installNodeDependencies();
 
@@ -67,7 +78,7 @@ class InstallFeaturesCommand extends Command
 
     protected function shouldDeferInstallerHooks(): bool
     {
-        if ($this->option('answers') !== null) {
+        if ($this->hasFeatureOptions()) {
             return false;
         }
 
@@ -77,6 +88,38 @@ class InstallFeaturesCommand extends Command
                 ?? getenv('LARAVEL_INSTALLER_DEFER_HOOKS'),
             FILTER_VALIDATE_BOOL,
         );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function featureAnswers(): array
+    {
+        if ($this->option('all')) {
+            return ['auth_features' => self::FEATURES];
+        }
+
+        $features = array_values(array_filter(
+            self::FEATURES,
+            fn (string $feature): bool => (bool) $this->option($feature),
+        ));
+
+        return $features === [] ? [] : ['auth_features' => $features];
+    }
+
+    protected function hasFeatureOptions(): bool
+    {
+        if ($this->option('all')) {
+            return true;
+        }
+
+        foreach (self::FEATURES as $feature) {
+            if ($this->option($feature)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     protected function installNodeDependencies(): void


### PR DESCRIPTION
The Fortify starter kit feature installer can block non-interactive installs because it still expects prompt answers. This drops the JSON answers option and replaces it with explicit flags that are easier for installers and users to pass from the command line.

The command now supports \`--all\` and one flag per feature, maps those flags into the existing chisel answer flow, and avoids deferring installer hooks when feature choices were provided directly.

Related installer PR: https://github.com/laravel/installer/pull/534