### PR TITLE
Use oxfmt's stylesheet option for Tailwind class sorting

### DIFF
--- a/kits/Inertia/Blank/React/vite.config.ts
+++ b/kits/Inertia/Blank/React/vite.config.ts
@@ -71,7 +71,7 @@ export default defineConfig({
         ],
         sortTailwindcss: {
             functions: ['clsx', 'cn', 'cva'],
-            entryPoint: 'resources/css/app.css',
+            stylesheet: 'resources/css/app.css',
         },
     },
 });

--- a/kits/Inertia/Blank/Svelte/vite.config.ts
+++ b/kits/Inertia/Blank/Svelte/vite.config.ts
@@ -75,7 +75,7 @@ export default defineConfig({
         ],
         sortTailwindcss: {
             functions: ['clsx', 'cn', 'cva'],
-            entryPoint: 'resources/css/app.css',
+            stylesheet: 'resources/css/app.css',
         },
     },
 });

--- a/kits/Inertia/Blank/Vue/vite.config.ts
+++ b/kits/Inertia/Blank/Vue/vite.config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
         ],
         sortTailwindcss: {
             functions: ['clsx', 'cn', 'cva'],
-            entryPoint: 'resources/css/app.css',
+            stylesheet: 'resources/css/app.css',
         },
     },
 });

