### PR TITLE
Port Laravel skeleton v13.9.0 changes to the kits

### DIFF
--- a/kits/Inertia/Blank/React/package.json
+++ b/kits/Inertia/Blank/React/package.json
@@ -36,7 +36,7 @@
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^5.2.0",
         "clsx": "^2.1.1",
-        "concurrently": "^9.0.1",
+        "concurrently": "^10.0.3",
         "globals": "^15.14.0",
         "laravel-vite-plugin": "^3.1",
         "react": "^19.2.0",

--- a/kits/Inertia/Blank/React/package.json
+++ b/kits/Inertia/Blank/React/package.json
@@ -47,6 +47,7 @@
         "vite": "^8.0.0"
     },
     "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1",
         "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",
         "lightningcss-linux-x64-gnu": "^1.29.1"

--- a/kits/Inertia/Blank/Svelte/package.json
+++ b/kits/Inertia/Blank/Svelte/package.json
@@ -34,7 +34,7 @@
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tailwindcss/vite": "^4.1.11",
         "clsx": "^2.1.1",
-        "concurrently": "^9.0.1",
+        "concurrently": "^10.0.3",
         "laravel-vite-plugin": "^3.1",
         "svelte": "^5.16.0",
         "tailwind-merge": "^3.2.0",

--- a/kits/Inertia/Blank/Svelte/package.json
+++ b/kits/Inertia/Blank/Svelte/package.json
@@ -43,6 +43,7 @@
         "vite": "^8.0.0"
     },
     "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1",
         "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",
         "lightningcss-linux-x64-gnu": "^1.29.1"

--- a/kits/Inertia/Blank/Vue/package.json
+++ b/kits/Inertia/Blank/Vue/package.json
@@ -43,6 +43,7 @@
         "vue": "^3.5.13"
     },
     "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1",
         "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",
         "lightningcss-linux-x64-gnu": "^1.29.1"

--- a/kits/Inertia/Blank/Vue/package.json
+++ b/kits/Inertia/Blank/Vue/package.json
@@ -34,7 +34,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "@vitejs/plugin-vue": "^6.0.0",
         "clsx": "^2.1.1",
-        "concurrently": "^9.0.1",
+        "concurrently": "^10.0.3",
         "laravel-vite-plugin": "^3.1",
         "tailwind-merge": "^3.2.0",
         "tailwindcss": "^4.1.1",

--- a/kits/Inertia/Fortify/React/package.json
+++ b/kits/Inertia/Fortify/React/package.json
@@ -66,6 +66,7 @@
         "vite": "^8.0.0"
     },
     "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1",
         "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@rollup/rollup-win32-x64-msvc": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",

--- a/kits/Inertia/Fortify/React/package.json
+++ b/kits/Inertia/Fortify/React/package.json
@@ -51,7 +51,7 @@
         "@vitejs/plugin-react": "^5.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "concurrently": "^9.0.1",
+        "concurrently": "^10.0.3",
         "globals": "^15.14.0",
         "input-otp": "^1.4.2",
         "laravel-vite-plugin": "^3.0.0",

--- a/kits/Inertia/Fortify/Svelte/package.json
+++ b/kits/Inertia/Fortify/Svelte/package.json
@@ -48,6 +48,7 @@
         "tw-animate-css": "^1.2.5"
     },
     "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1",
         "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@rollup/rollup-win32-x64-msvc": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",

--- a/kits/Inertia/Fortify/Svelte/package.json
+++ b/kits/Inertia/Fortify/Svelte/package.json
@@ -18,7 +18,7 @@
         "@stylistic/eslint-plugin": "^5.10.0",
         "@tailwindcss/vite": "^4.1.11",
         "@types/node": "^22.13.5",
-        "concurrently": "^9.0.1",
+        "concurrently": "^10.0.3",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-import-resolver-typescript": "^4.4.4",

--- a/kits/Inertia/Fortify/Vue/package.json
+++ b/kits/Inertia/Fortify/Vue/package.json
@@ -51,6 +51,7 @@
         "vue-sonner": "^2.0.0"
     },
     "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1",
         "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@rollup/rollup-win32-x64-msvc": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",

--- a/kits/Inertia/Fortify/Vue/package.json
+++ b/kits/Inertia/Fortify/Vue/package.json
@@ -20,7 +20,7 @@
         "@types/node": "^22.13.5",
         "@vitejs/plugin-vue": "^6.0.0",
         "@vue/eslint-config-typescript": "^14.3.0",
-        "concurrently": "^9.0.1",
+        "concurrently": "^10.0.3",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-import-resolver-typescript": "^4.4.4",

--- a/kits/Inertia/React/package.json
+++ b/kits/Inertia/React/package.json
@@ -64,6 +64,7 @@
         "vite": "^8.0.0"
     },
     "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1",
         "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@rollup/rollup-win32-x64-msvc": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",

--- a/kits/Inertia/React/package.json
+++ b/kits/Inertia/React/package.json
@@ -50,7 +50,7 @@
         "@vitejs/plugin-react": "^5.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "concurrently": "^9.0.1",
