### PR TITLE
Install Node dependencies in the skeleton sync workflow

### DIFF
--- a/.github/workflows/sync-laravel-skeleton.yml
+++ b/.github/workflows/sync-laravel-skeleton.yml
@@ -34,6 +34,10 @@ jobs:
         working-directory: orchestrator
         run: composer install --no-interaction --prefer-dist
 
+      - name: Install Node Dependencies
+        working-directory: orchestrator
+        run: npm ci
+
       - name: Sync Skeleton
         working-directory: orchestrator
         run: composer skeleton:sync


### PR DESCRIPTION
## Overview

The scheduled [Sync Laravel Skeleton workflow fails](https://github.com/laravel/maestro/actions/runs/30995159370) with `Cannot find package 'cross-spawn'`. Since #189, `orchestrator/scripts/kit-helpers.js` imports `cross-spawn`, but the workflow only installs Composer dependencies, so `composer skeleton:sync` crashes as soon as Node loads the script.

## Solution

Add an `npm ci` step for `orchestrator/` before the sync step so the Node scripts have their dependencies available. This also covers the later `Build Pull Request Body` step, which runs the same script.