### PR TITLE
Bump guzzlehttp/guzzle in /orchestrator to fix security advisories

### DIFF
--- a/orchestrator/composer.lock
+++ b/orchestrator/composer.lock
@@ -642,16 +642,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
@@ -750,7 +750,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -766,7 +766,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",


### PR DESCRIPTION
## Overview

Dependabot and `composer audit` flag two advisories on `guzzlehttp/guzzle` 7.15.1 in the orchestrator: CVE-2026-69246 (high, noncanonical host can bypass host-based checks) and CVE-2026-69245 (medium, noncanonical cookie domain keeps subdomain scope).

## Solution

Update `guzzlehttp/guzzle` to 7.15.2, the first patched release. Guzzle is a transitive dependency, so only the lockfile changes. `composer audit` is clean and the orchestrator tests pass after the update.