### PR TITLE
Render the Livewire `sr-only` headings as level 2 headings

### DIFF
--- a/kits/Livewire/Base/resources/views/pages/settings/appearance.blade.php
+++ b/kits/Livewire/Base/resources/views/pages/settings/appearance.blade.php
@@ -10,7 +10,7 @@ new #[Title('Appearance settings')] class extends Component {
 <section class="w-full">
     @include('partials.settings-heading')
 
-    <flux:heading class="sr-only">{{ __('Appearance settings') }}</flux:heading>
+    <flux:heading level="2" class="sr-only">{{ __('Appearance settings') }}</flux:heading>
 
     <x-pages::settings.layout :heading="__('Appearance')" :subheading="__('Update the appearance settings for your account')">
         <flux:radio.group x-data variant="segmented" x-model="$flux.appearance">

--- a/kits/Livewire/Base/resources/views/pages/settings/profile.blade.php
+++ b/kits/Livewire/Base/resources/views/pages/settings/profile.blade.php
@@ -78,7 +78,7 @@ new #[Title('Profile settings')] class extends Component {
 <section class="w-full">
     @include('partials.settings-heading')
 
-    <flux:heading class="sr-only">{{ __('Profile settings') }}</flux:heading>
+    <flux:heading level="2" class="sr-only">{{ __('Profile settings') }}</flux:heading>
 
     <x-pages::settings.layout :heading="__('Profile')" :subheading="__('Update your name and email address')">
         <form wire:submit="updateProfileInformation" class="my-6 w-full space-y-6">

--- a/kits/Livewire/Components/resources/views/livewire/settings/appearance.blade.php
+++ b/kits/Livewire/Components/resources/views/livewire/settings/appearance.blade.php
@@ -1,7 +1,7 @@
 <section class="w-full">
     @include('partials.settings-heading')
 
-    <flux:heading class="sr-only">{{ __('Appearance settings') }}</flux:heading>
+    <flux:heading level="2" class="sr-only">{{ __('Appearance settings') }}</flux:heading>
 
     <x-settings.layout :heading="__('Appearance')" :subheading=" __('Update the appearance settings for your account')">
         <flux:radio.group x-data variant="segmented" x-model="$flux.appearance">

--- a/kits/Livewire/Components/resources/views/livewire/settings/profile.blade.php
+++ b/kits/Livewire/Components/resources/views/livewire/settings/profile.blade.php
@@ -1,7 +1,7 @@
 <section class="w-full">
     @include('partials.settings-heading')
 
-    <flux:heading class="sr-only">{{ __('Profile settings') }}</flux:heading>
+    <flux:heading level="2" class="sr-only">{{ __('Profile settings') }}</flux:heading>
 
     <x-settings.layout :heading="__('Profile')" :subheading="__('Update your name and email address')">
         <form wire:submit="updateProfileInformation" class="my-6 w-full space-y-6">

--- a/kits/Livewire/Components/resources/views/livewire/settings/security.blade.php
+++ b/kits/Livewire/Components/resources/views/livewire/settings/security.blade.php
@@ -1,7 +1,7 @@
 <section class="w-full">
     @include('partials.settings-heading')
 
-    <flux:heading class="sr-only">{{ __('Security settings') }}</flux:heading>
+    <flux:heading level="2" class="sr-only">{{ __('Security settings') }}</flux:heading>
 
     <x-settings.layout :heading="__('Update password')" :subheading="__('Ensure your account is using a long, random password to stay secure')">
         <form method="POST" wire:submit="updatePassword" class="mt-6 space-y-6">

--- a/kits/Livewire/Fortify/resources/views/pages/settings/profile.blade.php
+++ b/kits/Livewire/Fortify/resources/views/pages/settings/profile.blade.php
@@ -83,7 +83,7 @@ new #[Title('Profile settings')] class extends Component {
 <section class="w-full">
     @include('partials.settings-heading')
 
-    <flux:heading class="sr-only">{{ __('Profile settings') }}</flux:heading>
+    <flux:heading level="2" class="sr-only">{{ __('Profile settings') }}</flux:heading>
 
     <x-pages::settings.layout :heading="__('Profile')" :subheading="__('Update your name and email address')">
         <form wire:submit="updateProfileInformation" class="my-6 w-full space-y-6">

--- a/kits/Livewire/Fortify/resources/views/pages/settings/security.blade.php
+++ b/kits/Livewire/Fortify/resources/views/pages/settings/security.blade.php
@@ -185,7 +185,7 @@ new #[Title('Security settings')] class extends Component {
 <section class="w-full">
     @include('partials.settings-heading')
 
-    <flux:heading class="sr-only">{{ __('Security settings') }}</flux:heading>
+    <flux:heading level="2" class="sr-only">{{ __('Security settings') }}</flux:heading>
 
     <x-pages::settings.layout :heading="__('Update password')" :subheading="__('Ensure your account is using a long, random password to stay secure')">
         <form method="POST" wire:submit="updatePassword" class="mt-6 space-y-6">

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/edit.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/edit.blade.php
@@ -140,7 +140,7 @@ new class extends Component
 <section class="w-full">
     @include('partials.settings-heading')
 
-    <flux:heading class="sr-only">{{ __('Teams') }}</flux:heading>
+    <flux:heading level="2" class="sr-only">{{ __('Teams') }}</flux:heading>
 
     <x-pages::settings.layout :heading="__('Teams')" :subheading="__('Manage your team settings')">
         <div class="space-y-10">

--- a/kits/Livewire/Teams/Base/resources/views/pages/teams/index.blade.php
+++ b/kits/Livewire/Teams/Base/resources/views/pages/teams/index.blade.php
@@ -71,7 +71,7 @@ new #[Title('Teams')] class extends Component {
 <section class="w-full">
     @include('partials.settings-heading')
 
-    <flux:heading class="sr-only">{{ __('Teams') }}</flux:heading>
+    <flux:heading level="2" class="sr-only">{{ __('Teams') }}</flux:heading>
 
     <x-pages::settings.layout :heading="__('Teams')" :subheading="__('Manage your teams and team memberships')">
         <div class="flex items-center justify-end">

--- a/kits/Livewire/WorkOS/resources/views/pages/settings/profile.blade.php
+++ b/kits/Livewire/WorkOS/resources/views/pages/settings/profile.blade.php
@@ -40,7 +40,7 @@ new #[Title('Profile settings')] class extends Component {
 <section class="w-full">
     @include('partials.settings-heading')
 
-    <flux:heading class="sr-only">{{ __('Profile settings') }}</flux:heading>
+    <flux:heading level="2" class="sr-only">{{ __('Profile settings') }}</flux:heading>
 
     <x-pages::settings.layout :heading="__('Profile')" :subheading="__('Update your name and email address')">
         <form wire:submit="updateProfileInformation" class="my-6 w-full space-y-6">


### PR DESCRIPTION
## Overview

The `sr-only` `flux:heading` instances across the Livewire kits render as `<div>` elements because `flux:heading` only emits a real heading tag when it receives a `level`. These headings exist purely for screen readers, and as `<div>`s they are invisible to heading navigation, which defeats their purpose. This follows up on #204, which fixed the same problem for the auth pages.

## Solution

Pass `level="2"` to the 10 `sr-only` headings on the settings, security, appearance, and teams pages. Every affected page already renders `<h1>Settings</h1>` from the shared `settings-heading` partial, so the hierarchy stays valid.

## Details

This also matches the Inertia kits, which render these same page titles as real `sr-only` heading elements.