### PR TITLE
Fix typos and improve clarity in documentation and comments across multiple files

### DIFF
--- a/.agents/skills/maestro/SKILL.md
+++ b/.agents/skills/maestro/SKILL.md
@@ -70,7 +70,7 @@ Every starter kit has a `ci:check` composer script that validates the kit withou
 
 **Inertia kits** run: Vite+ formatting and linting via `npm run check`, framework type checking via `npm run types:check`, then `@test` (Pint + PHPUnit).
 
-**Livewire kits** run: `@test` (pint + PHPUnit) only.
+**Livewire kits** run: `@test` (Pint + PHPUnit) only.
 
 ### Fortify Feature Matrix
 
@@ -383,7 +383,7 @@ cd ..
 ## Important Rules
 
 1. **Where to edit**: If a `build/` folder exists at the project root **and** `composer kit:run` is running (dev server + file watcher), make changes in `build/` — the watcher syncs them back to `kits/`. If there is no `build/` folder or the watcher is not running, edit `kits/` directly. Always commit in `kits/` regardless.
-2. **Follow sibling patterns**: When creating a Svelte file, check the React and Vue equivalents for expected structure and behavior and vice-versa.
+2. **Follow sibling patterns**: When creating a Svelte file, check the React and Vue equivalents for expected structure and behavior and vice versa.
 3. **Layer awareness**: Know which layer a file belongs to. Shared files affect all kits. Framework-specific files only affect that framework. Teams layers sit on top of auth layers — place team-specific code in the appropriate `Teams/` directory.
 4. **Placeholder awareness**: Files in `kits/` contain `{{placeholders}}`. Files in `build/` have resolved values. The watcher handles conversion.
 5. **Lint/check while watcher is stopped**: `kits:lint` and `kits:check` both delete and rebuild `build/` for each variant. If `kit:run` is active, the watcher interprets those deletions as file removals and propagates them to `kits/`, corrupting the source. Always stop `kit:run` before running `kits:lint` or `kits:check`. `kits:pint` is safe to run at any time — it operates directly on `kits/` and never touches `build/`.

--- a/.claude/skills/maestro/SKILL.md
+++ b/.claude/skills/maestro/SKILL.md
@@ -70,7 +70,7 @@ Every starter kit has a `ci:check` composer script that validates the kit withou
 
 **Inertia kits** run: Vite+ formatting and linting via `npm run check`, framework type checking via `npm run types:check`, then `@test` (Pint + PHPUnit).
 
-**Livewire kits** run: `@test` (pint + PHPUnit) only.
+**Livewire kits** run: `@test` (Pint + PHPUnit) only.
 
 ### Fortify Feature Matrix
 
@@ -383,7 +383,7 @@ cd ..
 ## Important Rules
 
 1. **Where to edit**: If a `build/` folder exists at the project root **and** `composer kit:run` is running (dev server + file watcher), make changes in `build/` — the watcher syncs them back to `kits/`. If there is no `build/` folder or the watcher is not running, edit `kits/` directly. Always commit in `kits/` regardless.
-2. **Follow sibling patterns**: When creating a Svelte file, check the React and Vue equivalents for expected structure and behavior and vice-versa.
+2. **Follow sibling patterns**: When creating a Svelte file, check the React and Vue equivalents for expected structure and behavior and vice versa.
 3. **Layer awareness**: Know which layer a file belongs to. Shared files affect all kits. Framework-specific files only affect that framework. Teams layers sit on top of auth layers — place team-specific code in the appropriate `Teams/` directory.
 4. **Placeholder awareness**: Files in `kits/` contain `{{placeholders}}`. Files in `build/` have resolved values. The watcher handles conversion.
 5. **Lint/check while watcher is stopped**: `kits:lint` and `kits:check` both delete and rebuild `build/` for each variant. If `kit:run` is active, the watcher interprets those deletions as file removals and propagates them to `kits/`, corrupting the source. Always stop `kit:run` before running `kits:lint` or `kits:check`. `kits:pint` is safe to run at any time — it operates directly on `kits/` and never touches `build/`.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ From the `orchestrator` directory, build a kit by running the following command:
 php artisan build
 ```
 
-This will prompt you to build the starter kit you want. In alternative you can use the `--kit` parameter and the `--workos`, `--components`, `--teams` or `--blank` flags to build directly:
+This will prompt you to build the starter kit you want. Alternatively, you can use the `--kit` parameter and the `--workos`, `--components`, `--teams` or `--blank` flags to build directly:
 
 ```bash
 php artisan build --kit=vue # Builds the Vue (Fortify) starter kit
@@ -46,7 +46,7 @@ php artisan build --kit=vue --chisel
 
 ### WorkOS
 
-When building a **WorkOS** variant for a starter kit, you can add your **WorkOS** client ID and the API key in the `orchestrator/.env` file, with this, when running the kit, it will copy these values over to the build directory.
+When building a **WorkOS** variant for a starter kit, you can add your **WorkOS** client ID and the API key in the `orchestrator/.env` file; with this configured, when running the kit, it will copy these values over to the build directory.
 
 ### Running the Starter Kit
 
@@ -170,7 +170,6 @@ The `kits/Shared` folder contains files that are 100% identical between Livewire
 - **Shared/Teams/Base:** Common Teams files (models, actions, events, migrations)
 - **Shared/Teams/Fortify:** Teams files specific to Fortify (CreateNewUser action, UserFactory)
 - **Shared/Teams/WorkOS:** Teams files specific to WorkOS (CreatePersonalTeam listener, UserFactory)
