### PR TITLE
Add __() translation markers to Inertia login pages

### DIFF
--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/login.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/login.tsx
@@ -1,4 +1,5 @@
-import { Form, Head } from '@inertiajs/react';
+import { Form, Head, setLayoutProps } from '@inertiajs/react';
+import { useLang } from '@/hooks/use-lang';
 import InputError from '@/components/input-error';
 import PasswordInput from '@/components/password-input';
 import TextLink from '@/components/text-link';
@@ -22,9 +23,16 @@ type Props = {
 };
 
 export default function Login({ status, canResetPassword }: Props) {
+    const { __ } = useLang();
+
+    setLayoutProps({
+        title: __('Log in to your account'),
+        description: __('Enter your email and password below to log in'),
+    });
+
     return (
         <>
-            <Head title="Log in" />
+            <Head title={__('Log in')} />
 
             {/* @chisel-passkeys */}
             <PasskeyVerify />
@@ -39,7 +47,9 @@ export default function Login({ status, canResetPassword }: Props) {
                     <>
                         <div className="grid gap-6">
                             <div className="grid gap-2">
-                                <Label htmlFor="email">Email address</Label>
+                                <Label htmlFor="email">
+                                    {__('Email address')}
+                                </Label>
                                 <Input
                                     id="email"
                                     type="email"
@@ -55,14 +65,16 @@ export default function Login({ status, canResetPassword }: Props) {
 
                             <div className="grid gap-2">
                                 <div className="flex items-center">
-                                    <Label htmlFor="password">Password</Label>
+                                    <Label htmlFor="password">
+                                        {__('Password')}
+                                    </Label>
                                     {canResetPassword && (
                                         <TextLink
                                             href={request()}
                                             className="ml-auto text-sm"
                                             tabIndex={5}
                                         >
-                                            Forgot your password?
+                                            {__('Forgot your password?')}
                                         </TextLink>
                                     )}
                                 </div>
@@ -83,7 +95,9 @@ export default function Login({ status, canResetPassword }: Props) {
                                     name="remember"
                                     tabIndex={3}
                                 />
-                                <Label htmlFor="remember">Remember me</Label>
+                                <Label htmlFor="remember">
+                                    {__('Remember me')}
+                                </Label>
                             </div>
 
                             <Button
@@ -94,15 +108,15 @@ export default function Login({ status, canResetPassword }: Props) {
                                 data-test="login-button"
                             >
                                 {processing && <Spinner />}
-                                Log in
+                                {__('Log in')}
                             </Button>
                         </div>
 
                         {/* @chisel-registration */}
                         <div className="text-center text-sm text-muted-foreground">
-                            Don't have an account?{' '}
+                            {__("Don't have an account?")}{' '}
                             <TextLink href={register()} tabIndex={5}>
-                                Sign up
+                                {__('Sign up')}
                             </TextLink>
                         </div>
                         {/* @end-chisel-registration */}
@@ -118,8 +132,3 @@ export default function Login({ status, canResetPassword }: Props) {
         </>
     );
 }
-
-Login.layout = {
-    title: 'Log in to your account',
-    description: 'Enter your email and password below to log in',
-};

--- a/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Login.svelte
+++ b/kits/Inertia/Fortify/Svelte/resources/js/pages/auth/Login.svelte
@@ -1,12 +1,6 @@
-<script module lang="ts">
-    export const layout = {
-        title: 'Log in to your account',
-        description: 'Enter your email and password below to log in',
-    };
-</script>
-
 <script lang="ts">
-    import { Form } from '@inertiajs/svelte';
+    import { Form, setLayoutProps } from '@inertiajs/svelte';
+    import { useLang } from '@/lib/useLang';
     import AppHead from '@/components/AppHead.svelte';
     import InputError from '@/components/InputError.svelte';
     import PasswordInput from '@/components/PasswordInput.svelte';
@@ -32,9 +26,16 @@
         status?: string;
         canResetPassword: boolean;
     } = $props();
+
+    const { __ } = useLang();
+
+    setLayoutProps({
+        title: __('Log in to your account'),
+        description: __('Enter your email and password below to log in'),
+    });
 </script>
 
-<AppHead title="Log in" />
+<AppHead title={__('Log in')} />
 
 {#if status}
     <div class="mb-4 text-center text-sm font-medium text-green-600">
@@ -54,7 +55,7 @@
     {#snippet children({ errors, processing })}
         <div class="grid gap-6">
             <div class="grid gap-2">
-                <Label for="email">Email address</Label>
+                <Label for="email">{__('Email address')}</Label>
                 <Input
                     id="email"
                     type="email"
@@ -68,10 +69,10 @@
 
             <div class="grid gap-2">
                 <div class="flex items-center justify-between">
-                    <Label for="password">Password</Label>
+                    <Label for="password">{__('Password')}</Label>
                     {#if canResetPassword}
                         <TextLink href={request()} class="text-sm">
-                            Forgot your password?
+                            {__('Forgot your password?')}
                         </TextLink>
                     {/if}
                 </div>
@@ -88,7 +89,7 @@
             <div class="flex items-center justify-between">
                 <Label for="remember" class="flex items-center space-x-3">
                     <Checkbox id="remember" name="remember" />
-                    <span>Remember me</span>
+                    <span>{__('Remember me')}</span>
                 </Label>
             </div>
 
@@ -99,14 +100,14 @@
                 data-test="login-button"
             >
                 {#if processing}<Spinner />{/if}
-                Log in
+                {__('Log in')}
             </Button>
         </div>
 
         <!-- @chisel-registration -->
         <div class="text-center text-sm text-muted-foreground">
-            Don't have an account?
-            <TextLink href={register()}>Sign up</TextLink>
+            {__("Don't have an account?")}
+            <TextLink href={register()}>{__('Sign up')}</TextLink>
         </div>
         <!-- @end-chisel-registration -->
     {/snippet}

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Login.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Login.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { Form, Head } from '@inertiajs/vue3';
+import { Form, Head, setLayoutProps } from '@inertiajs/vue3';
+import { useLang } from '@/composables/useLang';
 import InputError from '@/components/InputError.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import TextLink from '@/components/TextLink.vue';
@@ -17,21 +18,21 @@ import { request } from '@/routes/password';
 import PasskeyVerify from '@/components/PasskeyVerify.vue';
 /* @end-chisel-passkeys */
 
-defineOptions({
-    layout: {
-        title: 'Log in to your account',
-        description: 'Enter your email and password below to log in',
-    },
-});
-
 defineProps<{
     status?: string;
     canResetPassword: boolean;
 }>();
+
+const { __ } = useLang();
+
+setLayoutProps({
+    title: __('Log in to your account'),
+    description: __('Enter your email and password below to log in'),
+});
 </script>
 
 <template>
-    <Head title="Log in" />
+    <Head :title="__('Log in')" />
 
     <div
         v-if="status"
@@ -52,7 +53,7 @@ defineProps<{
     >
         <div class="grid gap-6">
             <div class="grid gap-2">
-                <Label for="email">Email address</Label>
+                <Label for="email">{{ __('Email address') }}</Label>
                 <Input
                     id="email"
                     type="email"
@@ -68,14 +69,14 @@ defineProps<{
 
             <div class="grid gap-2">
                 <div class="flex items-center justify-between">
-                    <Label for="password">Password</Label>
+                    <Label for="password">{{ __('Password') }}</Label>
                     <TextLink
                         v-if="canResetPassword"
                         :href="request()"
                         class="text-sm"
                         :tabindex="5"
                     >
-                        Forgot your password?
+                        {{ __('Forgot your password?') }}
                     </TextLink>
                 </div>
                 <PasswordInput
@@ -92,7 +93,7 @@ defineProps<{
             <div class="flex items-center justify-between">
                 <Label for="remember" class="flex items-center space-x-3">
                     <Checkbox id="remember" name="remember" :tabindex="3" />
-                    <span>Remember me</span>
+                    <span>{{ __('Remember me') }}</span>
                 </Label>
             </div>
 
@@ -104,14 +105,16 @@ defineProps<{
                 data-test="login-button"
             >
                 <Spinner v-if="processing" />
-                Log in
+                {{ __('Log in') }}
             </Button>
         </div>
 
         <!-- @chisel-registration -->
         <div class="text-center text-sm text-muted-foreground">
-            Don't have an account?
-            <TextLink :href="register()" :tabindex="5">Sign up</TextLink>
+            {{ __("Don't have an account?") }}
+            <TextLink :href="register()" :tabindex="5">{{
+                __('Sign up')
+            }}</TextLink>
         </div>
         <!-- @end-chisel-registration -->
     </Form>

--- a/kits/Inertia/React/resources/js/hooks/use-lang.ts
+++ b/kits/Inertia/React/resources/js/hooks/use-lang.ts
@@ -1,0 +1,19 @@
+import { usePage } from '@inertiajs/react';
+
+type Replacements = Record<string, string | number>;
+
+export function useLang() {
+    const lang = (usePage().props.lang ?? {}) as Record<string, string>;
+
+    function __(key: string, replace: Replacements = {}): string {
+        let line = lang[key] ?? key;
+
+        for (const [k, v] of Object.entries(replace)) {
+            line = line.replaceAll(`:${k}`, String(v));
+        }
+
+        return line;
+    }
+
+    return { __ };
+}

--- a/kits/Inertia/Svelte/resources/js/lib/useLang.ts
+++ b/kits/Inertia/Svelte/resources/js/lib/useLang.ts
@@ -1,0 +1,19 @@
+import { usePage } from '@inertiajs/svelte';
+
+type Replacements = Record<string, string | number>;
+
+export function useLang() {
+    const lang = (usePage().props.lang ?? {}) as Record<string, string>;
+
+    function __(key: string, replace: Replacements = {}): string {
+        let line = lang[key] ?? key;
+
+        for (const [k, v] of Object.entries(replace)) {
+            line = line.replaceAll(`:${k}`, String(v));
+        }
+
+        return line;
+    }
+
+    return { __ };
+}

--- a/kits/Inertia/Vue/resources/js/composables/useLang.ts
+++ b/kits/Inertia/Vue/resources/js/composables/useLang.ts
@@ -1,0 +1,19 @@
+import { usePage } from '@inertiajs/vue3';
+
+type Replacements = Record<string, string | number>;
+
+export function useLang() {
+    const lang = (usePage().props.lang ?? {}) as Record<string, string>;
+
+    function __(key: string, replace: Replacements = {}): string {
+        let line = lang[key] ?? key;
+
+        for (const [k, v] of Object.entries(replace)) {
+            line = line.replaceAll(`:${k}`, String(v));
+        }
+
+        return line;
+    }
+
+    return { __ };
+}


### PR DESCRIPTION
## Summary

- add lightweight `useLang()` helpers for React / Vue / Svelte
- wrap Fortify (non-Teams) login UI strings in `__()` markers
- replace static login layout metadata with [setLayoutProps()](https://inertiajs.com/docs/v3/the-basics/layouts#dynamic-props) where needed so marker calls are possible

## Scope (intentionally limited)

- **Included:** Fortify (non-Teams) login pages only
- **Not included:** Teams variants, other auth pages, lang JSON sharing in middleware

This is intentionally a small **draft** to reduce maintainer review load and confirm direction first.

## Context

- Related issue: #168
- Related prior alignment PR: #126

## References

- React extraction source (3 entries):
  - https://github.com/Laravel-Lang/starter-kits/blob/main/source/react/main/react.json
  - https://github.com/Laravel-Lang/starter-kits/blob/main/source/vue/main/vue.json
  - https://github.com/Laravel-Lang/starter-kits/blob/main/source/svelte/main/svelte.json
- Livewire extraction source (100+ entries):
  - https://github.com/Laravel-Lang/starter-kits/blob/main/source/livewire/main/livewire.json
- Finder implementation reference:
  - https://github.com/Laravel-Lang/status-generator/blob/main/src/Services/Packages/Finder.php
- PoC commits and demos (Japanese login page):
  - React: https://github.com/catatsumuri/react-starter-kit-ja-login/commit/0c65ebdde4342c54e6f1f357dd9935ad64ca13e8
      - https://react-starter-kit-ja-login-production-x4srt3.laravel.cloud/login
  - Vue: https://github.com/catatsumuri/vue-starter-kit-ja-login/commit/e2df48fd4b1bc090154ee489000cd442cce0be6d
      - https://vue-starter-kit-ja-login-production-rsb780.laravel.cloud/login
  - Svelte: https://github.com/catatsumuri/svelte-starter-kit-ja-login/commit/f9883681abbd28b69f53a7db2f95cbdbb8d10906
      - https://svelte-starter-kit-ja-login-production-dhc7nk.laravel.cloud/login

## Notes

- This PR focuses on parser-visible markers (`__()`) only.
- Placeholder-heavy keys (for example `:action` / `:team`) are intentionally left for a follow-up.
- Follow-ups (if direction is accepted): Teams variants, additional auth pages.
