### PR TITLE
Fix rendering JSON for Inertia

### DIFF
--- a/kits/Inertia/Base/bootstrap/app.php
+++ b/kits/Inertia/Base/bootstrap/app.php
@@ -25,6 +25,6 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(
-            fn (Request $request) => $request->is('api/*'),
+            fn (Request $request) => $request->is('api/*') || $request->expectsJson(),
         );
     })->create();

--- a/kits/Inertia/Blank/Base/bootstrap/app.php
+++ b/kits/Inertia/Blank/Base/bootstrap/app.php
@@ -21,6 +21,6 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(
-            fn (Request $request) => $request->is('api/*'),
+            fn (Request $request) => $request->is('api/*') || $request->expectsJson(),
         );
     })->create();

--- a/kits/Inertia/Teams/Base/bootstrap/app.php
+++ b/kits/Inertia/Teams/Base/bootstrap/app.php
@@ -27,6 +27,6 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(
-            fn (Request $request) => $request->is('api/*'),
+            fn (Request $request) => $request->is('api/*') || $request->expectsJson(),
         );
     })->create();

--- a/kits/Livewire/Blank/bootstrap/app.php
+++ b/kits/Livewire/Blank/bootstrap/app.php
@@ -16,6 +16,6 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(
-            fn (Request $request) => $request->is('api/*'),
+            fn (Request $request) => $request->is('api/*') || $request->expectsJson(),
         );
     })->create();

--- a/kits/Livewire/Teams/Base/bootstrap/app.php
+++ b/kits/Livewire/Teams/Base/bootstrap/app.php
@@ -19,6 +19,6 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(
-            fn (Request $request) => $request->is('api/*'),
+            fn (Request $request) => $request->is('api/*') || $request->expectsJson(),
         );
     })->create();


### PR DESCRIPTION
This applies the fix from laravel/laravel#6837 to the Inertia starter kits. Not sure if the Livewire kits also need this fix. This also solves issues like https://github.com/laravel/framework/discussions/60594, since it caused Precognition to always return a redirect response instead of a proper 204 or 422 response.