### PR TITLE
Add server watch ignore patterns for vendor, and AI assistant directories

### DIFF
--- a/kits/Inertia/Blank/React/vite.config.ts
+++ b/kits/Inertia/Blank/React/vite.config.ts
@@ -30,7 +30,13 @@ export default defineConfig({
     ],
     server: {
         watch: {
-            ignored: ['**/vendor/**', '**/node_modules/**', '**/.git/**'],
+            ignored: [
+                '**/.agents/**',
+                '**/.claude/**',
+                '**/.cursor/**',
+                '**/.junie/**',
+                '**/vendor/**',
+            ],
         },
     },
 });

--- a/kits/Inertia/Blank/React/vite.config.ts
+++ b/kits/Inertia/Blank/React/vite.config.ts
@@ -28,4 +28,9 @@ export default defineConfig({
             formVariants: true,
         }),
     ],
+    server: {
+        watch: {
+            ignored: ['**/vendor/**', '**/node_modules/**', '**/.git/**'],
+        },
+    },
 });

--- a/kits/Inertia/Blank/Svelte/vite.config.ts
+++ b/kits/Inertia/Blank/Svelte/vite.config.ts
@@ -30,4 +30,9 @@ export default defineConfig({
             formVariants: true,
         }),
     ],
+    server: {
+        watch: {
+            ignored: ['**/vendor/**', '**/node_modules/**', '**/.git/**'],
+        },
+    },
 });

--- a/kits/Inertia/Blank/Svelte/vite.config.ts
+++ b/kits/Inertia/Blank/Svelte/vite.config.ts
@@ -32,7 +32,13 @@ export default defineConfig({
     ],
     server: {
         watch: {
-            ignored: ['**/vendor/**', '**/node_modules/**', '**/.git/**'],
+            ignored: [
+                '**/.agents/**',
+                '**/.claude/**',
+                '**/.cursor/**',
+                '**/.junie/**',
+                '**/vendor/**',
+            ],
         },
     },
 });

--- a/kits/Inertia/Blank/Vue/vite.config.ts
+++ b/kits/Inertia/Blank/Vue/vite.config.ts
@@ -33,7 +33,13 @@ export default defineConfig({
     ],
     server: {
         watch: {
-            ignored: ['**/vendor/**', '**/node_modules/**', '**/.git/**'],
+            ignored: [
+                '**/.agents/**',
+                '**/.claude/**',
+                '**/.cursor/**',
+                '**/.junie/**',
+                '**/vendor/**',
+            ],
         },
     },
 });

--- a/kits/Inertia/Blank/Vue/vite.config.ts
+++ b/kits/Inertia/Blank/Vue/vite.config.ts
@@ -31,4 +31,9 @@ export default defineConfig({
             formVariants: true,
         }),
     ],
+    server: {
+        watch: {
+            ignored: ['**/vendor/**', '**/node_modules/**', '**/.git/**'],
+        },
+    },
 });

--- a/kits/Livewire/Blank/vite.config.js
+++ b/kits/Livewire/Blank/vite.config.js
@@ -21,7 +21,14 @@ export default defineConfig({
     server: {
         cors: true,
         watch: {
-            ignored: ['**/storage/framework/views/**', '**/vendor/**', '**/node_modules/**', '**/.git/**'],
+            ignored: [
+                '**/.agents/**',
+                '**/.claude/**',
+                '**/.cursor/**',
+                '**/.junie/**',
+                '**/storage/framework/views/**',
+                '**/vendor/**',
+            ],
         },
     },
 });

--- a/kits/Livewire/Blank/vite.config.js
+++ b/kits/Livewire/Blank/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
     server: {
         cors: true,
         watch: {
-            ignored: ['**/storage/framework/views/**'],
+            ignored: ['**/storage/framework/views/**', '**/vendor/**', '**/node_modules/**', '**/.git/**'],
         },
     },
 });

--- a/kits/Livewire/Fortify/vite.config.js
+++ b/kits/Livewire/Fortify/vite.config.js
@@ -27,7 +27,14 @@ export default defineConfig({
     server: {
         cors: true,
         watch: {
-            ignored: ['**/storage/framework/views/**', '**/vendor/**', '**/node_modules/**', '**/.git/**'],
+            ignored: [
+                '**/.agents/**',
+                '**/.claude/**',
+                '**/.cursor/**',
+                '**/.junie/**',
+                '**/storage/framework/views/**',
+                '**/vendor/**',
+            ],
         },
     },
 });

--- a/kits/Livewire/Fortify/vite.config.js
+++ b/kits/Livewire/Fortify/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig({
     server: {
         cors: true,
         watch: {
-            ignored: ['**/storage/framework/views/**'],
+            ignored: ['**/storage/framework/views/**', '**/vendor/**', '**/node_modules/**', '**/.git/**'],
         },
     },
 });


### PR DESCRIPTION
Added Vite's `server.watch.ignored` configuration to all 5 starter kit `vite.config.*` files, telling Vite's file watcher to skip `vendor/`, `node_modules/`, and `.git/` directories.

Without these ignores the Vite dev server can run out of memory and/or limit of watched files very quickly.

This is easily fixable by each developer running one CLI command to increase the memory limit or watched file count in their machine, but adding this prevent that for all Starter Kits would be a good addition.