### PR TITLE
Fix resuming two-factor setup after closing the modal in the React kit

### DIFF
--- a/browser_tests/common/tests/Browser/Settings/SecurityTest.php
+++ b/browser_tests/common/tests/Browser/Settings/SecurityTest.php
@@ -177,6 +177,33 @@ test('two-factor authentication can be enabled, confirmed, and disabled without 
         ->assertNoJavaScriptErrors();
 });
 
+test('two-factor setup can be resumed after closing the modal', function () {
+    actingAs(User::factory()->create());
+
+    $browser = visit(route('security.edit'))
+        ->assertSee('Enable 2FA')
+        ->click('Enable 2FA')
+        ->assertVisible('dialog, [role=dialog]')
+        ->keys('dialog, [role=dialog]', 'Escape')
+        ->assertMissing('dialog, [role=dialog]');
+
+    $isInertia = $browser->script('!window.Livewire');
+
+    if ($isInertia) {
+        $browser->assertSee('Continue setup')
+            ->assertDontSee('Enable 2FA')
+            ->click('Continue setup');
+    } else {
+        $browser->click('Enable 2FA');
+    }
+
+    $browser->assertVisible('dialog, [role=dialog]')
+        ->assertDontSee('Something went wrong')
+        ->assertDontSee('Failed to fetch a setup key')
+        ->assertNoConsoleLogs()
+        ->assertNoJavaScriptErrors();
+});
+
 test('security page displays password section without two-factor when feature is disabled', function () {
     config(['fortify.features' => []]);
 

--- a/browser_tests/common/tests/Browser/Settings/SecurityTest.php
+++ b/browser_tests/common/tests/Browser/Settings/SecurityTest.php
@@ -177,33 +177,6 @@ test('two-factor authentication can be enabled, confirmed, and disabled without 
         ->assertNoJavaScriptErrors();
 });
 
-test('two-factor setup can be resumed after closing the modal', function () {
-    actingAs(User::factory()->create());
-
-    $browser = visit(route('security.edit'))
-        ->assertSee('Enable 2FA')
-        ->click('Enable 2FA')
-        ->assertVisible('dialog, [role=dialog]')
-        ->keys('dialog, [role=dialog]', 'Escape')
-        ->assertMissing('dialog, [role=dialog]');
-
-    $isInertia = $browser->script('!window.Livewire');
-
-    if ($isInertia) {
-        $browser->assertSee('Continue setup')
-            ->assertDontSee('Enable 2FA')
-            ->click('Continue setup');
-    } else {
-        $browser->click('Enable 2FA');
-    }
-
-    $browser->assertVisible('dialog, [role=dialog]')
-        ->assertDontSee('Something went wrong')
-        ->assertDontSee('Failed to fetch a setup key')
-        ->assertNoConsoleLogs()
-        ->assertNoJavaScriptErrors();
-});
-
 test('security page displays password section without two-factor when feature is disabled', function () {
     config(['fortify.features' => []]);
 

--- a/kits/Inertia/Fortify/React/resources/js/components/two-factor-setup-modal.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/components/two-factor-setup-modal.tsx
@@ -287,9 +287,12 @@ export default function TwoFactorSetupModal({
     }, [twoFactorEnabled, showVerificationStep]);
 
     const resetModalState = useCallback(() => {
+        if (twoFactorEnabled) {
+            clearSetupData();
+        }
+
         setShowVerificationStep(false);
-        clearSetupData();
-    }, [clearSetupData]);
+    }, [clearSetupData, twoFactorEnabled]);
 
     const handleClose = useCallback(() => {
         resetModalState();
@@ -303,8 +306,9 @@ export default function TwoFactorSetupModal({
             return;
         }
 
+        clearSetupData();
         handleClose();
-    }, [requiresConfirmation, handleClose]);
+    }, [requiresConfirmation, clearSetupData, handleClose]);
 
     const fetchSetupDataRef = useRef(fetchSetupData);
 


### PR DESCRIPTION
## Overview

In the React starter kit, closing the two-factor setup modal mid-setup wiped the fetched QR code and setup key. The button kept showing "Enable 2FA" instead of "Continue setup", and reopening the modal failed with "Something went wrong. Failed to fetch a setup key".

## How

The React setup modal now clears the setup data on close only when two-factor is already enabled, matching Vue and Svelte, and still clears it explicitly when finishing setup without confirmation.

Fixes #175