-- **Livewire/Teams/Base:** Livewire Teams files shared between Fortify and WorkOS (layouts, components, team pages)
 
 ### Livewire
 

--- a/browser_tests/bootstrap/tests/Pest.php
+++ b/browser_tests/bootstrap/tests/Pest.php
@@ -10,7 +10,7 @@ use Tests\TestCase;
 |
 | The closure you provide to your test functions is always bound to a specific PHPUnit test
 | case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
-| need to change it using the "pest()" function to bind a different classes or traits.
+| need to change it using the "pest()" function to bind different classes or traits.
 |
 */
 

--- a/kits/Inertia/Fortify/Base/chisel.php
+++ b/kits/Inertia/Fortify/Base/chisel.php
@@ -64,7 +64,7 @@ function chiselRemoveNpmPackages(Chisel $c, string ...$packages): void
 
 /**
  * Framework-specific filenames are supplied by the sibling chisel-paths.php
- * that ships with each Inertia kit (React/Svelte/Vue). After build both files
+ * that ships with each Inertia kit (React/Svelte/Vue). After build, both files
  * land in the project root.
  *
  * @var array{

--- a/kits/Inertia/React/resources/js/components/ui/sidebar.tsx
+++ b/kits/Inertia/React/resources/js/components/ui/sidebar.tsx
@@ -604,7 +604,7 @@ function SidebarMenuSkeleton({
   // also ensures we have a stable reference to the style object
   const [skeletonStyle] = React.useState(() => (
       {
-        "--skeleton-width": `${Math.floor(Math.random() * 40) + 50}%` // Random width between 50 to 90%.
+        "--skeleton-width": `${Math.floor(Math.random() * 40) + 50}%` // Random width between 50 and 90%.
     } as React.CSSProperties
   ))
 

--- a/orchestrator/AGENTS.md
+++ b/orchestrator/AGENTS.md
@@ -6,7 +6,7 @@
 The Laravel Boost guidelines are specifically curated by Laravel maintainers for this application. These guidelines should be followed closely to enhance the user's satisfaction building Laravel applications.
 
 ## Foundational Context
-This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
+This application is a Laravel application and its main Laravel ecosystem packages & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
 - php - 8.5.1
 - laravel/framework (LARAVEL) - v12

--- a/orchestrator/CLAUDE.md
+++ b/orchestrator/CLAUDE.md
@@ -6,7 +6,7 @@
 The Laravel Boost guidelines are specifically curated by Laravel maintainers for this application. These guidelines should be followed closely to enhance the user's satisfaction building Laravel applications.
 
 ## Foundational Context
-This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
+This application is a Laravel application and its main Laravel ecosystem packages & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
 - php - 8.5.1
 - laravel/framework (LARAVEL) - v12

--- a/orchestrator/app/Console/Commands/BuildCommand.php
+++ b/orchestrator/app/Console/Commands/BuildCommand.php
@@ -276,7 +276,7 @@ class BuildCommand extends Command
     }
 
     /**
-     * Build an Inertia starter kit (React or Vue).
+     * Build an Inertia starter kit (React, Svelte, or Vue).
      */
     protected function buildInertiaKit(string $kit, bool $workos = false, bool $blank = false, bool $teams = false): int
     {

--- a/orchestrator/scripts/watch.js
+++ b/orchestrator/scripts/watch.js
@@ -54,7 +54,7 @@ const allowedEmptyTextFiles = new Set([
 ]);
 
 /**
- * Get the kit type (react or vue) from the starter kit string.
+ * Get the kit type (react, svelte, or vue) from the starter kit string.
  * Returns null for livewire kits since they don't use placeholders.
  */
 function getKitType(starterKit) {
@@ -136,7 +136,7 @@ function restoreComposerVariant(content, kitType) {
         return content;
     }
 
-    // Replace the variant (react/vue) back with {{variant}} in the name field
+    // Replace the variant (react/svelte/vue) back with {{variant}} in the name field
     // Handles patterns like "laravel/react-starter-kit" or "laravel/blank-react-starter-kit"
     return content.replace(
         new RegExp(`"name":\\s*"(laravel/(?:blank-)?)${kitType}(-starter-kit)"`, 'g'),

--- a/orchestrator/tests/Pest.php
+++ b/orchestrator/tests/Pest.php
@@ -9,7 +9,7 @@ use Tests\TestCase;
 |
 | The closure you provide to your test functions is always bound to a specific PHPUnit test
 | case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
-| need to change it using the "pest()" function to bind a different classes or traits.
+| need to change it using the "pest()" function to bind different classes or traits.
 |
 */
 


### PR DESCRIPTION
### Overview
This PR performs a comprehensive text and documentation cleanup across the Maestro repository:
- Fixes minor grammatical issues, typos, and comma splices in documentation (`README.md`, `AGENTS.md`, `CLAUDE.md`, and Maestro skill files).
- Updates docblocks and comments in `BuildCommand.php` and `watch.js` to accurately reflect Svelte alongside React and Vue.
- Fixes grammar in Pest bootstrap comments and React UI sidebar comments.
- Removes an errant `Livewire/Teams/Base` bullet point listed under the `kits/Shared` heading in `README.md`.

### Verification
- Ran Pest test suite in `orchestrator/` (all tests passed).
- Verified Pint formatting on all modified PHP files (passed).
- Verified JavaScript syntax for `watch.js` (passed).
- Verified all external links in documentation (all returned HTTP 200).
- No code logic, method signatures, or runtime behaviors were modified.