### PR TITLE
Normalize watcher paths across operating systems

### DIFF
--- a/orchestrator/scripts/watch.js
+++ b/orchestrator/scripts/watch.js
@@ -417,7 +417,7 @@ function loadGitignores() {
                 return path.posix.join(relativeDirPath, line);
             }
 
-            return normalizePath(line);
+            return line;
         }).filter(Boolean);
 
         if (lines.length > 0) {

--- a/orchestrator/scripts/watch.js
+++ b/orchestrator/scripts/watch.js
@@ -214,7 +214,7 @@ function collectKitFiles(folders) {
         }
 
         for (const file of getAllFiles(folderPath)) {
-            files.add(path.relative(folderPath, file).replace(/\\/g, '/'));
+            files.add(normalizePath(path.relative(folderPath, file)));
         }
     }
 
@@ -396,7 +396,7 @@ function loadGitignores() {
 
     for (const gitignorePath of gitignoreFiles) {
         const content = fs.readFileSync(gitignorePath, 'utf-8');
-        const relativeDirPath = path.relative(buildDir, path.dirname(gitignorePath));
+        const relativeDirPath = normalizePath(path.relative(buildDir, path.dirname(gitignorePath)));
 
         // Parse each line and prefix with the relative directory path
         const lines = content.split('\n').map(line => {
@@ -411,13 +411,13 @@ function loadGitignores() {
             if (relativeDirPath) {
                 // Handle negation patterns
                 if (line.startsWith('!')) {
-                    return '!' + path.join(relativeDirPath, line.slice(1));
+                    return '!' + path.posix.join(relativeDirPath, line.slice(1));
                 }
 
-                return path.join(relativeDirPath, line);
+                return path.posix.join(relativeDirPath, line);
             }
 
-            return line;
+            return normalizePath(line);
         }).filter(Boolean);
 
         if (lines.length > 0) {
@@ -442,7 +442,7 @@ function getStarterKit() {
  * Get the relative path from the build directory.
  */
 function getRelativePath(filePath) {
-    return path.relative(buildDir, filePath);
+    return normalizePath(path.relative(buildDir, filePath));
 }
 
 /**


### PR DESCRIPTION
## Summary

Normalize filesystem paths used by the starter kit watcher so they behave consistently across Windows, macOS, and Linux.

## Problem

The watcher uses the `ignore` package to determine whether files should be excluded based on the generated kit's `.gitignore` files.

On Windows, Node.js functions such as `path.relative()` and `path.join()` produce paths containing backslashes:

```text
database\database.sqlite
storage\framework\views\example.php
```

However, `.gitignore` patterns and the ignore package expect POSIX-style separators:

```text
database/database.sqlite
storage/framework/views/example.php
```

As a result, nested `.gitignore` rules may not match on Windows. This can cause ignored files to be synchronized or considered during stale-file reconciliation.

## Solution

This PR normalizes relative paths to use forward slashes before they are:

- matched against .gitignore rules;
- added to the set of generated build paths;
- compared during stale-file reconciliation.

It also uses `path.posix.join()` when prefixing patterns loaded from nested `.gitignore` files, ensuring that the generated patterns are platform-independent.

On macOS and Linux, paths already use forward slashes, so normalization is effectively a no-op.

## Result

The watcher now applies `.gitignore` rules consistently across:

- Windows
- macOS
- Linux