### PR TITLE
Fix child process spawning on Windows

### DIFF
--- a/orchestrator/package-lock.json
+++ b/orchestrator/package-lock.json
@@ -7,6 +7,7 @@
             "devDependencies": {
                 "chokidar": "^4.0.0",
                 "concurrently": "^9.2.4",
+                "cross-spawn": "^7.0.6",
                 "ignore": "^7.0.0"
             }
         },
@@ -142,6 +143,21 @@
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
             }
         },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -199,6 +215,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/readdirp": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -231,6 +264,29 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/shell-quote": {
@@ -306,6 +362,22 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
             "license": "0BSD"
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -8,6 +8,7 @@
     "devDependencies": {
         "chokidar": "^4.0.0",
         "concurrently": "^9.2.4",
+        "cross-spawn": "^7.0.6",
         "ignore": "^7.0.0"
     }
 }

--- a/orchestrator/scripts/browser-tests-kits.js
+++ b/orchestrator/scripts/browser-tests-kits.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { execSync, spawn } from 'child_process';
+import { execSync } from 'child_process';
+import { spawn } from 'cross-spawn';
 import fs from 'fs';
 import path from 'path';
 import {

--- a/orchestrator/scripts/kit-helpers.js
+++ b/orchestrator/scripts/kit-helpers.js
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { spawn, spawnSync } from 'child_process';
+import { spawn, sync as spawnSync } from 'cross-spawn';
 
 /**
  * All recognized framework flags.


### PR DESCRIPTION
### Summary

Use `cross-spawn` for synchronous and asynchronous child processes invoked by the orchestrator scripts.

This fixes command resolution on Windows for executables provided through `.bat` and `.cmd` wrappers, including Composer, npm, and npx.

### Problem

The orchestrator used Node.js `child_process.spawn()` and `spawnSync()` directly:

```js
spawn('composer', ['setup']);
```

On Windows, tools such as Composer, npm, and npx are commonly exposed through wrapper scripts:

- `composer.bat`
- `npm.cmd`
- `npx.cmd`

These scripts cannot be executed directly by modern Node.js versions without a command shell. As a result, running:

```bash
composer kit:run
```

failed while attempting to execute the generated kit setup:

```text
Running composer setup...
spawn composer ENOENT
Script node scripts/run.js handling the kit:run event returned with error code 1
```

Composer was installed and available on `PATH`, but Node.js could not execute its Windows wrapper using the default `spawn()` behavior.

Using `shell: true` made the command work, but it also produced the following deprecation warning:

```text
[DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
```

Therefore, enabling the shell was not an appropriate permanent solution.

### Solution

Add `cross-spawn` as a development dependency and use it for both asynchronous and synchronous process execution:

```js
import { spawn, sync as spawnSync } from 'cross-spawn';
```

`cross-spawn` handles platform-specific executable resolution, including Windows `.bat` and `.cmd` wrappers, while preserving the existing `spawn()` API and avoiding `shell: true`.

This fixes command execution for:

- Composer
- npm
- npx
- Other commands exposed through Windows command wrappers

### Verification

The change was verified on Windows with Node.js 26 by executing Composer through both APIs:

- `spawn('composer', ['--version'])`
- `spawnSync('composer', ['--version'])`

Both commands completed successfully without `ENOENT`, `EINVAL`, or the `DEP0190` warning.

### Alternatives considered

Another possible approach would be to detect Windows and resolve each command to its platform-specific wrapper:

```js
const composerCommand = process.platform === 'win32'
    ? 'composer.bat'
    : 'composer';

const npmCommand = process.platform === 'win32'
    ? 'npm.cmd'
    : 'npm';

spawn(composerCommand, ['setup']);
spawn(npmCommand, ['install']);
```

However, this approach has several drawbacks:

- The correct extension must be known for every command.
- Composer commonly uses `.bat`, while npm and npx commonly use `.cmd`.
- It requires platform-specific handling at every call site.
- Modern Node.js versions may reject direct `.bat` and `.cmd` execution with `EINVAL` unless the command is launched through `cmd.exe`.
- Using `shell: true` to execute these wrappers triggers the `DEP0190` warning when arguments are passed separately.
- Manually invoking `cmd.exe` would require carefully implementing Windows command-line quoting and escaping.

For example, a complete Windows-specific implementation would need to resemble:

```js
const command = process.platform === 'win32'
    ? process.env.ComSpec ?? 'cmd.exe'
    : 'composer';

const args = process.platform === 'win32'
    ? ['/d', '/s', '/c', 'composer.bat', 'setup']
    : ['setup'];

spawn(command, args);
```

This still requires special handling for argument escaping and shell metacharacters.

Using `cross-spawn` centralizes this platform-specific behavior, preserves the existing `spawn(command, args, options)` API, and avoids maintaining a custom command resolution and escaping implementation.