### PR TITLE
Bump league/commonmark in /orchestrator to fix security advisories

### DIFF
--- a/orchestrator/composer.lock
+++ b/orchestrator/composer.lock
@@ -1475,16 +1475,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.3",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7"
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/1902f60f984235023acbe03db6ad614a37b3c3e7",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
                 "shasum": ""
             },
             "require": {
@@ -1521,7 +1521,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.11-dev"
                 }
             },
             "autoload": {
@@ -1578,7 +1578,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-12T15:29:16+00:00"
+            "time": "2026-08-11T16:06:25+00:00"
         },
         {
             "name": "league/config",


### PR DESCRIPTION
## Overview

`composer audit` flags 6 security advisories in `league/commonmark` 2.8.3 — five denial-of-service issues and an unsafe-link filter bypass, all fixed in 2.9.0.

## Solution

Update the orchestrator lockfile to `league/commonmark` 2.10.0. It's a transitive dependency of `laravel/framework` and the existing `^2.8.1` constraint already allows it, so only `composer.lock` changes. `composer audit` is clean after the update.