### PR TITLE
Align YAML indentation with Oxfmt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 trim_trailing_whitespace = false
 
 [*.{yml,yaml}]
-indent_size = 2
+indent_size = 4
 
 [compose.yaml]
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,9 +10,3 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.{yml,yaml}]
-indent_size = 4
-
-[compose.yaml]
-indent_size = 4

--- a/kits/Shared/Blank/.editorconfig
+++ b/kits/Shared/Blank/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 trim_trailing_whitespace = false
 
 [*.{yml,yaml}]
-indent_size = 2
+indent_size = 4
 
 [{compose,docker-compose}.{yml,yaml}]
 indent_size = 4

--- a/kits/Shared/Blank/.editorconfig
+++ b/kits/Shared/Blank/.editorconfig
@@ -10,9 +10,3 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.{yml,yaml}]
-indent_size = 4
-
-[{compose,docker-compose}.{yml,yaml}]
-indent_size = 4


### PR DESCRIPTION
## Overview

Oxfmt formats YAML using four spaces, while EditorConfig overrides YAML files to use two. This causes files such as `pnpm-workspace.yaml` to use inconsistent indentation.

## Solution

Remove the redundant YAML and Compose overrides so all files inherit the global four-space indentation.

Fixes #207