### PR TITLE
Fix `position: sticky` inside the Inertia sidebar layouts

### DIFF
--- a/kits/Inertia/React/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/kits/Inertia/React/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -11,7 +11,7 @@ export default function AppSidebarLayout({
     return (
         <AppShell variant="sidebar">
             <AppSidebar />
-            <AppContent variant="sidebar" className="overflow-x-hidden">
+            <AppContent variant="sidebar" className="min-w-0 overflow-x-clip">
                 <AppSidebarHeader breadcrumbs={breadcrumbs} />
                 {children}
             </AppContent>

--- a/kits/Inertia/Svelte/resources/js/layouts/app/AppSidebarLayout.svelte
+++ b/kits/Inertia/Svelte/resources/js/layouts/app/AppSidebarLayout.svelte
@@ -18,7 +18,7 @@
 
 <AppShell variant="sidebar">
     <AppSidebar />
-    <AppContent variant="sidebar" class="overflow-x-hidden">
+    <AppContent variant="sidebar" class="min-w-0 overflow-x-clip">
         <AppSidebarHeader {breadcrumbs} />
         {@render children?.()}
     </AppContent>

--- a/kits/Inertia/Vue/resources/js/layouts/app/AppSidebarLayout.vue
+++ b/kits/Inertia/Vue/resources/js/layouts/app/AppSidebarLayout.vue
@@ -18,7 +18,7 @@ withDefaults(defineProps<Props>(), {
 <template>
     <AppShell variant="sidebar">
         <AppSidebar />
-        <AppContent variant="sidebar" class="overflow-x-hidden">
+        <AppContent variant="sidebar" class="min-w-0 overflow-x-clip">
             <AppSidebarHeader :breadcrumbs="breadcrumbs" />
             <slot />
         </AppContent>


### PR DESCRIPTION
## Overview

The `overflow-x-hidden` class on `AppContent` in the sidebar layouts turns the `<main>` element into a scroll container, because setting one overflow axis to `hidden` makes the other compute to `auto`. Any `position: sticky` element in page content then resolves against `<main>` instead of the viewport and never sticks, since `<main>` grows to fit its content and never scrolls. Reported in inertiajs/inertia#3219, where it was confirmed to be a starter kit CSS issue.

## Solution

Replace `overflow-x-hidden` with `min-w-0 overflow-x-clip` on `AppContent` in the React, Vue, and Svelte sidebar layouts. `overflow-x: clip` clips horizontal overflow without creating a scroll container, and `min-w-0` keeps wide content from stretching the flex item, which `clip` alone does not prevent.

## Details

The fix suggested in the issue comments (`contain: inline-size paint`) also restores sticky behavior, but paint containment makes `<main>` the containing block for `position: fixed` descendants and adds a new stacking context, so fixed elements in page content would scroll away with it. The combination in this PR was validated in the browser against all four scenarios: sticky pinning, wide content blowout, fixed positioning, and page level horizontal scroll. Livewire is not affected, since Flux's `main` component never had the class. `kits:lint` and `kits:check` passed for every React, Vue, and Svelte variant.