### PR TITLE
fix(DevCommands): skip Pail logs process on Windows

### DIFF
--- a/kits/Shared/Blank/app/Providers/AppServiceProvider.php
+++ b/kits/Shared/Blank/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Carbon\CarbonImmutable;
+use Illuminate\Foundation\DevCommands;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
@@ -32,6 +33,10 @@ class AppServiceProvider extends ServiceProvider
     protected function configureDefaults(): void
     {
         Date::use(CarbonImmutable::class);
+
+        if (windows_os()) {
+            DevCommands::except('logs');
+        }
 
         DB::prohibitDestructiveCommands(
             app()->isProduction(),


### PR DESCRIPTION
`php artisan dev` starts a `logs` process that runs Pail, which [requires the PCNTL extension](https://laravel.com/docs/13.x/logging#pail-installation), which is unavailable on native Windows. This causes `php artisan dev` to fail out of the gate for Windows developers.

This PR excludes the `logs` process on Windows via the shared `AppServiceProvider` (inherited by all starter kits):

```php
if (windows_os()) {
    DevCommands::except('logs');
}
```

`server`, `queue`, and `vite` still run as normal. No-op on Linux/macOS.
