### PR TITLE
Render the Livewire auth header as a level 1 heading

### DIFF
--- a/kits/Livewire/Base/resources/views/components/auth-header.blade.php
+++ b/kits/Livewire/Base/resources/views/components/auth-header.blade.php
@@ -4,6 +4,6 @@
 ])
 
 <div class="flex w-full flex-col text-center">
-    <flux:heading size="xl">{{ $title }}</flux:heading>
+    <flux:heading size="xl" level="1">{{ $title }}</flux:heading>
     <flux:subheading>{{ $description }}</flux:subheading>
 </div>


### PR DESCRIPTION
## Overview

The Livewire auth pages render their title through `flux:heading` without a `level`. `flux:heading` only emits `<h1>`–`<h6>` when it is given one, and otherwise falls through to its default branch and emits a `<div>`, so every auth screen in the Livewire kit ships without a heading element. A freshly built kit serves `/login` with zero headings.

The Inertia kits already use a real `<h1>` for the same title in their auth layouts, and this repository already passes `level="1"` in `partials/settings-heading.blade.php`.

## Solution

Pass `level="1"` in `kits/Livewire/Base/resources/views/components/auth-header.blade.php`. The component is shared, so this covers login, register, forgot password, reset password, confirm password and two factor challenge across the Fortify, Teams and WorkOS variants.

## Details

`flux:heading` applies the same classes and the same `data-flux-heading` attribute in every branch of its switch, so only the tag name changes. Diffing the rendered `/login` before and after gives a single changed line, `<div>` to `<h1>`, with an identical class attribute. The heading computes to 24px at weight 500 either way, since Tailwind's preflight resets the `<h1>` defaults, so there is no visual change.

`pages/auth/two-factor-challenge.blade.php` uses the component twice, for the authentication code and recovery code states, toggled with `x-show`. That page now serves two `<h1>` elements rather than none. Both are valid, and `x-show` sets `display: none`, so only the active one is exposed. Happy to give the component a `level` prop defaulting to `1` if you would rather that page opted out.

Built and checked against the Livewire (Fortify) kit; `php artisan test` passes with 33 tests and 81 assertions.