+        "concurrently": "^10.0.3",
         "globals": "^15.14.0",
         "laravel-vite-plugin": "^3.1",
         "lucide-react": "^0.475.0",

--- a/kits/Inertia/Svelte/package.json
+++ b/kits/Inertia/Svelte/package.json
@@ -18,7 +18,7 @@
         "@laravel/vite-plugin-wayfinder": "^0.1.3",
         "@tailwindcss/vite": "^4.1.11",
         "@types/node": "^22.13.5",
-        "concurrently": "^9.0.1",
+        "concurrently": "^10.0.3",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-import-resolver-typescript": "^4.4.4",

--- a/kits/Inertia/Svelte/package.json
+++ b/kits/Inertia/Svelte/package.json
@@ -47,6 +47,7 @@
         "tw-animate-css": "^1.2.5"
     },
     "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1",
         "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@rollup/rollup-win32-x64-msvc": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",

--- a/kits/Inertia/Vue/package.json
+++ b/kits/Inertia/Vue/package.json
@@ -49,6 +49,7 @@
         "vue-sonner": "^2.0.0"
     },
     "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1",
         "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@rollup/rollup-win32-x64-msvc": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",

--- a/kits/Inertia/Vue/package.json
+++ b/kits/Inertia/Vue/package.json
@@ -20,7 +20,7 @@
         "@types/node": "^22.13.5",
         "@vitejs/plugin-vue": "^6.0.0",
         "@vue/eslint-config-typescript": "^14.3.0",
-        "concurrently": "^9.0.1",
+        "concurrently": "^10.0.3",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-import-resolver-typescript": "^4.4.4",

--- a/kits/Inertia/WorkOS/Vue/package.json
+++ b/kits/Inertia/WorkOS/Vue/package.json
@@ -49,6 +49,7 @@
         "vue-sonner": "^2.0.0"
     },
     "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1",
         "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@rollup/rollup-win32-x64-msvc": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",

--- a/kits/Inertia/WorkOS/Vue/package.json
+++ b/kits/Inertia/WorkOS/Vue/package.json
@@ -20,7 +20,7 @@
         "@types/node": "^22.13.5",
         "@vitejs/plugin-vue": "^6.0.0",
         "@vue/eslint-config-typescript": "^14.3.0",
-        "concurrently": "^9.0.1",
+        "concurrently": "^10.0.3",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-import-resolver-typescript": "^4.4.4",

--- a/kits/Livewire/Blank/package.json
+++ b/kits/Livewire/Blank/package.json
@@ -14,6 +14,7 @@
         "vite": "^8.0.0"
     },
     "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1",
         "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",
         "lightningcss-linux-x64-gnu": "^1.29.1"

--- a/kits/Livewire/Blank/package.json
+++ b/kits/Livewire/Blank/package.json
@@ -8,7 +8,7 @@
     },
     "dependencies": {
         "@tailwindcss/vite": "^4.1.11",
-        "concurrently": "^9.0.1",
+        "concurrently": "^10.0.3",
         "laravel-vite-plugin": "^3.1",
         "tailwindcss": "^4.0.7",
         "vite": "^8.0.0"

--- a/kits/Livewire/Fortify/package.json
+++ b/kits/Livewire/Fortify/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "@laravel/passkeys": "^0.2.0",
         "@tailwindcss/vite": "^4.1.11",
-        "concurrently": "^9.0.1",
+        "concurrently": "^10.0.3",
         "laravel-vite-plugin": "^3.1",
         "tailwindcss": "^4.0.7",
         "vite": "^8.0.0"

--- a/kits/Livewire/Fortify/package.json
+++ b/kits/Livewire/Fortify/package.json
@@ -15,6 +15,7 @@
         "vite": "^8.0.0"
     },
     "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1",
         "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",
         "lightningcss-linux-x64-gnu": "^1.29.1"

--- a/kits/Shared/WorkOS/.env.example
+++ b/kits/Shared/WorkOS/.env.example
@@ -2,7 +2,7 @@ APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://localhost:8000
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/kits/Shared/WorkOS/config/services.php
+++ b/kits/Shared/WorkOS/config/services.php
@@ -8,7 +8,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | This file is for storing the credentials for third party services such
-    | as Mailgun, Postmark, AWS and more. This file provides the de facto
+    | as Resend, Postmark, AWS, and more. This file provides the de facto
     | location for this type of information, allowing packages to have
     | a conventional file to locate the various service credentials.
     |


### PR DESCRIPTION
## Overview

Laravel skeleton v13.9.0 shipped a few changes the automated sync doesn't pick up, since it only writes to `kits/Shared/Blank`. The WorkOS layer and the kit `package.json` files were left behind.

## Solution

Update the WorkOS layer's `.env.example` and `config/services.php` to match the already-synced Blank layer, bump `concurrently` to v10 in all 12 kit `package.json` files, and add `@laravel/multiplex` as an optional dependency, matching the skeleton.

## Details

The `artisan dev` command the kits already use prefers `@laravel/multiplex` when it's installed and falls back to `concurrently`, so the kits now match the skeleton on both.