### PR TITLE
Use new `artisan dev` command in `composer dev` script

### DIFF
--- a/kits/Inertia/Blank/Base/composer.json
+++ b/kits/Inertia/Blank/Base/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.3",
         "inertiajs/inertia-laravel": "^3.0",
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.17",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14"
     },
@@ -49,7 +49,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve --host=localhost\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "@php artisan dev"
         ],
         "lint": [
             "pint --parallel"

--- a/kits/Inertia/Fortify/Base/composer.json
+++ b/kits/Inertia/Fortify/Base/composer.json
@@ -13,7 +13,7 @@
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/chisel": "^0.1.0",
         "laravel/fortify": "^1.37.2",
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.17",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14"
     },
@@ -51,7 +51,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve --host=localhost\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "@php artisan dev"
         ],
         "lint": [
             "pint --parallel"

--- a/kits/Inertia/WorkOS/Base/composer.json
+++ b/kits/Inertia/WorkOS/Base/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.3",
         "inertiajs/inertia-laravel": "^3.0",
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.17",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14",
         "laravel/workos": "^0.6.0"
@@ -50,7 +50,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve --host=localhost\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "@php artisan dev"
         ],
         "lint": [
             "pint --parallel"

--- a/kits/Livewire/Blank/composer.json
+++ b/kits/Livewire/Blank/composer.json
@@ -51,11 +51,6 @@
             "Composer\\Config::disableProcessTimeout",
             "@php artisan dev"
         ],
-        "dev:ssr": [
-            "npm run build:ssr",
-            "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve --host=localhost\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"php artisan inertia:start-ssr\" --names=server,queue,logs,ssr --kill-others"
-        ],
         "lint": [
             "pint --parallel"
         ],

--- a/kits/Livewire/Blank/composer.json
+++ b/kits/Livewire/Blank/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.17",
         "laravel/tinker": "^3.0",
         "livewire/blaze": "^1.0",
         "livewire/livewire": "^4.1"
@@ -49,7 +49,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve --host=localhost\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "@php artisan dev"
         ],
         "dev:ssr": [
             "npm run build:ssr",

--- a/kits/Livewire/Fortify/composer.json
+++ b/kits/Livewire/Fortify/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.3",
         "laravel/chisel": "^0.1.0",
         "laravel/fortify": "^1.37.2",
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.17",
         "laravel/tinker": "^3.0",
         "livewire/blaze": "^1.0",
         "livewire/flux": "^2.13.1",
@@ -52,7 +52,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve --host=localhost\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "@php artisan dev"
         ],
         "lint": [
             "pint --parallel"

--- a/kits/Livewire/WorkOS/composer.json
+++ b/kits/Livewire/WorkOS/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "laravel/framework": "^13.7",
+        "laravel/framework": "^13.17",
         "laravel/tinker": "^3.0",
         "laravel/workos": "^0.6.0",
         "livewire/blaze": "^1.0",
@@ -51,7 +51,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve --host=localhost\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "@php artisan dev"
         ],
         "lint": [
             "pint --parallel"


### PR DESCRIPTION
Laravel 13.16 introduced [the new `php artisan dev` command](https://github.com/laravel/framework/pull/60412), so I thought it would be neat to have this stay in sync with the `composer dev` scripts of the starter kits.

I raised the Laravel dependency to `^13.17` across all starter kits to ensure users have the `artisan dev` command available as well as `artisan dev:list`.
I intentionally kept the `concurrently` Node dependency, as `artisan dev` uses it under the hood.

One more thing I did in my second commit: Removed the broken `dev:ssr` script from the blank Livewire Starter Kit; it referenced non-existing commands `npm run build:ssr` and `php artisan inertia:start-ssr`. The Livewire Fortify Starter Kit also doesn't have a `dev:ssr` script, so this should make both kits better aligned.