### PR TITLE
Use the app name from config in the brand component

### DIFF
--- a/kits/Inertia/React/resources/js/components/app-logo.tsx
+++ b/kits/Inertia/React/resources/js/components/app-logo.tsx
@@ -1,6 +1,10 @@
+import { usePage } from '@inertiajs/react';
+
 import AppLogoIcon from '@/components/app-logo-icon';
 
 export default function AppLogo() {
+    const { name } = usePage().props;
+
     return (
         <>
             <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground">
@@ -8,7 +12,7 @@ export default function AppLogo() {
             </div>
             <div className="ml-1 grid flex-1 text-left text-sm">
                 <span className="mb-0.5 truncate leading-tight font-semibold">
-                    Laravel Starter Kit
+                    {name || 'Laravel'}
                 </span>
             </div>
         </>

--- a/kits/Inertia/React/resources/js/components/app-logo.tsx
+++ b/kits/Inertia/React/resources/js/components/app-logo.tsx
@@ -12,7 +12,7 @@ export default function AppLogo() {
             </div>
             <div className="ml-1 grid flex-1 text-left text-sm">
                 <span className="mb-0.5 truncate leading-tight font-semibold">
-                    {name || 'Laravel'}
+                    {name}
                 </span>
             </div>
         </>

--- a/kits/Inertia/Svelte/resources/js/components/AppLogo.svelte
+++ b/kits/Inertia/Svelte/resources/js/components/AppLogo.svelte
@@ -12,6 +12,6 @@
 </div>
 <div class="ml-1 grid flex-1 text-left text-sm">
     <span class="mb-0.5 truncate leading-tight font-semibold"
-        >{name || 'Laravel'}</span
+        >{name}</span
     >
 </div>

--- a/kits/Inertia/Svelte/resources/js/components/AppLogo.svelte
+++ b/kits/Inertia/Svelte/resources/js/components/AppLogo.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+    import { page } from '@inertiajs/svelte';
     import AppLogoIcon from '@/components/AppLogoIcon.svelte';
+
+    const name = $derived(page.props.name);
 </script>
 
 <div
@@ -9,6 +12,6 @@
 </div>
 <div class="ml-1 grid flex-1 text-left text-sm">
     <span class="mb-0.5 truncate leading-tight font-semibold"
-        >Laravel Starter Kit</span
+        >{name || 'Laravel'}</span
     >
 </div>

--- a/kits/Inertia/Svelte/resources/js/components/AppLogo.svelte
+++ b/kits/Inertia/Svelte/resources/js/components/AppLogo.svelte
@@ -11,7 +11,5 @@
     <AppLogoIcon class="size-5 fill-current text-white dark:text-black" />
 </div>
 <div class="ml-1 grid flex-1 text-left text-sm">
-    <span class="mb-0.5 truncate leading-tight font-semibold"
-        >{name}</span
-    >
+    <span class="mb-0.5 truncate leading-tight font-semibold">{name}</span>
 </div>

--- a/kits/Inertia/Vue/resources/js/components/AppLogo.vue
+++ b/kits/Inertia/Vue/resources/js/components/AppLogo.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
+import { usePage } from '@inertiajs/vue3';
 import AppLogoIcon from '@/components/AppLogoIcon.vue';
+
+const name = usePage().props.name;
 </script>
 
 <template>
@@ -9,8 +12,8 @@ import AppLogoIcon from '@/components/AppLogoIcon.vue';
         <AppLogoIcon class="size-5 fill-current text-white dark:text-black" />
     </div>
     <div class="ml-1 grid flex-1 text-left text-sm">
-        <span class="mb-0.5 truncate leading-tight font-semibold"
-            >Laravel Starter Kit</span
-        >
+        <span class="mb-0.5 truncate leading-tight font-semibold">{{
+            name || 'Laravel'
+        }}</span>
     </div>
 </template>

--- a/kits/Inertia/Vue/resources/js/components/AppLogo.vue
+++ b/kits/Inertia/Vue/resources/js/components/AppLogo.vue
@@ -13,7 +13,7 @@ const name = usePage().props.name;
     </div>
     <div class="ml-1 grid flex-1 text-left text-sm">
         <span class="mb-0.5 truncate leading-tight font-semibold">{{
-            name || 'Laravel'
+            name
         }}</span>
     </div>
 </template>

--- a/kits/Livewire/Base/resources/views/components/app-logo.blade.php
+++ b/kits/Livewire/Base/resources/views/components/app-logo.blade.php
@@ -3,13 +3,13 @@
 ])
 
 @if($sidebar)
-    <flux:sidebar.brand name="Laravel Starter Kit" {{ $attributes }}>
+    <flux:sidebar.brand :name="config('app.name', 'Laravel')" {{ $attributes }}>
         <x-slot name="logo" class="flex aspect-square size-8 items-center justify-center rounded-md bg-accent-content text-accent-foreground">
             <x-app-logo-icon class="size-5 fill-current text-white dark:text-black" />
         </x-slot>
     </flux:sidebar.brand>
 @else
-    <flux:brand name="Laravel Starter Kit" {{ $attributes }}>
+    <flux:brand :name="config('app.name', 'Laravel')" {{ $attributes }}>
         <x-slot name="logo" class="flex aspect-square size-8 items-center justify-center rounded-md bg-accent-content text-accent-foreground">
             <x-app-logo-icon class="size-5 fill-current text-white dark:text-black" />
         </x-slot>


### PR DESCRIPTION
## Summary

- The brand component in every kit hardcoded `Laravel Starter Kit` as the display name.
- `config('app.name')` is already used elsewhere in each kit (e.g. `<title>`, auth layouts), and the Inertia kits already share it to the frontend as the `name` page prop via `HandleInertiaRequests`.
- This wires the brand component up to that existing value in all four kits, so it reflects `APP_NAME` instead of a fixed string. Falls back to `Laravel` when `APP_NAME` is unset, matching `config('app.name', 'Laravel')`'s existing default elsewhere.

## Changes

- **React** (`kits/Inertia/React/.../app-logo.tsx`): reads `usePage().props.name`.
- **Vue** (`kits/Inertia/Vue/.../AppLogo.vue`): reads `usePage().props.name`.
- **Svelte** (`kits/Inertia/Svelte/.../AppLogo.svelte`): reads `page.props.name` via `$derived`.
- **Livewire** (`kits/Livewire/Base/.../app-logo.blade.php`): passes `:name="config('app.name', 'Laravel')"` to `flux:brand` / `flux:sidebar.brand` (single file covers all Livewire variants — Fortify, WorkOS, Components, Teams).

## Test plan

- [x] `composer kits:pint` — pass
- [x] `composer kits:lint` (all 15 Inertia variants) — all passed
- [x] `composer kits:check` (all 21 variants) — all passed, 0 failed
- [x] Manually built and ran each of the four stacks via `composer kit:run`, logged in, and confirmed the sidebar/header brand text reflects a custom `APP_NAME` (`Maestro Demo`) instead of `Laravel Starter Kit`