--- a/kits/Inertia/Fortify/React/resources/js/components/manage-passkeys.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/components/manage-passkeys.tsx
@@ -14,11 +14,11 @@ export type Props = {
 const EmptyState = () => {
     return (
         <div className="p-8 text-center">
-            <div className="bg-muted mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl">
-                <KeyRound className="text-muted-foreground h-7 w-7" />
+            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-muted">
+                <KeyRound className="h-7 w-7 text-muted-foreground" />
             </div>
             <p className="font-medium">No passkeys yet</p>
-            <p className="text-muted-foreground mt-1 text-sm">
+            <p className="mt-1 text-sm text-muted-foreground">
                 Add a passkey to sign in without a password
             </p>
         </div>
@@ -51,7 +51,7 @@ export default function ManagePasskeys(props: Props) {
                 description="Manage your passkeys for passwordless sign-in"
             />
 
-            <div className="border-border overflow-hidden rounded-lg border">
+            <div className="overflow-hidden rounded-lg border border-border">
                 {passkeys.length > 0 ? (
                     passkeys.map((passkey) => (
                         <PasskeyItem

--- a/kits/Inertia/Fortify/React/resources/js/components/manage-two-factor.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/components/manage-two-factor.tsx
@@ -53,7 +53,7 @@ export default function ManageTwoFactor(props: Props) {
             />
             {twoFactorEnabled ? (
                 <div className="flex flex-col items-start justify-start space-y-4">
-                    <p className="text-muted-foreground text-sm">
+                    <p className="text-sm text-muted-foreground">
                         You will be prompted for a secure, random pin during
                         login, which you can retrieve from the TOTP-supported
                         application on your phone.
@@ -81,7 +81,7 @@ export default function ManageTwoFactor(props: Props) {
                 </div>
             ) : (
                 <div className="flex flex-col items-start justify-start space-y-4">
-                    <p className="text-muted-foreground text-sm">
+                    <p className="text-sm text-muted-foreground">
                         When you enable two-factor authentication, you will be
                         prompted for a secure pin during login. This pin can be
                         retrieved from a TOTP-supported application on your

--- a/kits/Inertia/Fortify/React/resources/js/components/passkey-item.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/components/passkey-item.tsx
@@ -28,8 +28,8 @@ export default function PasskeyItem({ passkey, onDelete }: Props) {
     return (
         <div className="flex items-center justify-between border-b p-4 last:border-b-0">
             <div className="flex items-center gap-4">
-                <div className="bg-muted flex h-10 w-10 shrink-0 items-center justify-center rounded-xl">
-                    <KeyRound className="text-muted-foreground h-5 w-5" />
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted">
+                    <KeyRound className="h-5 w-5 text-muted-foreground" />
                 </div>
                 <div className="space-y-1">
                     <div className="flex items-center gap-2.5">
@@ -37,16 +37,16 @@ export default function PasskeyItem({ passkey, onDelete }: Props) {
                             {passkey.name}
                         </p>
                         {passkey.authenticator && (
-                            <span className="bg-muted text-muted-foreground ring-border inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium tracking-wide uppercase ring-1 ring-inset">
+                            <span className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium tracking-wide text-muted-foreground uppercase ring-1 ring-border ring-inset">
                                 {passkey.authenticator}
                             </span>
                         )}
                     </div>
-                    <p className="text-muted-foreground text-sm">
+                    <p className="text-sm text-muted-foreground">
                         Added {passkey.created_at_diff}
                         {passkey.last_used_at_diff && (
                             <>
-                                <span className="text-muted-foreground/50 mx-1">
+                                <span className="mx-1 text-muted-foreground/50">
                                     /
                                 </span>
                                 Last used {passkey.last_used_at_diff}

--- a/kits/Inertia/Fortify/React/resources/js/components/passkey-register.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/components/passkey-register.tsx
@@ -58,7 +58,7 @@ export default function PasskeyRegistration({ onSuccess }: Props) {
 
     if (!isSupported) {
         return (
-            <div className="text-muted-foreground text-sm">
+            <div className="text-sm text-muted-foreground">
                 Passkeys are not supported in this browser.
             </div>
         );
@@ -75,7 +75,7 @@ export default function PasskeyRegistration({ onSuccess }: Props) {
     return (
         <form
             onSubmit={handleSubmit}
-            className="border-border bg-muted/50 space-y-4 rounded-lg border p-4"
+            className="space-y-4 rounded-lg border border-border bg-muted/50 p-4"
         >
             <div className="grid gap-2">
                 <Label htmlFor="passkey-name">Passkey name</Label>
@@ -85,10 +85,10 @@ export default function PasskeyRegistration({ onSuccess }: Props) {
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     placeholder="e.g., MacBook Pro, iPhone"
-                    className="border-foreground/20 mt-1 block w-full"
+                    className="mt-1 block w-full border-foreground/20"
                     autoFocus
                 />
-                <p className="text-muted-foreground text-xs">
+                <p className="text-xs text-muted-foreground">
                     A name helps you identify this passkey later.
                 </p>
             </div>

--- a/kits/Inertia/Fortify/React/resources/js/components/passkey-verify.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/components/passkey-verify.tsx
@@ -64,7 +64,7 @@ export default function PasskeyVerify({
                     <Separator className="w-full" />
                 </div>
                 <div className="relative flex justify-center text-xs uppercase">
-                    <span className="bg-background text-muted-foreground px-2">
+                    <span className="bg-background px-2 text-muted-foreground">
                         {separator ?? 'Or continue with email'}
                     </span>
                 </div>

--- a/kits/Inertia/Fortify/React/resources/js/components/two-factor-recovery-codes.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/components/two-factor-recovery-codes.tsx
@@ -110,7 +110,7 @@ export default function TwoFactorRecoveryCodes({
                             <>
                                 <div
                                     ref={codesSectionRef}
-                                    className="bg-muted grid gap-1 rounded-lg p-4 font-mono text-sm"
+                                    className="grid gap-1 rounded-lg bg-muted p-4 font-mono text-sm"
                                     role="list"
                                     aria-label="Recovery codes"
                                 >
@@ -134,7 +134,7 @@ export default function TwoFactorRecoveryCodes({
                                                 (_, index) => (
                                                     <div
                                                         key={index}
-                                                        className="bg-muted-foreground/20 h-4 animate-pulse rounded"
+                                                        className="h-4 animate-pulse rounded bg-muted-foreground/20"
                                                         aria-hidden="true"
                                                     />
                                                 ),
@@ -143,7 +143,7 @@ export default function TwoFactorRecoveryCodes({
                                     )}
                                 </div>
 
-                                <div className="text-muted-foreground text-xs select-none">
+                                <div className="text-xs text-muted-foreground select-none">
                                     <p id="regenerate-warning">
                                         Each recovery code can be used once to
                                         access your account and will be removed

--- a/kits/Inertia/Fortify/React/resources/js/components/two-factor-setup-modal.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/components/two-factor-setup-modal.tsx
@@ -25,13 +25,13 @@ import { confirm } from '@/routes/two-factor';
 
 function GridScanIcon() {
     return (
-        <div className="border-border bg-card mb-3 rounded-full border p-0.5 shadow-sm">
-            <div className="border-border bg-muted relative overflow-hidden rounded-full border p-2.5">
+        <div className="mb-3 rounded-full border border-border bg-card p-0.5 shadow-sm">
+            <div className="relative overflow-hidden rounded-full border border-border bg-muted p-2.5">
                 <div className="absolute inset-0 grid grid-cols-5 opacity-50">
                     {Array.from({ length: 5 }, (_, i) => (
                         <div
                             key={`col-${i + 1}`}
-                            className="border-border border-r last:border-r-0"
+                            className="border-r border-border last:border-r-0"
                         />
                     ))}
                 </div>
@@ -39,11 +39,11 @@ function GridScanIcon() {
                     {Array.from({ length: 5 }, (_, i) => (
                         <div
                             key={`row-${i + 1}`}
-                            className="border-border border-b last:border-b-0"
+                            className="border-b border-border last:border-b-0"
                         />
                     ))}
                 </div>
-                <ScanLine className="text-foreground relative z-20 size-6" />
+                <ScanLine className="relative z-20 size-6 text-foreground" />
             </div>
         </div>
     );
@@ -73,7 +73,7 @@ function TwoFactorSetupStep({
             ) : (
                 <>
                     <div className="mx-auto flex max-w-md overflow-hidden">
-                        <div className="border-border mx-auto aspect-square w-64 rounded-lg border">
+                        <div className="mx-auto aspect-square w-64 rounded-lg border border-border">
                             <div className="z-10 flex h-full w-full items-center justify-center p-5">
                                 {qrCodeSvg ? (
                                     <div
@@ -102,16 +102,16 @@ function TwoFactorSetupStep({
                     </div>
 
                     <div className="relative flex w-full items-center justify-center">
-                        <div className="bg-border absolute inset-0 top-1/2 h-px w-full" />
-                        <span className="bg-card relative px-2 py-1">
+                        <div className="absolute inset-0 top-1/2 h-px w-full bg-border" />
+                        <span className="relative bg-card px-2 py-1">
                             or, enter the code manually
                         </span>
                     </div>
 
                     <div className="flex w-full space-x-2">
-                        <div className="border-border flex w-full items-stretch overflow-hidden rounded-xl border">
+                        <div className="flex w-full items-stretch overflow-hidden rounded-xl border border-border">
                             {!manualSetupKey ? (
-                                <div className="bg-muted flex h-full w-full items-center justify-center p-3">
+                                <div className="flex h-full w-full items-center justify-center bg-muted p-3">
                                     <Spinner />
                                 </div>
                             ) : (
@@ -120,11 +120,11 @@ function TwoFactorSetupStep({
                                         type="text"
                                         readOnly
                                         value={manualSetupKey}
-                                        className="bg-background text-foreground h-full w-full p-3 outline-none"
+                                        className="h-full w-full bg-background p-3 text-foreground outline-none"
                                     />
                                     <button
                                         onClick={() => copy(manualSetupKey)}
-                                        className="border-border hover:bg-muted border-l px-3"
+                                        className="border-l border-border px-3 hover:bg-muted"
                                     >
                                         <IconComponent className="w-4" />
                                     </button>

--- a/kits/Inertia/Fortify/React/resources/js/layouts/auth/auth-card-layout.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/layouts/auth/auth-card-layout.tsx
@@ -20,7 +20,7 @@ export default function AuthCardLayout({
     description?: string;
 }>) {
     return (
-        <div className="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
+        <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">
             <div className="flex w-full max-w-md flex-col gap-6">
                 <Link
                     href={home()}

--- a/kits/Inertia/Fortify/React/resources/js/layouts/auth/auth-simple-layout.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/layouts/auth/auth-simple-layout.tsx
@@ -9,7 +9,7 @@ export default function AuthSimpleLayout({
     description,
 }: AuthLayoutProps) {
     return (
-        <div className="bg-background flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
+        <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-background p-6 md:p-10">
             <div className="w-full max-w-sm">
                 <div className="flex flex-col gap-8">
                     <div className="flex flex-col items-center gap-4">
@@ -25,7 +25,7 @@ export default function AuthSimpleLayout({
 
                         <div className="space-y-2 text-center">
                             <h1 className="text-xl font-medium">{title}</h1>
-                            <p className="text-muted-foreground text-center text-sm">
+                            <p className="text-center text-sm text-muted-foreground">
                                 {description}
                             </p>
                         </div>

--- a/kits/Inertia/Fortify/React/resources/js/layouts/auth/auth-split-layout.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/layouts/auth/auth-split-layout.tsx
@@ -12,7 +12,7 @@ export default function AuthSplitLayout({
 
     return (
         <div className="relative grid h-dvh flex-col items-center justify-center px-8 sm:px-0 lg:max-w-none lg:grid-cols-2 lg:px-0">
-            <div className="bg-muted relative hidden h-full flex-col p-10 text-white lg:flex dark:border-r">
+            <div className="relative hidden h-full flex-col bg-muted p-10 text-white lg:flex dark:border-r">
                 <div className="absolute inset-0 bg-zinc-900" />
                 <Link
                     href={home()}
@@ -32,7 +32,7 @@ export default function AuthSplitLayout({
                     </Link>
                     <div className="flex flex-col items-start gap-2 text-left sm:items-center sm:text-center">
                         <h1 className="text-xl font-medium">{title}</h1>
-                        <p className="text-muted-foreground text-sm text-balance">
+                        <p className="text-sm text-balance text-muted-foreground">
                             {description}
                         </p>
                     </div>

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/forgot-password.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/forgot-password.tsx
@@ -54,7 +54,7 @@ export default function ForgotPassword({ status }: { status?: string }) {
                     )}
                 </Form>
 
-                <div className="text-muted-foreground space-x-1 text-center text-sm">
+                <div className="space-x-1 text-center text-sm text-muted-foreground">
                     <span>Or, return to</span>
                     <TextLink href={login()}>log in</TextLink>
                 </div>

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/login.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/login.tsx
@@ -99,7 +99,7 @@ export default function Login({ status, canResetPassword }: Props) {
                         </div>
 
                         {/* @chisel-registration */}
-                        <div className="text-muted-foreground text-center text-sm">
+                        <div className="text-center text-sm text-muted-foreground">
                             Don't have an account?{' '}
                             <TextLink href={register()} tabIndex={5}>
                                 Sign up

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/register.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/register.tsx
@@ -101,7 +101,7 @@ export default function Register({ passwordRules }: Props) {
                             </Button>
                         </div>
 
-                        <div className="text-muted-foreground text-center text-sm">
+                        <div className="text-center text-sm text-muted-foreground">
                             Already have an account?{' '}
                             <TextLink href={login()} tabIndex={6}>
                                 Log in

--- a/kits/Inertia/Fortify/React/resources/js/pages/auth/two-factor-challenge.tsx
+++ b/kits/Inertia/Fortify/React/resources/js/pages/auth/two-factor-challenge.tsx
@@ -112,11 +112,11 @@ export default function TwoFactorChallenge() {
                                 Continue
                             </Button>
 
-                            <div className="text-muted-foreground text-center text-sm">
+                            <div className="text-center text-sm text-muted-foreground">
                                 <span>or you can </span>
                                 <button
                                     type="button"
-                                    className="text-foreground cursor-pointer underline decoration-neutral-300 underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-neutral-500"
+                                    className="cursor-pointer text-foreground underline decoration-neutral-300 underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-neutral-500"
                                     onClick={() =>
                                         toggleRecoveryMode(clearErrors)
                                     }

--- a/kits/Inertia/Fortify/Vue/resources/js/components/ManagePasskeys.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/components/ManagePasskeys.vue
@@ -37,7 +37,7 @@ const handleRegisterSuccess = () => {
             description="Manage your passkeys for passwordless sign-in"
         />
 
-        <div class="border-border overflow-hidden rounded-lg border">
+        <div class="overflow-hidden rounded-lg border border-border">
             <template v-if="passkeys.length">
                 <PasskeyItem
                     v-for="passkey in passkeys"
@@ -49,12 +49,12 @@ const handleRegisterSuccess = () => {
 
             <div v-else class="p-8 text-center">
                 <div
-                    class="bg-muted mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl"
+                    class="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-muted"
                 >
-                    <KeyRound class="text-muted-foreground h-7 w-7" />
+                    <KeyRound class="h-7 w-7 text-muted-foreground" />
                 </div>
                 <p class="font-medium">No passkeys yet</p>
-                <p class="text-muted-foreground mt-1 text-sm">
+                <p class="mt-1 text-sm text-muted-foreground">
                     Add a passkey to sign in without a password
                 </p>
             </div>

--- a/kits/Inertia/Fortify/Vue/resources/js/components/ManageTwoFactor.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/components/ManageTwoFactor.vue
@@ -39,7 +39,7 @@ onUnmounted(() => clearTwoFactorAuthData());
             v-if="!twoFactorEnabled"
             class="flex flex-col items-start justify-start space-y-4"
         >
-            <p class="text-muted-foreground text-sm">
+            <p class="text-sm text-muted-foreground">
                 When you enable two-factor authentication, you will be prompted
                 for a secure pin during login. This pin can be retrieved from a
                 TOTP-supported application on your phone.
@@ -63,7 +63,7 @@ onUnmounted(() => clearTwoFactorAuthData());
         </div>
 
         <div v-else class="flex flex-col items-start justify-start space-y-4">
-            <p class="text-muted-foreground text-sm">
+            <p class="text-sm text-muted-foreground">
                 You will be prompted for a secure, random pin during login,
                 which you can retrieve from the TOTP-supported application on
                 your phone.

--- a/kits/Inertia/Fortify/Vue/resources/js/components/PasskeyItem.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/components/PasskeyItem.vue
@@ -35,24 +35,24 @@ const handleDelete = () => {
     <div class="flex items-center justify-between border-b p-4 last:border-b-0">
         <div class="flex items-center gap-4">
             <div
-                class="bg-muted flex h-10 w-10 shrink-0 items-center justify-center rounded-xl"
+                class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted"
             >
-                <KeyRound class="text-muted-foreground h-5 w-5" />
+                <KeyRound class="h-5 w-5 text-muted-foreground" />
             </div>
             <div class="space-y-1">
                 <div class="flex items-center gap-2.5">
                     <p class="font-medium tracking-tight">{{ passkey.name }}</p>
                     <span
                         v-if="passkey.authenticator"
-                        class="bg-muted text-muted-foreground ring-border inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium tracking-wide uppercase ring-1 ring-inset"
+                        class="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium tracking-wide text-muted-foreground uppercase ring-1 ring-border ring-inset"
                     >
                         {{ passkey.authenticator }}
                     </span>
                 </div>
-                <p class="text-muted-foreground text-sm">
+                <p class="text-sm text-muted-foreground">
                     Added {{ passkey.created_at_diff }}
                     <template v-if="passkey.last_used_at_diff">
-                        <span class="text-muted-foreground/50 mx-1">/</span>
+                        <span class="mx-1 text-muted-foreground/50">/</span>
                         Last used {{ passkey.last_used_at_diff }}
                     </template>
                 </p>

--- a/kits/Inertia/Fortify/Vue/resources/js/components/PasskeyRegister.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/components/PasskeyRegister.vue
@@ -60,7 +60,7 @@ const handleCancel = () => {
 </script>
 
 <template>
-    <div v-if="!isSupported" class="text-muted-foreground text-sm">
+    <div v-if="!isSupported" class="text-sm text-muted-foreground">
         Passkeys are not supported in this browser.
     </div>
 
@@ -71,7 +71,7 @@ const handleCancel = () => {
     <form
         v-else
         @submit="handleSubmit"
-        class="border-border bg-muted/50 space-y-4 rounded-lg border p-4"
+        class="space-y-4 rounded-lg border border-border bg-muted/50 p-4"
     >
         <div class="grid gap-2">
             <Label for="passkey-name">Passkey name</Label>
@@ -80,10 +80,10 @@ const handleCancel = () => {
                 type="text"
                 v-model="name"
                 placeholder="e.g., MacBook Pro, iPhone"
-                class="border-foreground/20 mt-1 block w-full"
+                class="mt-1 block w-full border-foreground/20"
                 autofocus
             />
-            <p class="text-muted-foreground text-xs">
+            <p class="text-xs text-muted-foreground">
                 A name helps you identify this passkey later.
             </p>
         </div>

--- a/kits/Inertia/Fortify/Vue/resources/js/components/PasskeyVerify.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/components/PasskeyVerify.vue
@@ -64,7 +64,7 @@ const { verify, isLoading, error, isSupported } = usePasskeyVerify({
                 <Separator class="w-full" />
             </div>
             <div class="relative flex justify-center text-xs uppercase">
-                <span class="bg-background text-muted-foreground px-2">
+                <span class="bg-background px-2 text-muted-foreground">
                     {{ props.separator ?? 'Or continue with email' }}
                 </span>
             </div>

--- a/kits/Inertia/Fortify/Vue/resources/js/components/TwoFactorRecoveryCodes.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/components/TwoFactorRecoveryCodes.vue
@@ -93,13 +93,13 @@ onMounted(async () => {
                 <div v-else class="mt-3 space-y-3">
                     <div
                         ref="recoveryCodeSectionRef"
-                        class="bg-muted grid gap-1 rounded-lg p-4 font-mono text-sm"
+                        class="grid gap-1 rounded-lg bg-muted p-4 font-mono text-sm"
                     >
                         <div v-if="!recoveryCodesList.length" class="space-y-2">
                             <div
                                 v-for="n in 8"
                                 :key="n"
-                                class="bg-muted-foreground/20 h-4 animate-pulse rounded"
+                                class="h-4 animate-pulse rounded bg-muted-foreground/20"
                             ></div>
                         </div>
                         <div
@@ -110,7 +110,7 @@ onMounted(async () => {
                             {{ code }}
                         </div>
                     </div>
-                    <p class="text-muted-foreground text-xs select-none">
+                    <p class="text-xs text-muted-foreground select-none">
                         Each recovery code can be used once to access your
                         account and will be removed after use. If you need more,
                         click

--- a/kits/Inertia/Fortify/Vue/resources/js/components/TwoFactorSetupModal.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/components/TwoFactorSetupModal.vue
@@ -114,10 +114,10 @@ watch(
         <DialogContent class="sm:max-w-md">
             <DialogHeader class="flex items-center justify-center">
                 <div
-                    class="border-border bg-card mb-3 w-auto rounded-full border p-0.5 shadow-sm"
+                    class="mb-3 w-auto rounded-full border border-border bg-card p-0.5 shadow-sm"
                 >
                     <div
-                        class="border-border bg-muted relative overflow-hidden rounded-full border p-2.5"
+                        class="relative overflow-hidden rounded-full border border-border bg-muted p-2.5"
                     >
                         <div
                             class="absolute inset-0 grid grid-cols-5 opacity-50"
@@ -125,7 +125,7 @@ watch(
                             <div
                                 v-for="i in 5"
                                 :key="`col-${i}`"
-                                class="border-border border-r last:border-r-0"
+                                class="border-r border-border last:border-r-0"
                             />
                         </div>
                         <div
@@ -134,11 +134,11 @@ watch(
                             <div
                                 v-for="i in 5"
                                 :key="`row-${i}`"
-                                class="border-border border-b last:border-b-0"
+                                class="border-b border-border last:border-b-0"
                             />
                         </div>
                         <ScanLine
-                            class="text-foreground relative z-20 size-6"
+                            class="relative z-20 size-6 text-foreground"
                         />
                     </div>
                 </div>
@@ -158,11 +158,11 @@ watch(
                             class="relative mx-auto flex max-w-md items-center overflow-hidden"
                         >
                             <div
-                                class="border-border relative mx-auto aspect-square w-64 overflow-hidden rounded-lg border"
+                                class="relative mx-auto aspect-square w-64 overflow-hidden rounded-lg border border-border"
                             >
                                 <div
                                     v-if="!qrCodeSvg"
-                                    class="bg-background absolute inset-0 z-10 flex aspect-square h-auto w-full animate-pulse items-center justify-center"
+                                    class="absolute inset-0 z-10 flex aspect-square h-auto w-full animate-pulse items-center justify-center bg-background"
                                 >
                                     <Spinner class="size-6" />
                                 </div>
@@ -194,9 +194,9 @@ watch(
                             class="relative flex w-full items-center justify-center"
                         >
                             <div
-                                class="bg-border absolute inset-0 top-1/2 h-px w-full"
+                                class="absolute inset-0 top-1/2 h-px w-full bg-border"
                             />
-                            <span class="bg-card relative px-2 py-1"
+                            <span class="relative bg-card px-2 py-1"
                                 >or, enter the code manually</span
                             >
                         </div>
@@ -205,11 +205,11 @@ watch(
                             class="flex w-full items-center justify-center space-x-2"
                         >
                             <div
-                                class="border-border flex w-full items-stretch overflow-hidden rounded-xl border"
+                                class="flex w-full items-stretch overflow-hidden rounded-xl border border-border"
                             >
                                 <div
                                     v-if="!manualSetupKey"
-                                    class="bg-muted flex h-full w-full items-center justify-center p-3"
+                                    class="flex h-full w-full items-center justify-center bg-muted p-3"
                                 >
                                     <Spinner />
                                 </div>
@@ -218,11 +218,11 @@ watch(
                                         type="text"
                                         readonly
                                         :value="manualSetupKey"
-                                        class="bg-background text-foreground h-full w-full p-3"
+                                        class="h-full w-full bg-background p-3 text-foreground"
                                     />
                                     <button
                                         @click="copy(manualSetupKey || '')"
-                                        class="border-border hover:bg-muted relative block h-auto border-l px-3"
+                                        class="relative block h-auto border-l border-border px-3 hover:bg-muted"
                                     >
                                         <Check
                                             v-if="copied"

--- a/kits/Inertia/Fortify/Vue/resources/js/layouts/auth/AuthCardLayout.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/layouts/auth/AuthCardLayout.vue
@@ -18,7 +18,7 @@ defineProps<{
 
 <template>
     <div
-        class="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10"
+        class="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10"
     >
         <div class="flex w-full max-w-md flex-col gap-6">
             <Link

--- a/kits/Inertia/Fortify/Vue/resources/js/layouts/auth/AuthSimpleLayout.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/layouts/auth/AuthSimpleLayout.vue
@@ -11,7 +11,7 @@ defineProps<{
 
 <template>
     <div
-        class="bg-background flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10"
+        class="flex min-h-svh flex-col items-center justify-center gap-6 bg-background p-6 md:p-10"
     >
         <div class="w-full max-w-sm">
             <div class="flex flex-col gap-8">
@@ -31,7 +31,7 @@ defineProps<{
                     </Link>
                     <div class="space-y-2 text-center">
                         <h1 class="text-xl font-medium">{{ title }}</h1>
-                        <p class="text-muted-foreground text-center text-sm">
+                        <p class="text-center text-sm text-muted-foreground">
                             {{ description }}
                         </p>
                     </div>

--- a/kits/Inertia/Fortify/Vue/resources/js/layouts/auth/AuthSplitLayout.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/layouts/auth/AuthSplitLayout.vue
@@ -17,7 +17,7 @@ defineProps<{
         class="relative grid h-dvh flex-col items-center justify-center px-8 sm:px-0 lg:max-w-none lg:grid-cols-2 lg:px-0"
     >
         <div
-            class="bg-muted relative hidden h-full flex-col p-10 text-white lg:flex dark:border-r"
+            class="relative hidden h-full flex-col bg-muted p-10 text-white lg:flex dark:border-r"
         >
             <div class="absolute inset-0 bg-zinc-900" />
             <Link
@@ -36,7 +36,7 @@ defineProps<{
                     <h1 class="text-xl font-medium tracking-tight" v-if="title">
                         {{ title }}
                     </h1>
-                    <p class="text-muted-foreground text-sm" v-if="description">
+                    <p class="text-sm text-muted-foreground" v-if="description">
                         {{ description }}
                     </p>
                 </div>

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ForgotPassword.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/ForgotPassword.vue
@@ -58,7 +58,7 @@ defineProps<{
             </div>
         </Form>
 
-        <div class="text-muted-foreground space-x-1 text-center text-sm">
+        <div class="space-x-1 text-center text-sm text-muted-foreground">
             <span>Or, return to</span>
             <TextLink :href="login()">log in</TextLink>
         </div>

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Login.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Login.vue
@@ -109,7 +109,7 @@ defineProps<{
         </div>
 
         <!-- @chisel-registration -->
-        <div class="text-muted-foreground text-center text-sm">
+        <div class="text-center text-sm text-muted-foreground">
             Don't have an account?
             <TextLink :href="register()" :tabindex="5">Sign up</TextLink>
         </div>

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Register.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/Register.vue
@@ -101,7 +101,7 @@ defineOptions({
             </Button>
         </div>
 
-        <div class="text-muted-foreground text-center text-sm">
+        <div class="text-center text-sm text-muted-foreground">
             Already have an account?
             <TextLink
                 :href="login()"

--- a/kits/Inertia/Fortify/Vue/resources/js/pages/auth/TwoFactorChallenge.vue
+++ b/kits/Inertia/Fortify/Vue/resources/js/pages/auth/TwoFactorChallenge.vue
@@ -85,7 +85,7 @@ const toggleRecoveryMode = (clearErrors: () => void): void => {
                 <Button type="submit" class="w-full" :disabled="processing"
                     >Continue</Button
                 >
-                <div class="text-muted-foreground text-center text-sm">
+                <div class="text-center text-sm text-muted-foreground">
                     <span>or you can </span>
                     <button
                         type="button"
@@ -117,7 +117,7 @@ const toggleRecoveryMode = (clearErrors: () => void): void => {
                     >Continue</Button
                 >
 
-                <div class="text-muted-foreground text-center text-sm">
+                <div class="text-center text-sm text-muted-foreground">
                     <span>or you can </span>
                     <button
                         type="button"

--- a/kits/Inertia/React/resources/js/components/app-header.tsx
+++ b/kits/Inertia/React/resources/js/components/app-header.tsx
@@ -71,7 +71,7 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
 
     return (
         <>
-            <div className="border-sidebar-border/80 border-b">
+            <div className="border-b border-sidebar-border/80">
                 <div className="mx-auto flex h-16 items-center px-4 md:max-w-7xl">
                     {/* Mobile Menu */}
                     <div className="lg:hidden">
@@ -87,7 +87,7 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
                             </SheetTrigger>
                             <SheetContent
                                 side="left"
-                                className="bg-sidebar flex h-full w-64 flex-col items-stretch justify-between"
+                                className="flex h-full w-64 flex-col items-stretch justify-between bg-sidebar"
                             >
                                 <SheetTitle className="sr-only">
                                     Navigation menu
@@ -193,7 +193,7 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
                                                 href={toUrl(item.href)}
                                                 target="_blank"
                                                 rel="noopener noreferrer"
-                                                className="group text-accent-foreground ring-offset-background hover:bg-accent hover:text-accent-foreground focus-visible:ring-ring inline-flex h-9 w-9 items-center justify-center rounded-md bg-transparent p-0 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+                                                className="group inline-flex h-9 w-9 items-center justify-center rounded-md bg-transparent p-0 text-sm font-medium text-accent-foreground ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
                                             >
                                                 <span className="sr-only">
                                                     {item.title}
@@ -237,7 +237,7 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
                 </div>
             </div>
             {breadcrumbs.length > 1 && (
-                <div className="border-sidebar-border/70 flex w-full border-b">
+                <div className="flex w-full border-b border-sidebar-border/70">
                     <div className="mx-auto flex h-12 w-full items-center justify-start px-4 text-neutral-500 md:max-w-7xl">
                         <Breadcrumbs breadcrumbs={breadcrumbs} />
                     </div>

--- a/kits/Inertia/React/resources/js/components/app-logo.tsx
+++ b/kits/Inertia/React/resources/js/components/app-logo.tsx
@@ -7,7 +7,7 @@ export default function AppLogo() {
 
     return (
         <>
-            <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-md">
+            <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground">
                 <AppLogoIcon className="size-5 fill-current text-white dark:text-black" />
             </div>
             <div className="ml-1 grid flex-1 text-left text-sm">

--- a/kits/Inertia/React/resources/js/components/app-sidebar-header.tsx
+++ b/kits/Inertia/React/resources/js/components/app-sidebar-header.tsx
@@ -8,7 +8,7 @@ export function AppSidebarHeader({
     breadcrumbs?: BreadcrumbItemType[];
 }) {
     return (
-        <header className="border-sidebar-border/50 flex h-16 shrink-0 items-center gap-2 border-b px-6 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4">
+        <header className="flex h-16 shrink-0 items-center gap-2 border-b border-sidebar-border/50 px-6 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4">
             <div className="flex items-center gap-2">
                 <SidebarTrigger className="-ml-1" />
                 <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/kits/Inertia/React/resources/js/components/heading.tsx
+++ b/kits/Inertia/React/resources/js/components/heading.tsx
@@ -19,7 +19,7 @@ export default function Heading({
                 {title}
             </h2>
             {description && (
-                <p className="text-muted-foreground text-sm">{description}</p>
+                <p className="text-sm text-muted-foreground">{description}</p>
             )}
         </header>
     );

--- a/kits/Inertia/React/resources/js/components/password-input.tsx
+++ b/kits/Inertia/React/resources/js/components/password-input.tsx
@@ -22,7 +22,7 @@ export default function PasswordInput({
             <button
                 type="button"
                 onClick={() => setShowPassword((prev) => !prev)}
-                className="text-muted-foreground hover:text-foreground focus-visible:ring-ring absolute inset-y-0 right-0 flex items-center rounded-r-md px-3 focus-visible:ring-[3px] focus-visible:outline-none"
+                className="absolute inset-y-0 right-0 flex items-center rounded-r-md px-3 text-muted-foreground hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:outline-none"
                 aria-label={showPassword ? 'Hide password' : 'Show password'}
                 tabIndex={-1}
             >

--- a/kits/Inertia/React/resources/js/components/user-info.tsx
+++ b/kits/Inertia/React/resources/js/components/user-info.tsx
@@ -22,7 +22,7 @@ export function UserInfo({
             <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-medium">{user.name}</span>
                 {showEmail && (
-                    <span className="text-muted-foreground truncate text-xs">
+                    <span className="truncate text-xs text-muted-foreground">
                         {user.email}
                     </span>
                 )}

--- a/kits/Inertia/React/resources/js/pages/dashboard.tsx
+++ b/kits/Inertia/React/resources/js/pages/dashboard.tsx
@@ -8,17 +8,17 @@ export default function Dashboard() {
             <Head title="Dashboard" />
             <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
                 <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-                    <div className="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border">
+                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
                         <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
                     </div>
-                    <div className="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border">
+                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
                         <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
                     </div>
-                    <div className="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border">
+                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
                         <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
                     </div>
                 </div>
-                <div className="border-sidebar-border/70 dark:border-sidebar-border relative min-h-[100vh] flex-1 overflow-hidden rounded-xl border md:min-h-min">
+                <div className="relative min-h-[100vh] flex-1 overflow-hidden rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border">
                     <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
                 </div>
             </div>

--- a/kits/Inertia/React/resources/js/pages/settings/profile.tsx
+++ b/kits/Inertia/React/resources/js/pages/settings/profile.tsx
@@ -97,7 +97,7 @@ export default function Profile(
                             {mustVerifyEmail &&
                                 auth.user.email_verified_at === null && (
                                     <div>
-                                        <p className="text-muted-foreground -mt-4 text-sm">
+                                        <p className="-mt-4 text-sm text-muted-foreground">
                                             Your email address is unverified.{' '}
                                             <Link
                                                 href={send()}

--- a/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/login.tsx
+++ b/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/login.tsx
@@ -113,7 +113,7 @@ export default function Login({
                         </div>
 
                         {/* @chisel-registration */}
-                        <div className="text-muted-foreground text-center text-sm">
+                        <div className="text-center text-sm text-muted-foreground">
                             Don't have an account?{' '}
                             <TextLink
                                 href={register({

--- a/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/register.tsx
+++ b/kits/Inertia/Teams/Fortify/React/resources/js/pages/auth/register.tsx
@@ -111,7 +111,7 @@ export default function Register({ passwordRules, teamInvitation }: Props) {
                             </Button>
                         </div>
 
-                        <div className="text-muted-foreground text-center text-sm">
+                        <div className="text-center text-sm text-muted-foreground">
                             Already have an account?{' '}
                             <TextLink
                                 href={

--- a/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Login.vue
+++ b/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Login.vue
@@ -118,7 +118,7 @@ defineProps<{
         </div>
 
         <!-- @chisel-registration -->
-        <div class="text-muted-foreground text-center text-sm">
+        <div class="text-center text-sm text-muted-foreground">
             Don't have an account?
             <TextLink
                 :href="

--- a/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Register.vue
+++ b/kits/Inertia/Teams/Fortify/Vue/resources/js/pages/auth/Register.vue
@@ -110,7 +110,7 @@ defineOptions({
             </Button>
         </div>
 
-        <div class="text-muted-foreground text-center text-sm">
+        <div class="text-center text-sm text-muted-foreground">
             Already have an account?
             <TextLink
                 :href="

--- a/kits/Inertia/Teams/React/resources/js/components/app-header.tsx
+++ b/kits/Inertia/Teams/React/resources/js/components/app-header.tsx
@@ -74,7 +74,7 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
 
     return (
         <>
-            <div className="border-sidebar-border/80 border-b">
+            <div className="border-b border-sidebar-border/80">
                 <div className="mx-auto flex h-16 items-center px-4 md:max-w-7xl">
                     {/* Mobile Menu */}
                     <div className="lg:hidden">
@@ -90,7 +90,7 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
                             </SheetTrigger>
                             <SheetContent
                                 side="left"
-                                className="bg-sidebar flex h-full w-64 flex-col items-stretch justify-between"
+                                className="flex h-full w-64 flex-col items-stretch justify-between bg-sidebar"
                             >
                                 <SheetTitle className="sr-only">
                                     Navigation menu
@@ -200,7 +200,7 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
                                                     href={toUrl(item.href)}
                                                     target="_blank"
                                                     rel="noopener noreferrer"
-                                                    className="group text-accent-foreground ring-offset-background hover:bg-accent hover:text-accent-foreground focus-visible:ring-ring inline-flex h-9 w-9 items-center justify-center rounded-md bg-transparent p-0 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+                                                    className="group inline-flex h-9 w-9 items-center justify-center rounded-md bg-transparent p-0 text-sm font-medium text-accent-foreground ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
                                                 >
                                                     <span className="sr-only">
                                                         {item.title}
@@ -245,7 +245,7 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
                 </div>
             </div>
             {breadcrumbs.length > 1 && (
-                <div className="border-sidebar-border/70 flex w-full border-b">
+                <div className="flex w-full border-b border-sidebar-border/70">
                     <div className="mx-auto flex h-12 w-full items-center justify-start px-4 text-neutral-500 md:max-w-7xl">
                         <Breadcrumbs breadcrumbs={breadcrumbs} />
                     </div>

--- a/kits/Inertia/Teams/React/resources/js/components/pending-invitations-modal.tsx
+++ b/kits/Inertia/Teams/React/resources/js/components/pending-invitations-modal.tsx
@@ -65,7 +65,7 @@ export default function PendingInvitationsModal({
                                 <p className="font-medium">
                                     {invitation.team.name}
                                 </p>
-                                <p className="text-muted-foreground text-sm">
+                                <p className="text-sm text-muted-foreground">
                                     {invitation.inviterName} invited you to join
                                     this team.
                                 </p>

--- a/kits/Inertia/Teams/React/resources/js/components/team-switcher.tsx
+++ b/kits/Inertia/Teams/React/resources/js/components/team-switcher.tsx
@@ -60,7 +60,7 @@ export function TeamSwitcher({ inHeader = false }: TeamSwitcherProps) {
                     className={
                         inHeader
                             ? 'h-8 gap-1 px-2'
-                            : 'data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground w-full justify-start px-2 has-[>svg]:px-2'
+                            : 'w-full justify-start px-2 has-[>svg]:px-2 data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground'
                     }
                 >
                     <Users
@@ -106,7 +106,7 @@ export function TeamSwitcher({ inHeader = false }: TeamSwitcherProps) {
                 align={inHeader ? 'end' : 'start'}
                 sideOffset={inHeader ? undefined : 4}
             >
-                <DropdownMenuLabel className="text-muted-foreground text-xs">
+                <DropdownMenuLabel className="text-xs text-muted-foreground">
                     Teams
                 </DropdownMenuLabel>
                 {teams.map((team) => (

--- a/kits/Inertia/Teams/React/resources/js/components/user-info.tsx
+++ b/kits/Inertia/Teams/React/resources/js/components/user-info.tsx
@@ -27,12 +27,12 @@ export function UserInfo({
             <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-medium">{user.name}</span>
                 {team ? (
-                    <span className="text-muted-foreground truncate text-xs">
+                    <span className="truncate text-xs text-muted-foreground">
                         {team.name}
                     </span>
                 ) : null}
                 {!team && showEmail ? (
-                    <span className="text-muted-foreground truncate text-xs">
+                    <span className="truncate text-xs text-muted-foreground">
                         {user.email}
                     </span>
                 ) : null}

--- a/kits/Inertia/Teams/React/resources/js/pages/dashboard.tsx
+++ b/kits/Inertia/Teams/React/resources/js/pages/dashboard.tsx
@@ -24,17 +24,17 @@ export default function Dashboard({ pendingInvitations = [] }: Props) {
             />
             <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
                 <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-                    <div className="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border">
+                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
                         <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
                     </div>
-                    <div className="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border">
+                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
                         <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
                     </div>
-                    <div className="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border">
+                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
                         <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
                     </div>
                 </div>
-                <div className="border-sidebar-border/70 dark:border-sidebar-border relative min-h-[100vh] flex-1 overflow-hidden rounded-xl border md:min-h-min">
+                <div className="relative min-h-[100vh] flex-1 overflow-hidden rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border">
                     <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
                 </div>
             </div>

--- a/kits/Inertia/Teams/React/resources/js/pages/teams/edit.tsx
+++ b/kits/Inertia/Teams/React/resources/js/pages/teams/edit.tsx
@@ -189,7 +189,7 @@ export default function TeamEdit({
                                         <div className="font-medium">
                                             {member.name}
                                         </div>
-                                        <div className="text-muted-foreground text-sm">
+                                        <div className="text-sm text-muted-foreground">
                                             {member.email}
                                         </div>
                                     </div>
@@ -278,14 +278,14 @@ export default function TeamEdit({
                                     className="flex items-center justify-between rounded-lg border p-4"
                                 >
                                     <div className="flex items-center gap-4">
-                                        <div className="bg-muted flex h-10 w-10 items-center justify-center rounded-full">
-                                            <Mail className="text-muted-foreground h-5 w-5" />
+                                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                                            <Mail className="h-5 w-5 text-muted-foreground" />
                                         </div>
                                         <div>
                                             <div className="font-medium">
                                                 {invitation.email}
                                             </div>
-                                            <div className="text-muted-foreground text-sm">
+                                            <div className="text-sm text-muted-foreground">
                                                 {invitation.role_label}
                                             </div>
                                         </div>

--- a/kits/Inertia/Teams/React/resources/js/pages/teams/index.tsx
+++ b/kits/Inertia/Teams/React/resources/js/pages/teams/index.tsx
@@ -72,7 +72,7 @@ export default function TeamsIndex({ teams }: Props) {
                                                 </Badge>
                                             ) : null}
                                         </div>
-                                        <span className="text-muted-foreground text-sm">
+                                        <span className="text-sm text-muted-foreground">
                                             {team.roleLabel}
                                         </span>
                                     </div>
@@ -154,7 +154,7 @@ export default function TeamsIndex({ teams }: Props) {
                     })}
 
                     {teams.length === 0 ? (
-                        <p className="text-muted-foreground py-8 text-center">
+                        <p className="py-8 text-center text-muted-foreground">
                             You don't belong to any teams yet.
                         </p>
                     ) : null}

--- a/kits/Inertia/Teams/Vue/resources/js/components/AppHeader.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/components/AppHeader.vue
@@ -82,7 +82,7 @@ const rightNavItems: NavItem[] = [
 
 <template>
     <div>
-        <div class="border-sidebar-border/80 border-b">
+        <div class="border-b border-sidebar-border/80">
             <div class="mx-auto flex h-16 items-center px-4 md:max-w-7xl">
                 <!-- Mobile Menu -->
                 <div class="lg:hidden">
@@ -113,7 +113,7 @@ const rightNavItems: NavItem[] = [
                                         v-for="item in mainNavItems"
                                         :key="item.title"
                                         :href="item.href"
-                                        class="hover:bg-accent flex items-center gap-x-3 rounded-lg px-3 py-2 text-sm font-medium"
+                                        class="flex items-center gap-x-3 rounded-lg px-3 py-2 text-sm font-medium hover:bg-accent"
                                         :class="
                                             whenCurrentUrl(
                                                 item.href,
@@ -248,7 +248,7 @@ const rightNavItems: NavItem[] = [
                             <Button
                                 variant="ghost"
                                 size="icon"
-                                class="focus-within:ring-primary relative size-10 w-auto rounded-full p-1 focus-within:ring-2"
+                                class="relative size-10 w-auto rounded-full p-1 focus-within:ring-2 focus-within:ring-primary"
                             >
                                 <Avatar
                                     class="size-8 overflow-hidden rounded-full"
@@ -278,7 +278,7 @@ const rightNavItems: NavItem[] = [
 
         <div
             v-if="props.breadcrumbs.length > 1"
-            class="border-sidebar-border/70 flex w-full border-b"
+            class="flex w-full border-b border-sidebar-border/70"
         >
             <div
                 class="mx-auto flex h-12 w-full items-center justify-start px-4 text-neutral-500 md:max-w-7xl"

--- a/kits/Inertia/Teams/Vue/resources/js/components/PendingInvitationsModal.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/components/PendingInvitationsModal.vue
@@ -60,7 +60,7 @@ const declineInvitation = (invitation: DashboardInvitation) => {
                 >
                     <div class="space-y-1">
                         <p class="font-medium">{{ invitation.team.name }}</p>
-                        <p class="text-muted-foreground text-sm">
+                        <p class="text-sm text-muted-foreground">
                             {{ invitation.inviterName }} invited you to join
                             this team.
                         </p>

--- a/kits/Inertia/Teams/Vue/resources/js/components/TeamSwitcher.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/components/TeamSwitcher.vue
@@ -95,7 +95,7 @@ onUnmounted(() => {
                 :class="
                     props.inHeader
                         ? 'h-8 gap-1 px-2'
-                        : 'data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground w-full justify-start px-2 has-[>svg]:px-2'
+                        : 'w-full justify-start px-2 has-[>svg]:px-2 data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground'
                 "
             >
                 <Users
@@ -138,7 +138,7 @@ onUnmounted(() => {
             :align="props.inHeader ? 'end' : 'start'"
             :side-offset="props.inHeader ? undefined : 4"
         >
-            <DropdownMenuLabel class="text-muted-foreground text-xs">
+            <DropdownMenuLabel class="text-xs text-muted-foreground">
                 Teams
             </DropdownMenuLabel>
             <DropdownMenuItem

--- a/kits/Inertia/Teams/Vue/resources/js/components/UserInfo.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/components/UserInfo.vue
@@ -32,12 +32,12 @@ const showAvatar = computed(
 
     <div class="grid flex-1 text-left text-sm leading-tight">
         <span class="truncate font-medium">{{ user.name }}</span>
-        <span v-if="team" class="text-muted-foreground truncate text-xs">{{
+        <span v-if="team" class="truncate text-xs text-muted-foreground">{{
             team.name
         }}</span>
         <span
             v-else-if="showEmail"
-            class="text-muted-foreground truncate text-xs"
+            class="truncate text-xs text-muted-foreground"
             >{{ user.email }}</span
         >
     </div>

--- a/kits/Inertia/Teams/Vue/resources/js/pages/Dashboard.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/pages/Dashboard.vue
@@ -36,23 +36,23 @@ defineOptions({
     >
         <div class="grid auto-rows-min gap-4 md:grid-cols-3">
             <div
-                class="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border"
+                class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border"
             >
                 <PlaceholderPattern />
             </div>
             <div
-                class="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border"
+                class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border"
             >
                 <PlaceholderPattern />
             </div>
             <div
-                class="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border"
+                class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border"
             >
                 <PlaceholderPattern />
             </div>
         </div>
         <div
-            class="border-sidebar-border/70 dark:border-sidebar-border relative min-h-[100vh] flex-1 rounded-xl border md:min-h-min"
+            class="relative min-h-[100vh] flex-1 rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border"
         >
             <PlaceholderPattern />
         </div>

--- a/kits/Inertia/Teams/Vue/resources/js/pages/teams/Edit.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/pages/teams/Edit.vue
@@ -185,7 +185,7 @@ const confirmCancelInvitation = (invitation: TeamInvitation) => {
                             <div class="font-medium">
                                 {{ member.name }}
                             </div>
-                            <div class="text-muted-foreground text-sm">
+                            <div class="text-sm text-muted-foreground">
                                 {{ member.email }}
                             </div>
                         </div>
@@ -271,15 +271,15 @@ const confirmCancelInvitation = (invitation: TeamInvitation) => {
                 >
                     <div class="flex items-center gap-4">
                         <div
-                            class="bg-muted flex h-10 w-10 items-center justify-center rounded-full"
+                            class="flex h-10 w-10 items-center justify-center rounded-full bg-muted"
                         >
-                            <Mail class="text-muted-foreground h-5 w-5" />
+                            <Mail class="h-5 w-5 text-muted-foreground" />
                         </div>
                         <div>
                             <div class="font-medium">
                                 {{ invitation.email }}
                             </div>
-                            <div class="text-muted-foreground text-sm">
+                            <div class="text-sm text-muted-foreground">
                                 {{ invitation.role_label }}
                             </div>
                         </div>

--- a/kits/Inertia/Teams/Vue/resources/js/pages/teams/Index.vue
+++ b/kits/Inertia/Teams/Vue/resources/js/pages/teams/Index.vue
@@ -79,7 +79,7 @@ defineOptions({
                                 Personal
                             </Badge>
                         </div>
-                        <span class="text-muted-foreground text-sm">
+                        <span class="text-sm text-muted-foreground">
                             {{ team.roleLabel }}
                         </span>
                     </div>
@@ -144,7 +144,7 @@ defineOptions({
 
             <p
                 v-if="teams.length === 0"
-                class="text-muted-foreground py-8 text-center"
+                class="py-8 text-center text-muted-foreground"
             >
                 You don't belong to any teams yet.
             </p>

--- a/kits/Inertia/Vue/resources/js/components/AppHeader.vue
+++ b/kits/Inertia/Vue/resources/js/components/AppHeader.vue
@@ -77,7 +77,7 @@ const rightNavItems: NavItem[] = [
 
 <template>
     <div>
-        <div class="border-sidebar-border/80 border-b">
+        <div class="border-b border-sidebar-border/80">
             <div class="mx-auto flex h-16 items-center px-4 md:max-w-7xl">
                 <!-- Mobile Menu -->
                 <div class="lg:hidden">
@@ -108,7 +108,7 @@ const rightNavItems: NavItem[] = [
                                         v-for="item in mainNavItems"
                                         :key="item.title"
                                         :href="item.href"
-                                        class="hover:bg-accent flex items-center gap-x-3 rounded-lg px-3 py-2 text-sm font-medium"
+                                        class="flex items-center gap-x-3 rounded-lg px-3 py-2 text-sm font-medium hover:bg-accent"
                                         :class="
                                             whenCurrentUrl(
                                                 item.href,
@@ -243,7 +243,7 @@ const rightNavItems: NavItem[] = [
                             <Button
                                 variant="ghost"
                                 size="icon"
-                                class="focus-within:ring-primary relative size-10 w-auto rounded-full p-1 focus-within:ring-2"
+                                class="relative size-10 w-auto rounded-full p-1 focus-within:ring-2 focus-within:ring-primary"
                             >
                                 <Avatar
                                     class="size-8 overflow-hidden rounded-full"
@@ -271,7 +271,7 @@ const rightNavItems: NavItem[] = [
 
         <div
             v-if="props.breadcrumbs.length > 1"
-            class="border-sidebar-border/70 flex w-full border-b"
+            class="flex w-full border-b border-sidebar-border/70"
         >
             <div
                 class="mx-auto flex h-12 w-full items-center justify-start px-4 text-neutral-500 md:max-w-7xl"

--- a/kits/Inertia/Vue/resources/js/components/AppLogo.vue
+++ b/kits/Inertia/Vue/resources/js/components/AppLogo.vue
@@ -7,7 +7,7 @@ const name = usePage().props.name;
 
 <template>
     <div
-        class="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-md"
+        class="flex aspect-square size-8 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground"
     >
         <AppLogoIcon class="size-5 fill-current text-white dark:text-black" />
     </div>

--- a/kits/Inertia/Vue/resources/js/components/AppSidebarHeader.vue
+++ b/kits/Inertia/Vue/resources/js/components/AppSidebarHeader.vue
@@ -15,7 +15,7 @@ withDefaults(
 
 <template>
     <header
-        class="border-sidebar-border/70 flex h-16 shrink-0 items-center gap-2 border-b px-6 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4"
+        class="flex h-16 shrink-0 items-center gap-2 border-b border-sidebar-border/70 px-6 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4"
     >
         <div class="flex items-center gap-2">
             <SidebarTrigger class="-ml-1" />

--- a/kits/Inertia/Vue/resources/js/components/Heading.vue
+++ b/kits/Inertia/Vue/resources/js/components/Heading.vue
@@ -21,7 +21,7 @@ withDefaults(defineProps<Props>(), {
         >
             {{ title }}
         </h2>
-        <p v-if="description" class="text-muted-foreground text-sm">
+        <p v-if="description" class="text-sm text-muted-foreground">
             {{ description }}
         </p>
     </header>

--- a/kits/Inertia/Vue/resources/js/components/PasswordInput.vue
+++ b/kits/Inertia/Vue/resources/js/components/PasswordInput.vue
@@ -33,7 +33,7 @@ defineExpose({
             @click="showPassword = !showPassword"
             :class="
                 cn(
-                    'text-muted-foreground hover:text-foreground focus-visible:ring-ring absolute inset-y-0 right-0 flex items-center rounded-r-md px-3 focus-visible:ring-[3px] focus-visible:outline-none',
+                    'absolute inset-y-0 right-0 flex items-center rounded-r-md px-3 text-muted-foreground hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:outline-none',
                 )
             "
             :aria-label="showPassword ? 'Hide password' : 'Show password'"

--- a/kits/Inertia/Vue/resources/js/components/UserInfo.vue
+++ b/kits/Inertia/Vue/resources/js/components/UserInfo.vue
@@ -31,7 +31,7 @@ const showAvatar = computed(
 
     <div class="grid flex-1 text-left text-sm leading-tight">
         <span class="truncate font-medium">{{ user.name }}</span>
-        <span v-if="showEmail" class="text-muted-foreground truncate text-xs">{{
+        <span v-if="showEmail" class="truncate text-xs text-muted-foreground">{{
             user.email
         }}</span>
     </div>

--- a/kits/Inertia/Vue/resources/js/pages/Dashboard.vue
+++ b/kits/Inertia/Vue/resources/js/pages/Dashboard.vue
@@ -23,23 +23,23 @@ defineOptions({
     >
         <div class="grid auto-rows-min gap-4 md:grid-cols-3">
             <div
-                class="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border"
+                class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border"
             >
                 <PlaceholderPattern />
             </div>
             <div
-                class="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border"
+                class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border"
             >
                 <PlaceholderPattern />
             </div>
             <div
-                class="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border"
+                class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border"
             >
                 <PlaceholderPattern />
             </div>
         </div>
         <div
-            class="border-sidebar-border/70 dark:border-sidebar-border relative min-h-[100vh] flex-1 rounded-xl border md:min-h-min"
+            class="relative min-h-[100vh] flex-1 rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border"
         >
             <PlaceholderPattern />
         </div>

--- a/kits/Inertia/Vue/resources/js/pages/settings/Profile.vue
+++ b/kits/Inertia/Vue/resources/js/pages/settings/Profile.vue
@@ -79,7 +79,7 @@ const user = computed(() => page.props.auth.user);
 
             <!-- @chisel-email-verification -->
             <div v-if="page.props.mustVerifyEmail && !user.email_verified_at">
-                <p class="text-muted-foreground -mt-4 text-sm">
+                <p class="-mt-4 text-sm text-muted-foreground">
                     Your email address is unverified.
                     <Link
                         :href="send()"


### PR DESCRIPTION
## Overview

Since #60 the Inertia kits configure Tailwind class sorting like this:

```ts
sortTailwindcss: {
    functions: ['clsx', 'cn', 'cva'],
    entryPoint: 'resources/css/app.css',
},
```

oxfmt has no `entryPoint` option. The option that points the sorter at the Tailwind v4 stylesheet is `stylesheet` (`SortTailwindcssConfig` accepts `attributes`, `config`, `functions`, `preserveDuplicates`, `preserveWhitespace` and `stylesheet`). Unknown keys are dropped silently, so the sorter never reads `resources/css/app.css`.

Without the stylesheet, every theme utility (`bg-muted`, `text-muted-foreground`, `border-border`, `ring-ring`, …) is treated as an unknown class and pushed to the front of the class list:

```html
<!-- current kits -->
<KeyRound class="text-muted-foreground h-5 w-5" />

<!-- with the stylesheet loaded (same order prettier-plugin-tailwindcss produced) -->
<KeyRound class="h-5 w-5 text-muted-foreground" />
```

That is what produced the class reorders across the components in #60, and every kit generated since inherits it.

## Solution

- Rename the key to `stylesheet` in the three Blank kit configs (`kits/Inertia/Blank/{React,Svelte,Vue}/vite.config.ts`). The other layers inherit `vite.config.ts` from them.
- Run `composer kits:lint` for all fifteen Inertia variants and sync the result back. That is where the 62 component changes (31 Vue, 31 TSX) come from: each changed line contains the same class tokens as before, in the corrected order. Nothing else changes.
- Svelte components are untouched because oxfmt does not format `.svelte` files.

## Verification

- `composer kits:lint -- --react --svelte --vue`: all fifteen variants pass, and the second `check:fix` pass is a no-op.
- `composer kits:check -- --vue --fortify`: `composer setup && composer ci:check` passes end to end.
