### PR TITLE
Fix bug, rename paths of `chisel-paths.php` so they are recognized by Chisel.

### DIFF
--- a/kits/Livewire/Base/rename_livewire_files.php
+++ b/kits/Livewire/Base/rename_livewire_files.php
@@ -42,16 +42,18 @@ foreach ($files as $file) {
 }
 
 if (PHP_OS_FAMILY === 'Windows') {
-    $searches = array_map(fn (string $line): string => str_replace('\\', '/', $line), $searches);
-    $replacements = array_map(fn (string $line): string => str_replace('\\', '/', $line), $replacements);
+    $toForwardSlashes = fn (string $path): string => str_replace('\\', '/', $path);
+
+    $searches = array_map($toForwardSlashes, $searches);
+    $replacements = array_map($toForwardSlashes, $replacements);
 }
 
-$chiselPaths = __DIR__.DIRECTORY_SEPARATOR.'chisel-paths.php';
+$chiselPathsFile = __DIR__.DIRECTORY_SEPARATOR.'chisel-paths.php';
 
-if (file_exists($chiselPaths)) {
+if ($searches !== [] && file_exists($chiselPathsFile)) {
     file_put_contents(
-        $chiselPaths,
-        str_replace($searches, $replacements, file_get_contents($chiselPaths))
+        $chiselPathsFile,
+        str_replace($searches, $replacements, file_get_contents($chiselPathsFile)),
     );
 }
 

--- a/kits/Livewire/Base/rename_livewire_files.php
+++ b/kits/Livewire/Base/rename_livewire_files.php
@@ -22,6 +22,9 @@ foreach ($iterator as $file) {
     }
 }
 
+$searches = [];
+$replacements = [];
+
 foreach ($files as $file) {
     $directory = dirname($file);
     $filename = basename($file);
@@ -32,7 +35,24 @@ foreach ($files as $file) {
         rename($file, $newPath);
         $dirRelative = ltrim(str_replace(__DIR__.DIRECTORY_SEPARATOR, '', $directory), DIRECTORY_SEPARATOR);
         echo "Renamed: {$dirRelative}".DIRECTORY_SEPARATOR."{{$filename} => {$newFilename}}".PHP_EOL;
+
+        $searches[] = $dirRelative.DIRECTORY_SEPARATOR.$filename;
+        $replacements[] = $dirRelative.DIRECTORY_SEPARATOR.$newFilename;
     }
+}
+
+if (PHP_OS_FAMILY === 'Windows') {
+    $searches = array_map(fn (string $line): string => str_replace('\\', '/', $line), $searches);
+    $replacements = array_map(fn (string $line): string => str_replace('\\', '/', $line), $replacements);
+}
+
+$chiselPaths = __DIR__.DIRECTORY_SEPARATOR.'chisel-paths.php';
+
+if (file_exists($chiselPaths)) {
+    file_put_contents(
+        $chiselPaths,
+        str_replace($searches, $replacements, file_get_contents($chiselPaths))
+    );
 }
 
 $composerJson = json_decode(


### PR DESCRIPTION
This PR is a proposed solution for [https://github.com/laravel/chisel/issues/12](https://github.com/laravel/chisel/issues/12).

The script `rename_livewire_files.php` adds emojis (⚡) to livewire single file components. However, this causes an issue because the script **`chisel.php`** does not recognize them and does not apply the changes in the renamed files.

My solution was to add a way to the same script to rename the paths in `chisel-paths.php` so that they would be recognized later.