### PR TITLE
Respect --no-node in install:features hook

### DIFF
--- a/kits/Inertia/Fortify/Base/chisel.php
+++ b/kits/Inertia/Fortify/Base/chisel.php
@@ -39,6 +39,29 @@ function chiselRun(array $command, string $label): void
     }
 }
 
+function chiselSkipsNode(): bool
+{
+    return filter_var(
+        $_ENV['LARAVEL_INSTALLER_NO_NODE']
+            ?? $_SERVER['LARAVEL_INSTALLER_NO_NODE']
+            ?? getenv('LARAVEL_INSTALLER_NO_NODE'),
+        FILTER_VALIDATE_BOOL,
+    );
+}
+
+function chiselRemoveNpmPackages(Chisel $c, string ...$packages): void
+{
+    if (! chiselSkipsNode()) {
+        $c->npm()->remove(...$packages);
+
+        return;
+    }
+
+    foreach ($packages as $package) {
+        $c->file('package.json')->removeLinesContaining('"'.$package.'":');
+    }
+}
+
 /**
  * Framework-specific filenames are supplied by the sibling chisel-paths.php
  * that ships with each Inertia kit (React/Svelte/Vue). After build both files
@@ -164,7 +187,7 @@ return Chisel::script(__DIR__)
             )->removeSection('2fa');
 
             if ($paths['two_factor_otp_package'] !== null) {
-                $c->npm()->remove($paths['two_factor_otp_package']);
+                chiselRemoveNpmPackages($c, $paths['two_factor_otp_package']);
             }
 
             $c->files(...[
@@ -210,7 +233,7 @@ return Chisel::script(__DIR__)
                 $paths['confirm_password'],
             )->removeSection('passkeys');
 
-            $c->npm()->remove('@laravel/passkeys');
+            chiselRemoveNpmPackages($c, '@laravel/passkeys');
 
             $c->files(...[
                 ...$paths['passkey_files'],
@@ -266,8 +289,10 @@ return Chisel::script(__DIR__)
         chiselRun(['composer', 'lint'], 'Composer Lint');
         chiselRun(['php', 'artisan', 'wayfinder:generate', '--with-form', '--no-interaction'], 'Generate Wayfinder Resources');
 
-        $c->npm()->run('lint');
-        $c->npm()->run('format');
+        if (! chiselSkipsNode()) {
+            $c->npm()->run('lint');
+            $c->npm()->run('format');
+        }
 
         $c->file('composer.json')
             ->removeLinesContaining('"@php artisan install:features --ansi"');

--- a/kits/Livewire/Fortify/chisel.php
+++ b/kits/Livewire/Fortify/chisel.php
@@ -39,6 +39,29 @@ function chiselRun(array $command, string $label): void
     }
 }
 
+function chiselSkipsNode(): bool
+{
+    return filter_var(
+        $_ENV['LARAVEL_INSTALLER_NO_NODE']
+            ?? $_SERVER['LARAVEL_INSTALLER_NO_NODE']
+            ?? getenv('LARAVEL_INSTALLER_NO_NODE'),
+        FILTER_VALIDATE_BOOL,
+    );
+}
+
+function chiselRemoveNpmPackages(Chisel $c, string ...$packages): void
+{
+    if (! chiselSkipsNode()) {
+        $c->npm()->remove(...$packages);
+
+        return;
+    }
+
+    foreach ($packages as $package) {
+        $c->file('package.json')->removeLinesContaining('"'.$package.'":');
+    }
+}
+
 /**
  * Variant-specific filenames are supplied by the sibling chisel-paths.php.
  * The Single-File Component variant ships the default paths file; the
@@ -202,7 +225,7 @@ return Chisel::script(__DIR__)
                 ...$paths['security_files'],
             )->removeSection('passkeys');
 
-            $c->npm()->remove('@laravel/passkeys');
+            chiselRemoveNpmPackages($c, '@laravel/passkeys');
 
             $c->files(
                 'resources/views/components/passkey-verify.blade.php',

--- a/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
+++ b/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
@@ -77,20 +77,18 @@ class InstallFeaturesCommand extends Command
             return false;
         }
 
-        return filter_var(
-            $_ENV['LARAVEL_INSTALLER_DEFER_HOOKS']
-                ?? $_SERVER['LARAVEL_INSTALLER_DEFER_HOOKS']
-                ?? getenv('LARAVEL_INSTALLER_DEFER_HOOKS'),
-            FILTER_VALIDATE_BOOL,
-        );
+        return $this->installerFlag('LARAVEL_INSTALLER_DEFER_HOOKS');
     }
 
     protected function shouldSkipNode(): bool
     {
+        return $this->installerFlag('LARAVEL_INSTALLER_NO_NODE');
+    }
+
+    protected function installerFlag(string $name): bool
+    {
         return filter_var(
-            $_ENV['LARAVEL_INSTALLER_NO_NODE']
-                ?? $_SERVER['LARAVEL_INSTALLER_NO_NODE']
-                ?? getenv('LARAVEL_INSTALLER_NO_NODE'),
+            $_ENV[$name] ?? $_SERVER[$name] ?? getenv($name),
             FILTER_VALIDATE_BOOL,
         );
     }

--- a/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
+++ b/kits/Shared/Fortify/app/Console/Commands/InstallFeaturesCommand.php
@@ -56,11 +56,17 @@ class InstallFeaturesCommand extends Command
             ->interactive($this->input->isInteractive())
             ->withAnswers($providedAnswers);
 
-        $this->installNodeDependencies();
+        $skipNode = $this->shouldSkipNode();
+
+        if (! $skipNode) {
+            $this->installNodeDependencies();
+        }
 
         $script->chisel($answers);
 
-        $this->buildAssets();
+        if (! $skipNode) {
+            $this->buildAssets();
+        }
 
         return self::SUCCESS;
     }
@@ -75,6 +81,16 @@ class InstallFeaturesCommand extends Command
             $_ENV['LARAVEL_INSTALLER_DEFER_HOOKS']
                 ?? $_SERVER['LARAVEL_INSTALLER_DEFER_HOOKS']
                 ?? getenv('LARAVEL_INSTALLER_DEFER_HOOKS'),
+            FILTER_VALIDATE_BOOL,
+        );
+    }
+
+    protected function shouldSkipNode(): bool
+    {
+        return filter_var(
+            $_ENV['LARAVEL_INSTALLER_NO_NODE']
+                ?? $_SERVER['LARAVEL_INSTALLER_NO_NODE']
+                ?? getenv('LARAVEL_INSTALLER_NO_NODE'),
             FILTER_VALIDATE_BOOL,
         );
     }


### PR DESCRIPTION
Follow-up to laravel/installer#552 (merged), which passes `LARAVEL_INSTALLER_NO_NODE=1` to the starter kit hooks when `laravel new --no-node` is used. On its own that changed no behaviour, because `install:features` didn't read the variable and still ran npm. This closes laravel/installer#539.

This makes the command respect it. When `LARAVEL_INSTALLER_NO_NODE` is set, the node dependency install and asset build are skipped, while feature selection (chisel) still runs. The check mirrors the existing `LARAVEL_INSTALLER_DEFER_HOOKS` handling in the same command.

The change lives in `kits/Shared/Fortify`, so it applies to every Fortify variant across all frameworks.

Verified manually against a built kit. With `LARAVEL_INSTALLER_NO_NODE=1` the "Installing dependencies" and "Building assets" steps are skipped, without it they run as before.

I kept this consistent with the untested `DEFER_HOOKS` handling and didn't add a test here. The installer side is covered by laravel/installer#552 .