### PR TITLE
Scope personalTeam() to teams the user owns

### DIFF
--- a/kits/Inertia/Teams/Base/tests/Feature/Teams/TeamTest.php
+++ b/kits/Inertia/Teams/Base/tests/Feature/Teams/TeamTest.php
@@ -42,6 +42,24 @@ class TeamTest extends TestCase
         ]);
     }
 
+    public function test_personal_team_returns_the_team_owned_by_the_user()
+    {
+        $otherUser = User::factory()->create();
+        $user = User::factory()->make();
+        $user->save();
+
+        $otherUser->personalTeam()->members()->attach($user, [
+            'role' => TeamRole::Member->value,
+        ]);
+
+        $personalTeam = Team::factory()->personal()->create();
+        $personalTeam->members()->attach($user, [
+            'role' => TeamRole::Owner->value,
+        ]);
+
+        $this->assertTrue($personalTeam->is($user->personalTeam()));
+    }
+
     public function test_team_slug_uses_next_available_suffix()
     {
         $user = User::factory()->create();

--- a/kits/Livewire/Teams/Base/tests/Feature/Teams/TeamTest.php
+++ b/kits/Livewire/Teams/Base/tests/Feature/Teams/TeamTest.php
@@ -41,6 +41,24 @@ class TeamTest extends TestCase
         ]);
     }
 
+    public function test_personal_team_returns_the_team_owned_by_the_user(): void
+    {
+        $otherUser = User::factory()->create();
+        $user = User::factory()->make();
+        $user->save();
+
+        $otherUser->personalTeam()->members()->attach($user, [
+            'role' => TeamRole::Member->value,
+        ]);
+
+        $personalTeam = Team::factory()->personal()->create();
+        $personalTeam->members()->attach($user, [
+            'role' => TeamRole::Owner->value,
+        ]);
+
+        $this->assertTrue($personalTeam->is($user->personalTeam()));
+    }
+
     public function test_team_slug_uses_next_available_suffix(): void
     {
         $user = User::factory()->create();

--- a/kits/Shared/Teams/Base/app/Concerns/HasTeams.php
+++ b/kits/Shared/Teams/Base/app/Concerns/HasTeams.php
@@ -72,6 +72,7 @@ trait HasTeams
     public function personalTeam(): ?Team
     {
         return $this->teams()
+            ->wherePivot('role', TeamRole::Owner->value)
             ->where('is_personal', true)
             ->first();
     }

--- a/kits/Shared/Teams/Base/app/Concerns/HasTeams.php
+++ b/kits/Shared/Teams/Base/app/Concerns/HasTeams.php
@@ -71,9 +71,8 @@ trait HasTeams
      */
     public function personalTeam(): ?Team
     {
-        return $this->teams()
-            ->wherePivot('role', TeamRole::Owner->value)
-            ->where('is_personal', true)
+        return $this->ownedTeams()
+            ->where('teams.is_personal', true)
             ->first();
     }
 


### PR DESCRIPTION
`personalTeam()` resolved the personal team through `teams()`, which returns every team the user belongs to whatever their role.

Scoping the pivot to the owner role makes the result unambiguous: a user owns exactly one personal team, created at registration.